### PR TITLE
feat(ensemble): designate a Slack receiver persona and delegate on @mention

### DIFF
--- a/api/v1alpha1/ensemble_types.go
+++ b/api/v1alpha1/ensemble_types.go
@@ -288,6 +288,16 @@ type AgentConfigSpec struct {
 	// When empty, the provider-appropriate default applies.
 	// +optional
 	RunTimeout string `json:"runTimeout,omitempty"`
+
+	// SlackListener marks this persona as the designated receiver for inbound
+	// Slack messages. At most one persona per Ensemble should set this to true;
+	// if none do, the channel router falls back to the first Slack-bound persona
+	// (today's behaviour). The ensemble-controller propagates this flag as the
+	// annotation "sympozium.io/slack-listener: true" on the generated Agent CR
+	// so the channel router can resolve the receiver without reading the Ensemble.
+	// +optional
+	// +kubebuilder:validation:Optional
+	SlackListener bool `json:"slackListener,omitempty"`
 }
 
 // AgentConfigWebEndpoint configures the web endpoint for an agent configuration.

--- a/api/v1alpha1/ensemble_types.go
+++ b/api/v1alpha1/ensemble_types.go
@@ -28,6 +28,11 @@ type EnsembleSpec struct {
 	Version string `json:"version,omitempty"`
 
 	// Personas is the list of agent personas in this ensemble.
+	// At most one persona may set slackListener=true — the designated Slack
+	// receiver (ISI-1497). Setting it on more than one persona is rejected at
+	// admission so the misconfiguration surfaces instead of silently resolving
+	// to the first declared listener.
+	// +kubebuilder:validation:XValidation:rule="self.filter(c, has(c.slackListener) && c.slackListener).size() <= 1",message="at most one persona may set slackListener=true (the designated Slack receiver)"
 	AgentConfigs []AgentConfigSpec `json:"agentConfigs"`
 
 	// AuthRefs references secrets containing AI provider credentials.
@@ -290,11 +295,14 @@ type AgentConfigSpec struct {
 	RunTimeout string `json:"runTimeout,omitempty"`
 
 	// SlackListener marks this persona as the designated receiver for inbound
-	// Slack messages. At most one persona per Ensemble should set this to true;
-	// if none do, the channel router falls back to the first Slack-bound persona
-	// (today's behaviour). The ensemble-controller propagates this flag as the
-	// annotation "sympozium.io/slack-listener: true" on the generated Agent CR
-	// so the channel router can resolve the receiver without reading the Ensemble.
+	// Slack messages. At most one persona per Ensemble may set this to true
+	// (enforced by CEL validation on agentConfigs); if none do, the channel
+	// router falls back to the first Slack-bound persona (today's behaviour).
+	// The channel router resolves the receiver by reading the Ensemble CR
+	// (see resolveSlackReceiver). The ensemble-controller additionally stamps
+	// the label/annotation "sympozium.ai/slack-listener: true" on the generated
+	// Agent CR for observability and kubectl selectability
+	// (`kubectl get agents -l sympozium.ai/slack-listener=true`).
 	// +optional
 	// +kubebuilder:validation:Optional
 	SlackListener bool `json:"slackListener,omitempty"`

--- a/channels/slack/main.go
+++ b/channels/slack/main.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -536,6 +537,18 @@ type slackAPIResponse struct {
 	Error string `json:"error,omitempty"`
 }
 
+// slackAPIError carries the machine-readable Slack error code from an
+// ok:false response so callers can branch on the exact code rather than
+// substring-matching the formatted message (ISI-1561 #4).
+type slackAPIError struct {
+	Endpoint string
+	Code     string
+}
+
+func (e *slackAPIError) Error() string {
+	return fmt.Sprintf("slack %s rejected request: %s", e.Endpoint, e.Code)
+}
+
 // callSlackAPI performs a JSON POST to the given Slack Web API endpoint
 // and returns an error when either the transport fails, the HTTP status
 // is non-2xx, or Slack reports ok:false. Errors classified as benign
@@ -575,7 +588,7 @@ func (sc *SlackChannel) callSlackAPI(ctx context.Context, endpoint string, paylo
 			return nil
 		}
 	}
-	return fmt.Errorf("slack %s rejected request: %s", endpoint, parsed.Error)
+	return &slackAPIError{Endpoint: endpoint, Code: parsed.Error}
 }
 
 // sendMessage sends a message via the Slack chat.postMessage API.
@@ -603,15 +616,40 @@ func (sc *SlackChannel) sendMessage(ctx context.Context, msg channel.OutboundMes
 		payload["icon_emoji"] = msg.IconEmoji
 	}
 	err := sc.callSlackAPI(ctx, "https://slack.com/api/chat.postMessage", payload)
-	if err != nil && strings.Contains(err.Error(), "not_allowed_token_type") {
-		// chat:write.customize scope missing — retry without customization fields.
+	// Retry without the chat:write.customize fields when the bot token cannot
+	// customize the sender. Classic tokens report not_allowed_token_type;
+	// granular bot tokens missing the scope report missing_scope. Match the
+	// machine-readable code from the typed error rather than substring-scanning
+	// the formatted message (ISI-1561 #4).
+	if isMissingCustomizeScope(err) {
 		sc.log.Info("bot token lacks chat:write.customize; sending without username/icon override",
-			"displayName", msg.DisplayName)
+			"displayName", msg.DisplayName, "code", slackErrorCode(err))
 		delete(payload, "username")
 		delete(payload, "icon_emoji")
 		err = sc.callSlackAPI(ctx, "https://slack.com/api/chat.postMessage", payload)
 	}
 	return err
+}
+
+// slackErrorCode returns the machine-readable Slack error code carried by a
+// *slackAPIError, or "" when err is nil or not a Slack API error.
+func slackErrorCode(err error) string {
+	var apiErr *slackAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code
+	}
+	return ""
+}
+
+// isMissingCustomizeScope reports whether err indicates the bot token cannot
+// set username/icon overrides (the chat:write.customize scope is absent).
+func isMissingCustomizeScope(err error) bool {
+	switch slackErrorCode(err) {
+	case "not_allowed_token_type", "missing_scope":
+		return true
+	default:
+		return false
+	}
 }
 
 // addReaction adds an emoji reaction to a message via the Slack

--- a/channels/slack/main.go
+++ b/channels/slack/main.go
@@ -596,7 +596,22 @@ func (sc *SlackChannel) sendMessage(ctx context.Context, msg channel.OutboundMes
 	if threadTS != "" {
 		payload["thread_ts"] = threadTS
 	}
-	return sc.callSlackAPI(ctx, "https://slack.com/api/chat.postMessage", payload)
+	if msg.DisplayName != "" {
+		payload["username"] = msg.DisplayName
+	}
+	if msg.IconEmoji != "" {
+		payload["icon_emoji"] = msg.IconEmoji
+	}
+	err := sc.callSlackAPI(ctx, "https://slack.com/api/chat.postMessage", payload)
+	if err != nil && strings.Contains(err.Error(), "not_allowed_token_type") {
+		// chat:write.customize scope missing — retry without customization fields.
+		sc.log.Info("bot token lacks chat:write.customize; sending without username/icon override",
+			"displayName", msg.DisplayName)
+		delete(payload, "username")
+		delete(payload, "icon_emoji")
+		err = sc.callSlackAPI(ctx, "https://slack.com/api/chat.postMessage", payload)
+	}
+	return err
 }
 
 // addReaction adds an emoji reaction to a message via the Slack

--- a/channels/slack/reactions_test.go
+++ b/channels/slack/reactions_test.go
@@ -192,3 +192,102 @@ func TestSendMessage_PostsExpectedPayload(t *testing.T) {
 		t.Errorf("payload = %+v", payload)
 	}
 }
+
+func TestSendMessage_DisplayName_SetsUsernameAndIcon(t *testing.T) {
+	var capturedBody []byte
+	sc := newTestSlackChannel(func(req *http.Request) (*http.Response, error) {
+		capturedBody, _ = io.ReadAll(req.Body)
+		return jsonResponse(`{"ok":true}`), nil
+	})
+	err := sc.sendMessage(context.Background(), channel.OutboundMessage{
+		Channel:     "slack",
+		ChatID:      "C123",
+		Text:        "hi from Alfred",
+		DisplayName: "Alfred",
+		IconEmoji:   ":robot_face:",
+	})
+	if err != nil {
+		t.Fatalf("sendMessage: %v", err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if payload["username"] != "Alfred" {
+		t.Errorf("username = %v, want Alfred", payload["username"])
+	}
+	if payload["icon_emoji"] != ":robot_face:" {
+		t.Errorf("icon_emoji = %v, want :robot_face:", payload["icon_emoji"])
+	}
+}
+
+func TestSendMessage_DisplayName_NoCustomization_WhenEmpty(t *testing.T) {
+	var capturedBody []byte
+	sc := newTestSlackChannel(func(req *http.Request) (*http.Response, error) {
+		capturedBody, _ = io.ReadAll(req.Body)
+		return jsonResponse(`{"ok":true}`), nil
+	})
+	err := sc.sendMessage(context.Background(), channel.OutboundMessage{
+		Channel: "slack",
+		ChatID:  "C123",
+		Text:    "plain message",
+	})
+	if err != nil {
+		t.Fatalf("sendMessage: %v", err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, ok := payload["username"]; ok {
+		t.Errorf("username should not be set when DisplayName is empty, got: %v", payload["username"])
+	}
+	if _, ok := payload["icon_emoji"]; ok {
+		t.Errorf("icon_emoji should not be set when IconEmoji is empty, got: %v", payload["icon_emoji"])
+	}
+}
+
+func TestSendMessage_DisplayName_FallsBackOnNotAllowedTokenType(t *testing.T) {
+	callCount := 0
+	var bodies [][]byte
+	sc := newTestSlackChannel(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		body, _ := io.ReadAll(req.Body)
+		bodies = append(bodies, body)
+		if callCount == 1 {
+			return jsonResponse(`{"ok":false,"error":"not_allowed_token_type"}`), nil
+		}
+		return jsonResponse(`{"ok":true}`), nil
+	})
+	err := sc.sendMessage(context.Background(), channel.OutboundMessage{
+		Channel:     "slack",
+		ChatID:      "C123",
+		Text:        "hi from Alfred",
+		DisplayName: "Alfred",
+	})
+	if err != nil {
+		t.Fatalf("sendMessage with fallback: %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 calls (with customization, then without), got %d", callCount)
+	}
+	// First call should have username set.
+	var first map[string]interface{}
+	if err := json.Unmarshal(bodies[0], &first); err != nil {
+		t.Fatalf("decode first body: %v", err)
+	}
+	if first["username"] != "Alfred" {
+		t.Errorf("first call username = %v, want Alfred", first["username"])
+	}
+	// Retry should not have username or icon_emoji.
+	var second map[string]interface{}
+	if err := json.Unmarshal(bodies[1], &second); err != nil {
+		t.Fatalf("decode second body: %v", err)
+	}
+	if _, ok := second["username"]; ok {
+		t.Errorf("retry should not include username, got: %v", second["username"])
+	}
+	if second["text"] != "hi from Alfred" {
+		t.Errorf("retry text = %v, want 'hi from Alfred'", second["text"])
+	}
+}

--- a/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
@@ -65,7 +65,12 @@ spec:
               and optionally seeds memory for each persona.
             properties:
               agentConfigs:
-                description: Personas is the list of agent personas in this ensemble.
+                description: |-
+                  Personas is the list of agent personas in this ensemble.
+                  At most one persona may set slackListener=true — the designated Slack
+                  receiver (ISI-1497). Setting it on more than one persona is rejected at
+                  admission so the misconfiguration surfaces instead of silently resolving
+                  to the first declared listener.
                 items:
                   description: AgentConfigSpec defines a single agent configuration
                     within an Ensemble.
@@ -571,6 +576,18 @@ spec:
                       items:
                         type: string
                       type: array
+                    slackListener:
+                      description: |-
+                        SlackListener marks this persona as the designated receiver for inbound
+                        Slack messages. At most one persona per Ensemble may set this to true
+                        (enforced by CEL validation on agentConfigs); if none do, the channel
+                        router falls back to the first Slack-bound persona (today's behaviour).
+                        The channel router resolves the receiver by reading the Ensemble CR
+                        (see resolveSlackReceiver). The ensemble-controller additionally stamps
+                        the label/annotation "sympozium.ai/slack-listener: true" on the generated
+                        Agent CR for observability and kubectl selectability
+                        (`kubectl get agents -l sympozium.ai/slack-listener=true`).
+                      type: boolean
                     slackOptions:
                       description: |-
                         SlackOptions overrides ensemble-level Slack-specific channel
@@ -684,6 +701,11 @@ spec:
                   - systemPrompt
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: at most one persona may set slackListener=true (the designated
+                    Slack receiver)
+                  rule: self.filter(c, has(c.slackListener) && c.slackListener).size()
+                    <= 1
               agentSandbox:
                 description: |-
                   AgentSandbox configures the Kubernetes Agent Sandbox (CRD) execution backend

--- a/charts/sympozium/crds/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium/crds/sympozium.ai_ensembles.yaml
@@ -65,7 +65,12 @@ spec:
               and optionally seeds memory for each persona.
             properties:
               agentConfigs:
-                description: Personas is the list of agent personas in this ensemble.
+                description: |-
+                  Personas is the list of agent personas in this ensemble.
+                  At most one persona may set slackListener=true — the designated Slack
+                  receiver (ISI-1497). Setting it on more than one persona is rejected at
+                  admission so the misconfiguration surfaces instead of silently resolving
+                  to the first declared listener.
                 items:
                   description: AgentConfigSpec defines a single agent configuration
                     within an Ensemble.
@@ -571,6 +576,18 @@ spec:
                       items:
                         type: string
                       type: array
+                    slackListener:
+                      description: |-
+                        SlackListener marks this persona as the designated receiver for inbound
+                        Slack messages. At most one persona per Ensemble may set this to true
+                        (enforced by CEL validation on agentConfigs); if none do, the channel
+                        router falls back to the first Slack-bound persona (today's behaviour).
+                        The channel router resolves the receiver by reading the Ensemble CR
+                        (see resolveSlackReceiver). The ensemble-controller additionally stamps
+                        the label/annotation "sympozium.ai/slack-listener: true" on the generated
+                        Agent CR for observability and kubectl selectability
+                        (`kubectl get agents -l sympozium.ai/slack-listener=true`).
+                      type: boolean
                     slackOptions:
                       description: |-
                         SlackOptions overrides ensemble-level Slack-specific channel
@@ -684,6 +701,11 @@ spec:
                   - systemPrompt
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: at most one persona may set slackListener=true (the designated
+                    Slack receiver)
+                  rule: self.filter(c, has(c.slackListener) && c.slackListener).size()
+                    <= 1
               agentSandbox:
                 description: |-
                   AgentSandbox configures the Kubernetes Agent Sandbox (CRD) execution backend

--- a/config/crd/bases/sympozium.ai_ensembles.yaml
+++ b/config/crd/bases/sympozium.ai_ensembles.yaml
@@ -65,7 +65,12 @@ spec:
               and optionally seeds memory for each persona.
             properties:
               agentConfigs:
-                description: Personas is the list of agent personas in this ensemble.
+                description: |-
+                  Personas is the list of agent personas in this ensemble.
+                  At most one persona may set slackListener=true — the designated Slack
+                  receiver (ISI-1497). Setting it on more than one persona is rejected at
+                  admission so the misconfiguration surfaces instead of silently resolving
+                  to the first declared listener.
                 items:
                   description: AgentConfigSpec defines a single agent configuration
                     within an Ensemble.
@@ -535,15 +540,6 @@ spec:
                         RUN_TIMEOUT env), so scheduled/sweep runs can exceed the 10m default.
                         When empty, the provider-appropriate default applies.
                       type: string
-                    slackListener:
-                      description: |-
-                        SlackListener marks this persona as the designated receiver for inbound
-                        Slack messages. At most one persona per Ensemble should set this to true;
-                        if none do, the channel router falls back to the first Slack-bound persona
-                        (today's behaviour). The ensemble-controller propagates this flag as the
-                        annotation "sympozium.io/slack-listener: true" on the generated Agent CR
-                        so the channel router can resolve the receiver without reading the Ensemble.
-                      type: boolean
                     schedule:
                       description: Schedule defines a recurring task for this agent
                         configuration.
@@ -580,6 +576,18 @@ spec:
                       items:
                         type: string
                       type: array
+                    slackListener:
+                      description: |-
+                        SlackListener marks this persona as the designated receiver for inbound
+                        Slack messages. At most one persona per Ensemble may set this to true
+                        (enforced by CEL validation on agentConfigs); if none do, the channel
+                        router falls back to the first Slack-bound persona (today's behaviour).
+                        The channel router resolves the receiver by reading the Ensemble CR
+                        (see resolveSlackReceiver). The ensemble-controller additionally stamps
+                        the label/annotation "sympozium.ai/slack-listener: true" on the generated
+                        Agent CR for observability and kubectl selectability
+                        (`kubectl get agents -l sympozium.ai/slack-listener=true`).
+                      type: boolean
                     slackOptions:
                       description: |-
                         SlackOptions overrides ensemble-level Slack-specific channel
@@ -693,6 +701,11 @@ spec:
                   - systemPrompt
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: at most one persona may set slackListener=true (the designated
+                    Slack receiver)
+                  rule: self.filter(c, has(c.slackListener) && c.slackListener).size()
+                    <= 1
               agentSandbox:
                 description: |-
                   AgentSandbox configures the Kubernetes Agent Sandbox (CRD) execution backend

--- a/config/crd/bases/sympozium.ai_ensembles.yaml
+++ b/config/crd/bases/sympozium.ai_ensembles.yaml
@@ -535,6 +535,15 @@ spec:
                         RUN_TIMEOUT env), so scheduled/sweep runs can exceed the 10m default.
                         When empty, the provider-appropriate default applies.
                       type: string
+                    slackListener:
+                      description: |-
+                        SlackListener marks this persona as the designated receiver for inbound
+                        Slack messages. At most one persona per Ensemble should set this to true;
+                        if none do, the channel router falls back to the first Slack-bound persona
+                        (today's behaviour). The ensemble-controller propagates this flag as the
+                        annotation "sympozium.io/slack-listener: true" on the generated Agent CR
+                        so the channel router can resolve the receiver without reading the Ensemble.
+                      type: boolean
                     schedule:
                       description: Schedule defines a recurring task for this agent
                         configuration.

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -44,3 +44,68 @@ For reliable Slack connectivity, configure your Slack app with both tokens and r
 
 !!! warning
     If `SLACK_APP_TOKEN` is omitted, Sympozium falls back to Slack Events API mode, which requires a publicly reachable webhook URL.
+
+## Slack Agent Routing (ISI-1497)
+
+By default the channel router delivers inbound Slack messages to the first
+Slack-bound persona in the Ensemble.  Two opt-in features give you finer
+control:
+
+### Designated Slack Receiver (`slackListener`)
+
+Mark exactly one `agentConfig` with `slackListener: true` to make it the
+explicit front door for all inbound Slack messages:
+
+```yaml
+agentConfigs:
+  - name: triage
+    displayName: "Support Triage"
+    slackListener: true   # this persona receives all Slack messages
+    channels:
+      - slack
+    systemPrompt: "..."
+```
+
+Rules:
+
+- If **one** persona sets `slackListener: true`, all Slack messages go there.
+- If **none** set it, today's behaviour is preserved (first Slack-bound persona).
+- Setting it on **more than one** persona per Ensemble triggers a kubebuilder
+  validation warning; only the first match is used at runtime.
+
+### `@name` → Delegation
+
+When the designated receiver gets a message that starts with `@<name>`, the
+channel router turns the request into a **delegation** to the named persona
+using the built-in delegation executor (ISI-1463 guardrails apply).
+
+Name resolution is case-insensitive and checks both `Name` and `DisplayName`:
+
+| Message | Resolves to |
+|---|---|
+| `@billing can I get a refund?` | persona with `name: billing` or `displayName: Billing` |
+| `@Engineering Support debug this` | persona with `displayName: Engineering Support` |
+| `@unknown help` | stays on receiver, friendly "I don't know that name" reply |
+
+The named persona must be reachable from the receiver via a `delegation`
+relationship in `spec.relationships`.  If no delegation edge exists the
+message stays on the receiver.
+
+### No-Listener Fallback
+
+When no persona has `slackListener: true`, the router falls back to the
+existing behaviour: the first Agent CR in the Ensemble whose `spec.channels`
+includes `slack` is used.  This keeps older Ensembles working without changes.
+
+### Per-Agent Identity
+
+!!! tip "Per-Agent Identity"
+    Replies from a delegated persona can carry a distinct Slack display name
+    and icon once ISI-1497 C4 (outbound per-persona attribution) is deployed.
+    See the `displayName` field on `AgentConfigSpec` and the `chat:write.customize`
+    Slack scope for details.
+
+### Sample Ensemble
+
+A complete example showing the `slackListener` flag and delegation relationships
+is available at [`examples/yaml/ensemble-slack-routing.yaml`](https://github.com/sympozium-ai/sympozium/blob/main/examples/yaml/ensemble-slack-routing.yaml).

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -45,11 +45,12 @@ For reliable Slack connectivity, configure your Slack app with both tokens and r
 !!! warning
     If `SLACK_APP_TOKEN` is omitted, Sympozium falls back to Slack Events API mode, which requires a publicly reachable webhook URL.
 
-## Slack Agent Routing (ISI-1497)
+## Slack Agent Routing
 
 By default the channel router delivers inbound Slack messages to the first
-Slack-bound persona in the Ensemble.  Two opt-in features give you finer
-control:
+Slack-bound persona in the Ensemble. Two opt-in features give you finer
+control: a designated receiver that acts as the front door, and `@name`
+addressing that redirects a message to a specific persona.
 
 ### Designated Slack Receiver (`slackListener`)
 
@@ -69,43 +70,65 @@ agentConfigs:
 Rules:
 
 - If **one** persona sets `slackListener: true`, all Slack messages go there.
-- If **none** set it, today's behaviour is preserved (first Slack-bound persona).
+- If **none** set it, today's behavior is preserved (first Slack-bound persona).
 - Setting it on **more than one** persona per Ensemble triggers a kubebuilder
   validation warning; only the first match is used at runtime.
 
-### `@name` → Delegation
+### Addressing a persona with `@name`
 
-When the designated receiver gets a message that starts with `@<name>`, the
-channel router turns the request into a **delegation** to the named persona
-using the built-in delegation executor (ISI-1463 guardrails apply).
+When an inbound message begins with `@<name>` (or `name:`), the channel router
+**redirects the message to the addressed persona** instead of the designated
+receiver. This is a direct reassignment: the router looks up the named
+persona's Agent instance in the same Ensemble and hands the message to it,
+stripping the mention from the text. There is no separate delegation step and
+no in-flight or depth guardrail on this path — the addressed persona simply
+receives the message as if it had been sent to it directly.
 
-Name resolution is case-insensitive and checks both `Name` and `DisplayName`:
+Both prefixes are accepted, so `@billing can I get a refund?` and
+`billing: can I get a refund?` route the same way.
+
+Name resolution matches the token (case-insensitive, exact) against each
+persona's `name` **or** `displayName` in `spec.agentConfigs`. No
+`spec.relationships` edge is required or consulted — any persona in the
+Ensemble can be addressed by name.
 
 | Message | Resolves to |
 |---|---|
-| `@billing can I get a refund?` | persona with `name: billing` or `displayName: Billing` |
-| `@Engineering Support debug this` | persona with `displayName: Engineering Support` |
-| `@unknown help` | stays on receiver, friendly "I don't know that name" reply |
+| `@billing can I get a refund?` | persona with `name: billing` (or a single-word `displayName: Billing`) |
+| `@docs where are the guides?` | persona with `name: docs` |
+| `@unknown help` | no match — see below |
 
-The named persona must be reachable from the receiver via a `delegation`
-relationship in `spec.relationships`.  If no delegation edge exists the
-message stays on the receiver.
+**Unknown names are dropped.** If the token matches no persona, the router
+replies with a note listing the available personas (for example, *"Sorry, I
+don't know who \"unknown\" is. Available personas: Support Triage, Billing
+Support, …"*) and stops — the message is not processed further.
 
-### No-Listener Fallback
+**Missing Agent instance falls through.** If the name matches a persona but its
+Agent instance can't be fetched (for example, the Ensemble hasn't finished
+reconciling that persona yet), the message falls through to the designated
+receiver rather than being dropped.
+
+!!! note
+    A `@name` / `name:` token is only recognised as a mention when the name
+    itself contains no whitespace. To address a persona whose `displayName`
+    has spaces, use its single-word `name` instead.
+
+### No-listener fallback
 
 When no persona has `slackListener: true`, the router falls back to the
-existing behaviour: the first Agent CR in the Ensemble whose `spec.channels`
-includes `slack` is used.  This keeps older Ensembles working without changes.
+existing behavior: the first Agent CR in the Ensemble whose `spec.channels`
+includes `slack` is used. This keeps older Ensembles working without changes.
 
-### Per-Agent Identity
+### Per-agent identity
 
-!!! tip "Per-Agent Identity"
-    Replies from a delegated persona can carry a distinct Slack display name
-    and icon once ISI-1497 C4 (outbound per-persona attribution) is deployed.
-    See the `displayName` field on `AgentConfigSpec` and the `chat:write.customize`
-    Slack scope for details.
+!!! tip
+    Replies from an addressed persona can carry a distinct Slack display name
+    once per-persona outbound attribution is deployed. See the `displayName`
+    field on `AgentConfigSpec` and the `chat:write.customize` Slack scope for
+    details.
 
 ### Sample Ensemble
 
-A complete example showing the `slackListener` flag and delegation relationships
-is available at [`examples/yaml/ensemble-slack-routing.yaml`](https://github.com/sympozium-ai/sympozium/blob/main/examples/yaml/ensemble-slack-routing.yaml).
+A complete example showing the `slackListener` flag and `@name` addressing is
+available at
+[`examples/yaml/ensemble-slack-routing.yaml`](../../examples/yaml/ensemble-slack-routing.yaml).

--- a/examples/yaml/ensemble-slack-routing.yaml
+++ b/examples/yaml/ensemble-slack-routing.yaml
@@ -1,0 +1,90 @@
+---
+# Ensemble with designated Slack receiver and @name delegation (ISI-1497)
+#
+# One persona is marked slackListener: true — it is the single front door for
+# all inbound Slack messages.  When the message begins with @<name>, the
+# listener delegates to that named persona through the built-in delegation
+# executor (ISI-1463/1465 guardrails apply: in-flight cap, depth cap).
+#
+# Requires: slackListener feature shipped in ISI-1497 C1-C4.
+# Apply:    kubectl apply -f ensemble-slack-routing.yaml
+# Activate: sympozium (Personas tab → Enter on "support-team")
+apiVersion: sympozium.ai/v1alpha1
+kind: Ensemble
+metadata:
+  name: support-team
+  namespace: default
+spec:
+  description: "Customer support team with designated Slack receiver and @name routing"
+  category: support
+  version: "1.0.0"
+  authRefs:
+    - secret: my-openai-key
+  channelConfigs:
+    slack: slack-tokens
+
+  agentConfigs:
+    # ── Designated Slack receiver ─────────────────────────────────────────────
+    # This persona is the single entry-point for all inbound Slack messages.
+    # It dispatches @name mentions to the right specialist via the delegation
+    # executor.  Only one persona per Ensemble should set slackListener: true.
+    - name: triage
+      displayName: "Support Triage"
+      slackListener: true          # <── ISI-1497 C1: designated Slack receiver
+      channels:
+        - slack
+      systemPrompt: |
+        You are the triage agent for the support team.  Your job is to:
+        1. Greet the user and understand their request.
+        2. If the request is addressed to a specific expert (@billing, @engineering,
+           @docs), hand off to that persona — the system will delegate automatically.
+        3. Otherwise, handle general questions yourself or ask clarifying questions.
+      memory:
+        enabled: true
+
+    # ── Named specialists ─────────────────────────────────────────────────────
+    # Users can address these personas with @billing, @engineering, or @docs in
+    # their Slack message.  The triage agent's delegation executor routes the
+    # task to the matching Agent CR resolved by Name (and DisplayName as alias).
+    - name: billing
+      displayName: "Billing Support"
+      systemPrompt: |
+        You are the billing and payments specialist.  Help users with invoices,
+        subscription changes, refunds, and payment method updates.
+      memory:
+        enabled: true
+
+    - name: engineering
+      displayName: "Engineering Support"
+      systemPrompt: |
+        You are the engineering support specialist.  Help users with integration
+        issues, API questions, SDK usage, and technical debugging.
+      skills:
+        - github-gitops
+        - k8s-ops
+      memory:
+        enabled: true
+
+    - name: docs
+      displayName: "Documentation"
+      systemPrompt: |
+        You are the documentation specialist.  Help users find the right guide,
+        clarify concepts, and point them to relevant reference material.
+      memory:
+        enabled: true
+
+  # Delegation relationships wire the receiver to each specialist.
+  # The @name router picks the matching edge automatically.
+  relationships:
+    - name: triage-to-billing
+      from: triage
+      to: billing
+      workflowType: delegation
+    - name: triage-to-engineering
+      from: triage
+      to: engineering
+      workflowType: delegation
+    - name: triage-to-docs
+      from: triage
+      to: docs
+      workflowType: delegation

--- a/examples/yaml/ensemble-slack-routing.yaml
+++ b/examples/yaml/ensemble-slack-routing.yaml
@@ -1,12 +1,12 @@
 ---
-# Ensemble with designated Slack receiver and @name delegation (ISI-1497)
+# Ensemble with a designated Slack receiver and @name addressing
 #
 # One persona is marked slackListener: true — it is the single front door for
-# all inbound Slack messages.  When the message begins with @<name>, the
-# listener delegates to that named persona through the built-in delegation
-# executor (ISI-1463/1465 guardrails apply: in-flight cap, depth cap).
+# all inbound Slack messages.  When a message begins with @<name> (or name:),
+# the router redirects it directly to that named persona; the message is
+# handled as if it had been sent to that persona.  Personas are matched by
+# name / displayName — no relationships edge is required for @name addressing.
 #
-# Requires: slackListener feature shipped in ISI-1497 C1-C4.
 # Apply:    kubectl apply -f ensemble-slack-routing.yaml
 # Activate: sympozium (Personas tab → Enter on "support-team")
 apiVersion: sympozium.ai/v1alpha1
@@ -26,26 +26,27 @@ spec:
   agentConfigs:
     # ── Designated Slack receiver ─────────────────────────────────────────────
     # This persona is the single entry-point for all inbound Slack messages.
-    # It dispatches @name mentions to the right specialist via the delegation
-    # executor.  Only one persona per Ensemble should set slackListener: true.
+    # When a user addresses a specialist with @name, the router redirects the
+    # message straight to that persona.  Only one persona per Ensemble should
+    # set slackListener: true.
     - name: triage
       displayName: "Support Triage"
-      slackListener: true          # <── ISI-1497 C1: designated Slack receiver
+      slackListener: true          # <── designated Slack receiver
       channels:
         - slack
       systemPrompt: |
         You are the triage agent for the support team.  Your job is to:
         1. Greet the user and understand their request.
         2. If the request is addressed to a specific expert (@billing, @engineering,
-           @docs), hand off to that persona — the system will delegate automatically.
+           @docs), the router hands the message directly to that persona.
         3. Otherwise, handle general questions yourself or ask clarifying questions.
       memory:
         enabled: true
 
     # ── Named specialists ─────────────────────────────────────────────────────
     # Users can address these personas with @billing, @engineering, or @docs in
-    # their Slack message.  The triage agent's delegation executor routes the
-    # task to the matching Agent CR resolved by Name (and DisplayName as alias).
+    # their Slack message.  The router redirects to the matching Agent CR,
+    # resolved by Name (and DisplayName as alias) — case-insensitive, exact.
     - name: billing
       displayName: "Billing Support"
       systemPrompt: |
@@ -73,8 +74,9 @@ spec:
       memory:
         enabled: true
 
-  # Delegation relationships wire the receiver to each specialist.
-  # The @name router picks the matching edge automatically.
+  # NOTE: @name Slack addressing does NOT use these relationships — personas are
+  # matched by name / displayName directly.  The edges below are optional here
+  # and only matter for other workflow types (e.g. delegation workflows).
   relationships:
     - name: triage-to-billing
       from: triage

--- a/internal/channel/types.go
+++ b/internal/channel/types.go
@@ -38,6 +38,8 @@ type OutboundMessage struct {
 	Reaction        string            `json:"reaction,omitempty"`        // emoji identifier (channel-specific format)
 	TargetMessageID string            `json:"targetMessageId,omitempty"` // inbound message id this reaction targets
 	Metadata        map[string]string `json:"metadata,omitempty"`        // channel-specific routing hints (e.g. Slack replyToTS)
+	DisplayName     string            `json:"displayName,omitempty"`     // override Slack bot display name (requires chat:write.customize)
+	IconEmoji       string            `json:"iconEmoji,omitempty"`       // e.g. ":robot_face:"
 }
 
 // Attachment represents a file or media attachment.

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -240,6 +240,91 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		return
 	}
 
+	// @name / name: routing (ISI-1497 C3).
+	// When the inbound text begins with @name or name:, attempt to match
+	// against sibling personas in the same Ensemble.  A match redirects the
+	// AgentRun to the named delegate while keeping the receiver as the
+	// Slack-facing front door (Option 2).  Unknown names produce a friendly
+	// note and drop the message.
+	var nameRoutingApplied bool
+	if ensembleName := inst.Labels["sympozium.ai/ensemble"]; ensembleName != "" {
+		if mention, remainder := extractNameMention(msg.Text); mention != "" {
+			var ensemble sympoziumv1alpha1.Ensemble
+			ensErr := cr.Client.Get(ctx, client.ObjectKey{Name: ensembleName, Namespace: inst.Namespace}, &ensemble)
+			if ensErr == nil {
+				delegate := resolveNamedDelegate(ensemble.Spec.AgentConfigs, mention)
+				if delegate == nil {
+					// Unknown persona — respond with a helpful note and drop.
+					names := make([]string, 0, len(ensemble.Spec.AgentConfigs))
+					for _, p := range ensemble.Spec.AgentConfigs {
+						if p.DisplayName != "" {
+							names = append(names, p.DisplayName)
+						} else {
+							names = append(names, p.Name)
+						}
+					}
+					cr.sendDenialResponse(ctx, msg, fmt.Sprintf(
+						"Sorry, I don't know who %q is. Available personas: %s.",
+						mention, strings.Join(names, ", "),
+					))
+					span.SetAttributes(attribute.String("sympozium.slack.routing.unknown_mention", mention))
+					cr.Log.Info("Unknown @name mention — dropped", "mention", mention, "instance", msg.InstanceName)
+					return
+				}
+				// Redirect to the delegate's Agent instance.
+				delegateInstanceName := ensembleName + "-" + delegate.Name
+				var delegateInst sympoziumv1alpha1.Agent
+				if getErr := cr.Client.Get(ctx, client.ObjectKey{Name: delegateInstanceName, Namespace: inst.Namespace}, &delegateInst); getErr == nil {
+					inst = &delegateInst
+					msg.InstanceName = delegateInstanceName
+					msg.Text = remainder
+					nameRoutingApplied = true
+					span.SetAttributes(
+						attribute.String("sympozium.slack.routing.delegate", delegate.Name),
+						attribute.String("sympozium.slack.routing.mention", mention),
+					)
+					cr.Log.Info("Routing @name mention to delegate",
+						"mention", mention, "delegate", delegateInstanceName)
+				} else {
+					cr.Log.Error(getErr, "Delegate Agent not found, falling through to receiver",
+						"delegate", delegateInstanceName)
+				}
+			}
+		}
+	}
+
+	// SlackListener routing (ISI-1499 C2): for unaddressed inbound messages
+	// that were not already redirected by @name routing, direct to the
+	// designated Slack-receiver persona when the Ensemble has one set.
+	// Falls back to the receiving inst when none is configured.
+	if !nameRoutingApplied {
+		if ensembleName := inst.Labels["sympozium.ai/ensemble"]; ensembleName != "" {
+			var ensemble sympoziumv1alpha1.Ensemble
+			if err := cr.Client.Get(ctx, client.ObjectKey{Name: ensembleName, Namespace: inst.Namespace}, &ensemble); err == nil {
+				if receiver := resolveSlackReceiver(ensemble.Spec.AgentConfigs); receiver != nil {
+					listenerName := ensembleName + "-" + receiver.Name
+					var listenerInst sympoziumv1alpha1.Agent
+					if err := cr.Client.Get(ctx, client.ObjectKey{Name: listenerName, Namespace: inst.Namespace}, &listenerInst); err == nil && listenerInst.Name != inst.Name {
+						inst = &listenerInst
+						msg.InstanceName = listenerName
+						span.SetAttributes(attribute.String("sympozium.slack.routing.slack_listener", receiver.Name))
+						cr.Log.Info("Routing to SlackListener persona", "listener", listenerName)
+					} else if err != nil {
+						cr.Log.Error(err, "SlackListener Agent not found, using receiving agent", "listener", listenerName)
+					}
+				}
+			}
+		}
+	}
+
+	// Resolve AgentID (ISI-1499 C2): use the resolved inst's agent-config
+	// label so runs carry the persona name rather than the literal "primary".
+	// Standalone Agents (no Ensemble, no agent-config label) keep "primary".
+	agentID := inst.Labels["sympozium.ai/agent-config"]
+	if agentID == "" {
+		agentID = "primary"
+	}
+
 	// Enforce channel access control before creating an AgentRun.
 	if allowed, denyMsg := checkChannelAccess(inst, &msg); !allowed {
 		span.SetAttributes(attribute.Bool("sympozium.access.denied", true))
@@ -265,16 +350,24 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 	provider := resolveProvider(inst)
 	authSecret := resolveAuthSecret(inst)
 
+	// Build run labels; include Ensemble/agent-config attrs when present so
+	// the Ensemble controller's per-instance run queries target the right persona.
+	runLabels := map[string]string{
+		"sympozium.ai/instance":       msg.InstanceName,
+		"sympozium.ai/source":         "channel",
+		"sympozium.ai/source-channel": msg.Channel,
+	}
+	if ens := inst.Labels["sympozium.ai/ensemble"]; ens != "" {
+		runLabels["sympozium.ai/ensemble"] = ens
+		runLabels["sympozium.ai/agent-config"] = agentID
+	}
+
 	// Create an AgentRun for the inbound message.
 	run := &sympoziumv1alpha1.AgentRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: msg.InstanceName + "-ch-",
 			Namespace:    inst.Namespace,
-			Labels: map[string]string{
-				"sympozium.ai/instance":       msg.InstanceName,
-				"sympozium.ai/source":         "channel",
-				"sympozium.ai/source-channel": msg.Channel,
-			},
+			Labels:       runLabels,
 			Annotations: map[string]string{
 				"sympozium.ai/reply-channel":    msg.Channel,
 				"sympozium.ai/reply-chat-id":    msg.ChatID,
@@ -286,7 +379,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:   msg.InstanceName,
-			AgentID:    "primary",
+			AgentID:    agentID,
 			SessionKey: fmt.Sprintf("channel-%s-%s-%d", msg.Channel, msg.ChatID, time.Now().UnixNano()),
 			Task:       msg.Text,
 			Model: sympoziumv1alpha1.ModelSpec{

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -67,6 +67,32 @@ func (cr *ChannelRouter) Start(ctx context.Context) error {
 	}
 }
 
+// agentDisplayName returns a human-readable display name for the agent instance.
+// It prefers the DisplayName from the matching AgentConfigSpec in the parent Ensemble
+// (resolved by the sympozium.ai/agent-config label), falling back to the config name,
+// then the instance name.
+func agentDisplayName(ctx context.Context, c client.Client, inst *sympoziumv1alpha1.Agent) string {
+	configName := inst.Labels["sympozium.ai/agent-config"]
+	ensembleName := inst.Labels["sympozium.ai/ensemble"]
+	if configName == "" {
+		return inst.Name
+	}
+	if ensembleName != "" {
+		var ensemble sympoziumv1alpha1.Ensemble
+		if err := c.Get(ctx, client.ObjectKey{Name: ensembleName, Namespace: inst.Namespace}, &ensemble); err == nil {
+			for _, cfg := range ensemble.Spec.AgentConfigs {
+				if cfg.Name == configName {
+					if cfg.DisplayName != "" {
+						return cfg.DisplayName
+					}
+					return cfg.Name
+				}
+			}
+		}
+	}
+	return configName
+}
+
 // memorySystemPrompt returns the Memory.SystemPrompt for the instance,
 // safely handling a nil MemorySpec pointer.
 func memorySystemPrompt(inst *sympoziumv1alpha1.Agent) string {
@@ -370,12 +396,13 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 			Namespace:    inst.Namespace,
 			Labels:       runLabels,
 			Annotations: map[string]string{
-				"sympozium.ai/reply-channel":    msg.Channel,
-				"sympozium.ai/reply-chat-id":    msg.ChatID,
-				"sympozium.ai/reply-thread-id":  msg.ThreadID,
-				"sympozium.ai/reply-message-ts": msg.Metadata["ts"],
-				"sympozium.ai/sender-name":      msg.SenderName,
-				"sympozium.ai/sender-id":        msg.SenderID,
+				"sympozium.ai/reply-channel":      msg.Channel,
+				"sympozium.ai/reply-chat-id":      msg.ChatID,
+				"sympozium.ai/reply-thread-id":    msg.ThreadID,
+				"sympozium.ai/reply-message-ts":   msg.Metadata["ts"],
+				"sympozium.ai/sender-name":        msg.SenderName,
+				"sympozium.ai/sender-id":          msg.SenderID,
+				"sympozium.ai/agent-display-name": agentDisplayName(ctx, cr.Client, inst),
 			},
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
@@ -490,6 +517,7 @@ func (cr *ChannelRouter) handleCompleted(ctx context.Context, event *eventbus.Ev
 	replyChatID := run.Annotations["sympozium.ai/reply-chat-id"]
 	replyThreadID := run.Annotations["sympozium.ai/reply-thread-id"]
 	replyMessageTS := run.Annotations["sympozium.ai/reply-message-ts"]
+	agentDisplayNameVal := run.Annotations["sympozium.ai/agent-display-name"]
 
 	if replyChannel == "" {
 		return
@@ -519,19 +547,24 @@ func (cr *ChannelRouter) handleCompleted(ctx context.Context, event *eventbus.Ev
 
 	// Publish outbound message to the channel.
 	outMsg := channelpkg.OutboundMessage{
-		Channel:  replyChannel,
-		ChatID:   replyChatID,
-		ThreadID: replyThreadID,
-		Text:     responseText,
+		Channel:     replyChannel,
+		ChatID:      replyChatID,
+		ThreadID:    replyThreadID,
+		Text:        responseText,
+		DisplayName: agentDisplayNameVal,
 	}
 	if replyMessageTS != "" {
 		outMsg.Metadata = map[string]string{"replyToTS": replyMessageTS}
 	}
 
-	outEvent, err := eventbus.NewEvent(eventbus.TopicChannelMessageSend, map[string]string{
+	eventMeta := map[string]string{
 		"instanceName": instanceName,
 		"channel":      replyChannel,
-	}, outMsg)
+	}
+	if agentDisplayNameVal != "" {
+		eventMeta["agentDisplayName"] = agentDisplayNameVal
+	}
+	outEvent, err := eventbus.NewEvent(eventbus.TopicChannelMessageSend, eventMeta, outMsg)
 	if err != nil {
 		cr.Log.Error(err, "failed to create outbound event")
 		return

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -351,7 +351,6 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		agentID = "primary"
 	}
 
-
 	// Enforce channel access control before creating an AgentRun.
 	if allowed, denyMsg := checkChannelAccess(inst, &msg); !allowed {
 		span.SetAttributes(attribute.Bool("sympozium.access.denied", true))

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -266,93 +266,53 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		return
 	}
 
-	// @name / name: routing (ISI-1497 C3, ISI-1524).
-	// When the inbound text begins with @name or name:, attempt to match
-	// against sibling personas in the same Ensemble.  A match redirects the
-	// AgentRun to the named delegate while keeping the receiver as the
-	// Slack-facing front door (Option 2).
+	// Routing + access control (ISI-1497, ISI-1524, ISI-1561).
 	//
-	// Ordering (ISI-1524): name extraction happens early so the delegate
-	// becomes the effective front door, but the unknown-@persona denial is
-	// gated on access/mute checks below.  After a successful redirect,
-	// access/mute are evaluated against the delegate (the post-swap inst),
-	// not the original receiver.  word: prefixes such as "Note:",
-	// "TODO:", "https://…" fall through to normal processing without a
-	// denial.
-	var nameRoutingApplied bool
-	var unknownMention string // set when isMention=true but no persona matched
+	// The Ensemble is fetched once here and threaded through every routing
+	// decision below, replacing the up-to-four repeated client.Get calls that
+	// risked torn reads (ISI-1561 #7).  @name and SlackListener routing are
+	// Slack-only features: non-Slack channels (Telegram/WhatsApp/Discord) skip
+	// them entirely so a Telegram "@john" is never denied or rerouted to a
+	// Slack listener (ISI-1561 #2).
+	var ensemble sympoziumv1alpha1.Ensemble
+	var haveEnsemble bool
 	if ensembleName := inst.Labels["sympozium.ai/ensemble"]; ensembleName != "" {
-		if mention, remainder, isMention := extractNameMention(msg.Text); mention != "" {
-			var ensemble sympoziumv1alpha1.Ensemble
-			ensErr := cr.Client.Get(ctx, client.ObjectKey{Name: ensembleName, Namespace: inst.Namespace}, &ensemble)
-			if ensErr == nil {
-				delegate := resolveNamedDelegate(ensemble.Spec.AgentConfigs, mention)
-				if delegate == nil {
-					if isMention {
-						// Unambiguous @persona mention with no matching persona.
-						// Defer the denial until after access/mute checks so
-						// muted/restricted channels emit no bot output (ISI-1524).
-						unknownMention = mention
-					}
-					// word: prefix matched no persona — fall through to normal processing.
-				} else {
-					// Redirect to the delegate's Agent instance.
-					delegateInstanceName := ensembleName + "-" + delegate.Name
-					var delegateInst sympoziumv1alpha1.Agent
-					if getErr := cr.Client.Get(ctx, client.ObjectKey{Name: delegateInstanceName, Namespace: inst.Namespace}, &delegateInst); getErr == nil {
-						inst = &delegateInst
-						msg.InstanceName = delegateInstanceName
-						msg.Text = remainder
-						nameRoutingApplied = true
-						span.SetAttributes(
-							attribute.String("sympozium.slack.routing.delegate", delegate.Name),
-							attribute.String("sympozium.slack.routing.mention", mention),
-						)
-						cr.Log.Info("Routing @name mention to delegate",
-							"mention", mention, "delegate", delegateInstanceName)
-					} else {
-						cr.Log.Error(getErr, "Delegate Agent not found, falling through to receiver",
-							"delegate", delegateInstanceName)
-					}
-				}
-			}
+		if err := cr.Client.Get(ctx, client.ObjectKey{Name: ensembleName, Namespace: inst.Namespace}, &ensemble); err == nil {
+			haveEnsemble = true
+		} else {
+			cr.Log.Error(err, "failed to get Ensemble for routing; handling as standalone Agent",
+				"ensemble", ensembleName)
 		}
 	}
 
-	// SlackListener routing (ISI-1499 C2): for unaddressed inbound messages
-	// that were not already redirected by @name routing, direct to the
-	// designated Slack-receiver persona when the Ensemble has one set.
-	// Falls back to the receiving inst when none is configured.
-	if !nameRoutingApplied {
-		if ensembleName := inst.Labels["sympozium.ai/ensemble"]; ensembleName != "" {
-			var ensemble sympoziumv1alpha1.Ensemble
-			if err := cr.Client.Get(ctx, client.ObjectKey{Name: ensembleName, Namespace: inst.Namespace}, &ensemble); err == nil {
-				if receiver := resolveSlackReceiver(ensemble.Spec.AgentConfigs); receiver != nil {
-					listenerName := ensembleName + "-" + receiver.Name
-					var listenerInst sympoziumv1alpha1.Agent
-					if err := cr.Client.Get(ctx, client.ObjectKey{Name: listenerName, Namespace: inst.Namespace}, &listenerInst); err == nil && listenerInst.Name != inst.Name {
-						inst = &listenerInst
-						msg.InstanceName = listenerName
-						span.SetAttributes(attribute.String("sympozium.slack.routing.slack_listener", receiver.Name))
-						cr.Log.Info("Routing to SlackListener persona", "listener", listenerName)
-					} else if err != nil {
-						cr.Log.Error(err, "SlackListener Agent not found, using receiving agent", "listener", listenerName)
-					}
-				}
+	// Resolve the front door: the persona that owns the Slack channel binding
+	// and its access-control rules.  Access and mute MUST be evaluated against
+	// this instance — never against an @name delegate.  A delegate is typically
+	// an internal persona with no channel spec, so checkChannelAccess would
+	// return allow-all and let a blocked sender bypass restrictions via
+	// "@billing do X" (ISI-1561 #1).  Defaults to the receiving inst; a
+	// designated SlackListener persona takes precedence when configured.
+	frontDoor := inst
+	if haveEnsemble && msg.Channel == "slack" {
+		if receiver := resolveSlackReceiver(ensemble.Spec.AgentConfigs); receiver != nil {
+			listenerName := personaInstanceName(&ensemble, receiver.Name)
+			var listenerInst sympoziumv1alpha1.Agent
+			if err := cr.Client.Get(ctx, client.ObjectKey{Name: listenerName, Namespace: inst.Namespace}, &listenerInst); err == nil {
+				frontDoor = &listenerInst
+				span.SetAttributes(attribute.String("sympozium.slack.routing.slack_listener", receiver.Name))
+				cr.Log.Info("Resolved SlackListener front door", "listener", listenerName)
+			} else {
+				cr.Log.Error(err, "SlackListener Agent not found, using receiving agent", "listener", listenerName)
 			}
 		}
 	}
+	// The front door owns the Slack channel; access decisions and denial
+	// responses are attributed to and published through it (a delegate may have
+	// no channel to reply on).
+	msg.InstanceName = frontDoor.Name
 
-	// Resolve AgentID (ISI-1499 C2): use the resolved inst's agent-config
-	// label so runs carry the persona name rather than the literal "primary".
-	// Standalone Agents (no Ensemble, no agent-config label) keep "primary".
-	agentID := inst.Labels["sympozium.ai/agent-config"]
-	if agentID == "" {
-		agentID = "primary"
-	}
-
-	// Enforce channel access control before creating an AgentRun.
-	if allowed, denyMsg := checkChannelAccess(inst, &msg); !allowed {
+	// Enforce channel access control against the front door before any routing.
+	if allowed, denyMsg := checkChannelAccess(frontDoor, &msg); !allowed {
 		span.SetAttributes(attribute.Bool("sympozium.access.denied", true))
 		recordChannelAccess(ctx, "denied", msg.Channel, msg.InstanceName)
 		cr.Log.Info("Channel message denied by access control",
@@ -366,33 +326,81 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 	// Complementary positive signal so denial rate = denied / (allowed+denied).
 	recordChannelAccess(ctx, "allowed", msg.Channel, msg.InstanceName)
 
-	// Evaluate stop/start keyword triggers (mute state, reactions).
-	// Returns false when the message must not be turned into an AgentRun.
-	if !cr.applyTriggers(ctx, span, inst, msg) {
+	// Evaluate stop/start keyword triggers (mute state, reactions) against the
+	// front door. Returns false when the message must not become an AgentRun.
+	if !cr.applyTriggers(ctx, span, frontDoor, msg) {
 		return
 	}
 
-	// Deferred unknown-@persona denial (ISI-1524): only emit after
-	// access/mute checks confirm the channel is allowed and unmuted.
-	if unknownMention != "" {
-		var ensemble sympoziumv1alpha1.Ensemble
-		if ensErr := cr.Client.Get(ctx, client.ObjectKey{Name: inst.Labels["sympozium.ai/ensemble"], Namespace: inst.Namespace}, &ensemble); ensErr == nil {
-			names := make([]string, 0, len(ensemble.Spec.AgentConfigs))
-			for _, p := range ensemble.Spec.AgentConfigs {
-				if p.DisplayName != "" {
-					names = append(names, p.DisplayName)
+	// Compute-target resolution.  The front door stays the Slack-facing
+	// instance (Option 2); @name routing (Slack-only) redirects the AgentRun to
+	// a named sibling persona.  Access/mute have already passed above, so an
+	// unknown @persona now emits a denial only on allowed, unmuted channels
+	// (ISI-1524).
+	target := frontDoor
+	if haveEnsemble && msg.Channel == "slack" {
+		if mention, remainder, isMention := extractNameMention(msg.Text); mention != "" {
+			delegate := resolveNamedDelegate(ensemble.Spec.AgentConfigs, mention)
+			switch {
+			case delegate != nil:
+				// Redirect to the delegate's Agent instance.
+				delegateInstanceName := personaInstanceName(&ensemble, delegate.Name)
+				var delegateInst sympoziumv1alpha1.Agent
+				if err := cr.Client.Get(ctx, client.ObjectKey{Name: delegateInstanceName, Namespace: inst.Namespace}, &delegateInst); err == nil {
+					target = &delegateInst
+					msg.InstanceName = delegateInstanceName
+					msg.Text = remainder
+					span.SetAttributes(
+						attribute.String("sympozium.slack.routing.delegate", delegate.Name),
+						attribute.String("sympozium.slack.routing.mention", mention),
+					)
+					cr.Log.Info("Routing @name mention to delegate",
+						"mention", mention, "delegate", delegateInstanceName)
 				} else {
-					names = append(names, p.Name)
+					cr.Log.Error(err, "Delegate Agent not found, staying on front door",
+						"delegate", delegateInstanceName)
 				}
+			case isMention:
+				// Unambiguous @persona with no matching persona.  Channel is
+				// already confirmed allowed + unmuted, so emit the denial.
+				names := make([]string, 0, len(ensemble.Spec.AgentConfigs))
+				for _, p := range ensemble.Spec.AgentConfigs {
+					if p.DisplayName != "" {
+						names = append(names, p.DisplayName)
+					} else {
+						names = append(names, p.Name)
+					}
+				}
+				cr.sendDenialResponse(ctx, msg, fmt.Sprintf(
+					"Sorry, I don't know who %q is. Available personas: %s.",
+					mention, strings.Join(names, ", "),
+				))
+				span.SetAttributes(attribute.String("sympozium.slack.routing.unknown_mention", mention))
+				cr.Log.Info("Unknown @name mention — dropped", "mention", mention, "instance", msg.InstanceName)
+				return
 			}
-			cr.sendDenialResponse(ctx, msg, fmt.Sprintf(
-				"Sorry, I don't know who %q is. Available personas: %s.",
-				unknownMention, strings.Join(names, ", "),
-			))
-			span.SetAttributes(attribute.String("sympozium.slack.routing.unknown_mention", unknownMention))
-			cr.Log.Info("Unknown @name mention — dropped", "mention", unknownMention, "instance", msg.InstanceName)
-			return
+			// word: prefix that matched no persona falls through to normal processing.
 		}
+	}
+
+	// A bare "@persona" leaves an empty task once the mention is stripped; the
+	// top-of-function empty-text guard ran before the remainder was assigned,
+	// so re-check here to avoid creating an AgentRun with an empty Task
+	// (ISI-1561 #6).
+	if strings.TrimSpace(msg.Text) == "" {
+		cr.Log.Info("Skipping inbound message with empty task after @name strip",
+			"instance", msg.InstanceName)
+		return
+	}
+
+	inst = target
+
+	// Resolve AgentID (ISI-1499 C2): use the resolved inst's agent-config
+	// label so runs carry the persona name rather than the literal "primary".
+	// Standalone Agents (no Ensemble, no agent-config label) keep "primary".
+	agentID := inst.Labels["sympozium.ai/agent-config"]
+	if agentID == "" {
+		agentID = "primary"
 	}
 
 	// Resolve model configuration from the Agent (same logic as TUI).
@@ -612,6 +620,21 @@ func truncateForLog(s string, n int) string {
 	return s[:n] + "..."
 }
 
+// personaInstanceName resolves the generated Agent instance name for a persona
+// using the Ensemble's authoritative install status (Status.InstalledAgentConfigs),
+// the same map spawner.resolvePersonaTarget uses. Falls back to the
+// "<ensemble>-<persona>" naming convention only when the status has not yet
+// recorded the persona (e.g. mid-install), so routing degrades gracefully
+// instead of duplicating the controller's naming logic (ISI-1561 #8).
+func personaInstanceName(ensemble *sympoziumv1alpha1.Ensemble, persona string) string {
+	for _, ip := range ensemble.Status.InstalledAgentConfigs {
+		if ip.Name == persona {
+			return ip.InstanceName
+		}
+	}
+	return ensemble.Name + "-" + persona
+}
+
 // resolveSlackReceiver returns the first AgentConfigSpec marked slackListener=true.
 // Returns nil when none is set; callers fall back to the first Slack-bound agent
 // (backwards-compatible behaviour for ensembles that predate ISI-1497).
@@ -680,6 +703,11 @@ func extractNameMention(text string) (name, remainder string, isMention bool) {
 		} else {
 			token = rest[:idx]
 		}
+		// Strip trailing punctuation so "@billing," / "@architect." / "@john?"
+		// still match a persona by exact name (ISI-1561 #3). The stripped
+		// punctuation is discarded with the removed @token, not re-added to the
+		// remainder.
+		token = strings.TrimRight(token, ",.;:!?")
 		if token == "" {
 			continue
 		}

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -270,50 +270,65 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 	// When the inbound text begins with @name or name:, attempt to match
 	// against sibling personas in the same Ensemble.  A match redirects the
 	// AgentRun to the named delegate while keeping the receiver as the
-	// Slack-facing front door (Option 2).  Unknown names produce a friendly
-	// note and drop the message.
+	// Slack-facing front door (Option 2).
+	//
+	// Ordering: name routing runs before checkChannelAccess and mute checks.
+	// After a successful redirect, access/mute are evaluated against the
+	// delegate (the post-swap inst), not the original receiver — the delegate
+	// is the effective front door once routing is resolved.  For unambiguous
+	// unknown @persona mentions the denial fires before access/mute, but
+	// only after extractNameMention confirms the @word form (isMention=true);
+	// word: prefixes such as "Note:", "TODO:", "https://…" fall through to
+	// normal processing without a denial.
 	var nameRoutingApplied bool
 	if ensembleName := inst.Labels["sympozium.ai/ensemble"]; ensembleName != "" {
-		if mention, remainder := extractNameMention(msg.Text); mention != "" {
+		if mention, remainder, isMention := extractNameMention(msg.Text); mention != "" {
 			var ensemble sympoziumv1alpha1.Ensemble
 			ensErr := cr.Client.Get(ctx, client.ObjectKey{Name: ensembleName, Namespace: inst.Namespace}, &ensemble)
 			if ensErr == nil {
 				delegate := resolveNamedDelegate(ensemble.Spec.AgentConfigs, mention)
 				if delegate == nil {
-					// Unknown persona — respond with a helpful note and drop.
-					names := make([]string, 0, len(ensemble.Spec.AgentConfigs))
-					for _, p := range ensemble.Spec.AgentConfigs {
-						if p.DisplayName != "" {
-							names = append(names, p.DisplayName)
-						} else {
-							names = append(names, p.Name)
+					if isMention {
+						// Unambiguous @persona mention with no matching persona —
+						// respond with a helpful note and drop.  word: prefixes
+						// (e.g. "Note:", "TODO:", "https://…") are not persona-
+						// directed and fall through to normal receiver handling.
+						names := make([]string, 0, len(ensemble.Spec.AgentConfigs))
+						for _, p := range ensemble.Spec.AgentConfigs {
+							if p.DisplayName != "" {
+								names = append(names, p.DisplayName)
+							} else {
+								names = append(names, p.Name)
+							}
 						}
+						cr.sendDenialResponse(ctx, msg, fmt.Sprintf(
+							"Sorry, I don't know who %q is. Available personas: %s.",
+							mention, strings.Join(names, ", "),
+						))
+						span.SetAttributes(attribute.String("sympozium.slack.routing.unknown_mention", mention))
+						cr.Log.Info("Unknown @name mention — dropped", "mention", mention, "instance", msg.InstanceName)
+						return
 					}
-					cr.sendDenialResponse(ctx, msg, fmt.Sprintf(
-						"Sorry, I don't know who %q is. Available personas: %s.",
-						mention, strings.Join(names, ", "),
-					))
-					span.SetAttributes(attribute.String("sympozium.slack.routing.unknown_mention", mention))
-					cr.Log.Info("Unknown @name mention — dropped", "mention", mention, "instance", msg.InstanceName)
-					return
-				}
-				// Redirect to the delegate's Agent instance.
-				delegateInstanceName := ensembleName + "-" + delegate.Name
-				var delegateInst sympoziumv1alpha1.Agent
-				if getErr := cr.Client.Get(ctx, client.ObjectKey{Name: delegateInstanceName, Namespace: inst.Namespace}, &delegateInst); getErr == nil {
-					inst = &delegateInst
-					msg.InstanceName = delegateInstanceName
-					msg.Text = remainder
-					nameRoutingApplied = true
-					span.SetAttributes(
-						attribute.String("sympozium.slack.routing.delegate", delegate.Name),
-						attribute.String("sympozium.slack.routing.mention", mention),
-					)
-					cr.Log.Info("Routing @name mention to delegate",
-						"mention", mention, "delegate", delegateInstanceName)
+					// word: prefix matched no persona — fall through to normal processing.
 				} else {
-					cr.Log.Error(getErr, "Delegate Agent not found, falling through to receiver",
-						"delegate", delegateInstanceName)
+					// Redirect to the delegate's Agent instance.
+					delegateInstanceName := ensembleName + "-" + delegate.Name
+					var delegateInst sympoziumv1alpha1.Agent
+					if getErr := cr.Client.Get(ctx, client.ObjectKey{Name: delegateInstanceName, Namespace: inst.Namespace}, &delegateInst); getErr == nil {
+						inst = &delegateInst
+						msg.InstanceName = delegateInstanceName
+						msg.Text = remainder
+						nameRoutingApplied = true
+						span.SetAttributes(
+							attribute.String("sympozium.slack.routing.delegate", delegate.Name),
+							attribute.String("sympozium.slack.routing.mention", mention),
+						)
+						cr.Log.Info("Routing @name mention to delegate",
+							"mention", mention, "delegate", delegateInstanceName)
+					} else {
+						cr.Log.Error(getErr, "Delegate Agent not found, falling through to receiver",
+							"delegate", delegateInstanceName)
+					}
 				}
 			}
 		}
@@ -618,29 +633,52 @@ func resolveNamedDelegate(configs []sympoziumv1alpha1.AgentConfigSpec, mention s
 	return nil
 }
 
+// slackKeywords are Slack @-mentions that address the whole channel or workspace
+// rather than a specific persona. They must not trigger persona routing or
+// produce an unknown-persona denial.
+var slackKeywords = map[string]bool{
+	"here":     true,
+	"channel":  true,
+	"everyone": true,
+}
+
 // extractNameMention parses an @name or name: prefix from text (case-insensitive).
-// Returns the bare name token (no leading @, no trailing colon) and the remainder
-// of the message after the prefix, or ("", text) when no such pattern is found.
-func extractNameMention(text string) (name, remainder string) {
+// Returns the bare name token (no leading @, no trailing colon), the remainder
+// of the message, and whether the match used the @name form (isMention=true).
+// Returns ("", text, false) when no routing-relevant prefix is found.
+// Slack channel keywords (@here, @channel, @everyone) are ignored.
+func extractNameMention(text string) (name, remainder string, isMention bool) {
 	t := strings.TrimSpace(text)
 	if strings.HasPrefix(t, "@") {
 		// "@name rest of message" — name ends at first whitespace
 		rest := t[1:]
 		idx := strings.IndexAny(rest, " \t\n\r")
+		var token string
 		if idx < 0 {
-			return rest, ""
+			token = rest
+		} else {
+			token = rest[:idx]
 		}
-		return rest[:idx], strings.TrimSpace(rest[idx+1:])
+		// Slack channel/workspace keywords are not persona mentions.
+		if slackKeywords[strings.ToLower(token)] {
+			return "", text, false
+		}
+		if idx < 0 {
+			return token, "", true
+		}
+		return token, strings.TrimSpace(rest[idx+1:]), true
 	}
-	// "name: rest of message"
+	// "name: rest of message" — isMention=false so callers fall through
+	// rather than deny when the token doesn't match a known persona
+	// (avoids false-positive drops on "Note:", "TODO:", "https://…", etc.).
 	idx := strings.Index(t, ":")
 	if idx > 0 {
 		candidate := t[:idx]
 		if !strings.ContainsAny(candidate, " \t\n\r") {
-			return candidate, strings.TrimSpace(t[idx+1:])
+			return candidate, strings.TrimSpace(t[idx+1:]), false
 		}
 	}
-	return "", text
+	return "", text, false
 }
 
 // checkChannelAccess evaluates access control rules for the channel that

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -266,21 +266,21 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		return
 	}
 
-	// @name / name: routing (ISI-1497 C3).
+	// @name / name: routing (ISI-1497 C3, ISI-1524).
 	// When the inbound text begins with @name or name:, attempt to match
 	// against sibling personas in the same Ensemble.  A match redirects the
 	// AgentRun to the named delegate while keeping the receiver as the
 	// Slack-facing front door (Option 2).
 	//
-	// Ordering: name routing runs before checkChannelAccess and mute checks.
-	// After a successful redirect, access/mute are evaluated against the
-	// delegate (the post-swap inst), not the original receiver — the delegate
-	// is the effective front door once routing is resolved.  For unambiguous
-	// unknown @persona mentions the denial fires before access/mute, but
-	// only after extractNameMention confirms the @word form (isMention=true);
-	// word: prefixes such as "Note:", "TODO:", "https://…" fall through to
-	// normal processing without a denial.
+	// Ordering (ISI-1524): name extraction happens early so the delegate
+	// becomes the effective front door, but the unknown-@persona denial is
+	// gated on access/mute checks below.  After a successful redirect,
+	// access/mute are evaluated against the delegate (the post-swap inst),
+	// not the original receiver.  word: prefixes such as "Note:",
+	// "TODO:", "https://…" fall through to normal processing without a
+	// denial.
 	var nameRoutingApplied bool
+	var unknownMention string // set when isMention=true but no persona matched
 	if ensembleName := inst.Labels["sympozium.ai/ensemble"]; ensembleName != "" {
 		if mention, remainder, isMention := extractNameMention(msg.Text); mention != "" {
 			var ensemble sympoziumv1alpha1.Ensemble
@@ -289,25 +289,10 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 				delegate := resolveNamedDelegate(ensemble.Spec.AgentConfigs, mention)
 				if delegate == nil {
 					if isMention {
-						// Unambiguous @persona mention with no matching persona —
-						// respond with a helpful note and drop.  word: prefixes
-						// (e.g. "Note:", "TODO:", "https://…") are not persona-
-						// directed and fall through to normal receiver handling.
-						names := make([]string, 0, len(ensemble.Spec.AgentConfigs))
-						for _, p := range ensemble.Spec.AgentConfigs {
-							if p.DisplayName != "" {
-								names = append(names, p.DisplayName)
-							} else {
-								names = append(names, p.Name)
-							}
-						}
-						cr.sendDenialResponse(ctx, msg, fmt.Sprintf(
-							"Sorry, I don't know who %q is. Available personas: %s.",
-							mention, strings.Join(names, ", "),
-						))
-						span.SetAttributes(attribute.String("sympozium.slack.routing.unknown_mention", mention))
-						cr.Log.Info("Unknown @name mention — dropped", "mention", mention, "instance", msg.InstanceName)
-						return
+						// Unambiguous @persona mention with no matching persona.
+						// Defer the denial until after access/mute checks so
+						// muted/restricted channels emit no bot output (ISI-1524).
+						unknownMention = mention
 					}
 					// word: prefix matched no persona — fall through to normal processing.
 				} else {
@@ -386,6 +371,29 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 	// Returns false when the message must not be turned into an AgentRun.
 	if !cr.applyTriggers(ctx, span, inst, msg) {
 		return
+	}
+
+	// Deferred unknown-@persona denial (ISI-1524): only emit after
+	// access/mute checks confirm the channel is allowed and unmuted.
+	if unknownMention != "" {
+		var ensemble sympoziumv1alpha1.Ensemble
+		if ensErr := cr.Client.Get(ctx, client.ObjectKey{Name: inst.Labels["sympozium.ai/ensemble"], Namespace: inst.Namespace}, &ensemble); ensErr == nil {
+			names := make([]string, 0, len(ensemble.Spec.AgentConfigs))
+			for _, p := range ensemble.Spec.AgentConfigs {
+				if p.DisplayName != "" {
+					names = append(names, p.DisplayName)
+				} else {
+					names = append(names, p.Name)
+				}
+			}
+			cr.sendDenialResponse(ctx, msg, fmt.Sprintf(
+				"Sorry, I don't know who %q is. Available personas: %s.",
+				unknownMention, strings.Join(names, ", "),
+			))
+			span.SetAttributes(attribute.String("sympozium.slack.routing.unknown_mention", unknownMention))
+			cr.Log.Info("Unknown @name mention — dropped", "mention", unknownMention, "instance", msg.InstanceName)
+			return
+		}
 	}
 
 	// Resolve model configuration from the Agent (same logic as TUI).
@@ -642,16 +650,30 @@ var slackKeywords = map[string]bool{
 	"everyone": true,
 }
 
-// extractNameMention parses an @name or name: prefix from text (case-insensitive).
-// Returns the bare name token (no leading @, no trailing colon), the remainder
-// of the message, and whether the match used the @name form (isMention=true).
-// Returns ("", text, false) when no routing-relevant prefix is found.
-// Slack channel keywords (@here, @channel, @everyone) are ignored.
+// extractNameMention parses an @name mention (anywhere in the message) or a
+// leading name: prefix from text (case-insensitive). Returns the bare name
+// token (no leading @, no trailing colon), the remainder of the message with
+// the matched @token removed, and whether the match used the @name form
+// (isMention=true). Returns ("", text, false) when no routing-relevant token
+// is found. Slack channel keywords (@here, @channel, @everyone) are ignored.
+//
+// ISI-1497 C7: the @mention is honoured anywhere in the message, not only as
+// the leading token, so text like "1. @architect please review" routes to the
+// architect. A whitespace/start boundary is required before '@' so that email
+// addresses ("henrik@perfbytes.com") and URLs — where '@' follows a non-space
+// character — do not misfire as persona mentions.
 func extractNameMention(text string) (name, remainder string, isMention bool) {
-	t := strings.TrimSpace(text)
-	if strings.HasPrefix(t, "@") {
-		// "@name rest of message" — name ends at first whitespace
-		rest := t[1:]
+	// @name form — scan for the first boundary-anchored @token anywhere.
+	for i := 0; i < len(text); i++ {
+		if text[i] != '@' {
+			continue
+		}
+		if i > 0 {
+			if prev := text[i-1]; prev != ' ' && prev != '\t' && prev != '\n' && prev != '\r' {
+				continue // '@' not on a word boundary (email/URL) — not a mention
+			}
+		}
+		rest := text[i+1:]
 		idx := strings.IndexAny(rest, " \t\n\r")
 		var token string
 		if idx < 0 {
@@ -659,18 +681,34 @@ func extractNameMention(text string) (name, remainder string, isMention bool) {
 		} else {
 			token = rest[:idx]
 		}
+		if token == "" {
+			continue
+		}
 		// Slack channel/workspace keywords are not persona mentions.
 		if slackKeywords[strings.ToLower(token)] {
-			return "", text, false
+			continue
 		}
-		if idx < 0 {
-			return token, "", true
+		// First matching @mention wins (e.g. "@architect @winston" → architect).
+		// Remainder is the message with the matched token removed.
+		before := strings.TrimSpace(text[:i])
+		var after string
+		if idx >= 0 {
+			after = strings.TrimSpace(rest[idx+1:])
 		}
-		return token, strings.TrimSpace(rest[idx+1:]), true
+		switch {
+		case before == "":
+			remainder = after
+		case after == "":
+			remainder = before
+		default:
+			remainder = before + " " + after
+		}
+		return token, remainder, true
 	}
 	// "name: rest of message" — isMention=false so callers fall through
 	// rather than deny when the token doesn't match a known persona
 	// (avoids false-positive drops on "Note:", "TODO:", "https://…", etc.).
+	t := strings.TrimSpace(text)
 	idx := strings.Index(t, ":")
 	if idx > 0 {
 		candidate := t[:idx]

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -325,6 +325,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		agentID = "primary"
 	}
 
+
 	// Enforce channel access control before creating an AgentRun.
 	if allowed, denyMsg := checkChannelAccess(inst, &msg); !allowed {
 		span.SetAttributes(attribute.Bool("sympozium.access.denied", true))
@@ -554,6 +555,59 @@ func truncateForLog(s string, n int) string {
 		return s
 	}
 	return s[:n] + "..."
+}
+
+// resolveSlackReceiver returns the first AgentConfigSpec marked slackListener=true.
+// Returns nil when none is set; callers fall back to the first Slack-bound agent
+// (backwards-compatible behaviour for ensembles that predate ISI-1497).
+func resolveSlackReceiver(configs []sympoziumv1alpha1.AgentConfigSpec) *sympoziumv1alpha1.AgentConfigSpec {
+	for i := range configs {
+		if configs[i].SlackListener {
+			return &configs[i]
+		}
+	}
+	return nil
+}
+
+// resolveNamedDelegate matches a bare name token (stripped of any leading @)
+// against AgentConfigSpec.Name and AgentConfigSpec.DisplayName, case-insensitively.
+// Returns nil when there is no match; callers stay on the designated receiver.
+func resolveNamedDelegate(configs []sympoziumv1alpha1.AgentConfigSpec, mention string) *sympoziumv1alpha1.AgentConfigSpec {
+	if mention == "" {
+		return nil
+	}
+	lower := strings.ToLower(mention)
+	for i := range configs {
+		if strings.ToLower(configs[i].Name) == lower || strings.ToLower(configs[i].DisplayName) == lower {
+			return &configs[i]
+		}
+	}
+	return nil
+}
+
+// extractNameMention parses an @name or name: prefix from text (case-insensitive).
+// Returns the bare name token (no leading @, no trailing colon) and the remainder
+// of the message after the prefix, or ("", text) when no such pattern is found.
+func extractNameMention(text string) (name, remainder string) {
+	t := strings.TrimSpace(text)
+	if strings.HasPrefix(t, "@") {
+		// "@name rest of message" — name ends at first whitespace
+		rest := t[1:]
+		idx := strings.IndexAny(rest, " \t\n\r")
+		if idx < 0 {
+			return rest, ""
+		}
+		return rest[:idx], strings.TrimSpace(rest[idx+1:])
+	}
+	// "name: rest of message"
+	idx := strings.Index(t, ":")
+	if idx > 0 {
+		candidate := t[:idx]
+		if !strings.ContainsAny(candidate, " \t\n\r") {
+			return candidate, strings.TrimSpace(t[idx+1:])
+		}
+	}
+	return "", text
 }
 
 // checkChannelAccess evaluates access control rules for the channel that

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -432,7 +431,6 @@ func TestHandleInbound_NameRouting(t *testing.T) {
 			Client:   c,
 			EventBus: bus,
 			Log:      logr.Discard(),
-			seen:     make(map[string]time.Time),
 		}, bus
 	}
 
@@ -629,7 +627,6 @@ func TestHandleInbound_UnknownMentionMutedChannel(t *testing.T) {
 		Client:   c,
 		EventBus: bus,
 		Log:      logr.Discard(),
-		seen:     make(map[string]time.Time),
 	}
 
 	msg := channelpkg.InboundMessage{

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -1,9 +1,5 @@
-//go:build isi1497
-
 // Tests for ISI-1497 Slack agent routing: designated receiver selection and
-// @name → delegation resolution.  Build tag keeps these out of standard CI
-// until the SlackListener CRD field (C1) and router functions (C2/C3) land.
-// Remove the build tag in the same PR that ships C1+C2+C3.
+// @name → delegation resolution.
 
 package controller
 

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -4,9 +4,19 @@
 package controller
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	channelpkg "github.com/sympozium-ai/sympozium/internal/channel"
+	"github.com/sympozium-ai/sympozium/internal/eventbus"
 )
 
 func TestExtractNameMention(t *testing.T) {
@@ -296,4 +306,176 @@ func TestNoListenerFallback(t *testing.T) {
 		t.Errorf("expected nil for no-listener ensemble, got %q", got.Name)
 	}
 	// Caller interprets nil as "use first agent" — no extra assertion needed here.
+}
+
+// handleInboundScheme builds the runtime.Scheme required by the fake client
+// used in handleInbound integration tests.
+func handleInboundScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add sympoziumv1alpha1: %v", err)
+	}
+	return s
+}
+
+// outboundTexts extracts the Text fields from all outbound channel.message.send
+// events captured by a recordingEventBus.
+func outboundTexts(t *testing.T, bus *recordingEventBus) []string {
+	t.Helper()
+	var texts []string
+	for _, rec := range bus.published {
+		if rec.Topic != eventbus.TopicChannelMessageSend {
+			continue
+		}
+		var out channelpkg.OutboundMessage
+		if err := json.Unmarshal(rec.Event.Data, &out); err != nil {
+			t.Fatalf("decode outbound: %v", err)
+		}
+		texts = append(texts, out.Text)
+	}
+	return texts
+}
+
+// TestHandleInbound_NameRouting exercises the three key paths in handleInbound's
+// @name / name: routing block:
+//
+//   - known @persona  → no denial, redirect routes to the delegate Agent
+//   - unknown @persona → denial published on the event bus
+//   - word: prefix    → no denial (falls through; word: is not persona-directed)
+func TestHandleInbound_NameRouting(t *testing.T) {
+	const (
+		ns           = "default"
+		ensembleName = "myteam"
+		receiverName = "myteam-triage"
+		delegateName = "myteam-billing"
+	)
+
+	// Ensemble with two personas: "triage" (receiver) and "billing" (delegate).
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: ensembleName, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "triage", SlackListener: true},
+				{Name: "billing"},
+			},
+		},
+	}
+
+	agentLabels := map[string]string{
+		"sympozium.ai/ensemble":     ensembleName,
+		"sympozium.ai/agent-config": "triage",
+	}
+	receiver := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: receiverName, Namespace: ns, Labels: agentLabels},
+	}
+	delegate := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      delegateName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     ensembleName,
+				"sympozium.ai/agent-config": "billing",
+			},
+		},
+	}
+
+	newRouter := func(t *testing.T) (*ChannelRouter, *recordingEventBus) {
+		t.Helper()
+		bus := &recordingEventBus{}
+		c := fake.NewClientBuilder().
+			WithScheme(handleInboundScheme(t)).
+			WithObjects(ensemble, receiver, delegate).
+			Build()
+		return &ChannelRouter{
+			Client:   c,
+			EventBus: bus,
+			Log:      logr.Discard(),
+			seen:     make(map[string]time.Time),
+		}, bus
+	}
+
+	inboundEvent := func(text string) *eventbus.Event {
+		msg := channelpkg.InboundMessage{
+			InstanceName: receiverName,
+			Channel:      "slack",
+			ChatID:       "C1",
+			Text:         text,
+		}
+		ev, _ := eventbus.NewEvent(eventbus.TopicChannelMessageRecv, nil, msg)
+		return ev
+	}
+
+	t.Run("known @persona — no denial, AgentRun created for delegate", func(t *testing.T) {
+		cr, bus := newRouter(t)
+		cr.handleInbound(context.Background(), inboundEvent("@billing please invoice me"))
+		texts := outboundTexts(t, bus)
+		for _, text := range texts {
+			if len(text) > 0 {
+				t.Errorf("expected no outbound denial, got %q", text)
+			}
+		}
+		// Verify an AgentRun was created targeting the delegate.
+		var runs sympoziumv1alpha1.AgentRunList
+		if err := cr.Client.List(context.Background(), &runs); err != nil {
+			t.Fatalf("list runs: %v", err)
+		}
+		if len(runs.Items) == 0 {
+			t.Fatal("expected AgentRun to be created, got none")
+		}
+		got := runs.Items[0].Spec.AgentRef
+		if got != delegateName {
+			t.Errorf("AgentRun.Spec.AgentRef = %q, want %q", got, delegateName)
+		}
+	})
+
+	t.Run("unknown @persona — denial sent, no AgentRun", func(t *testing.T) {
+		cr, bus := newRouter(t)
+		cr.handleInbound(context.Background(), inboundEvent("@finance help me"))
+		texts := outboundTexts(t, bus)
+		if len(texts) == 0 {
+			t.Fatal("expected denial to be published, got none")
+		}
+		// denial must mention the unknown persona
+		found := false
+		for _, text := range texts {
+			if len(text) > 0 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("denial text was empty; got %v", texts)
+		}
+		var runs sympoziumv1alpha1.AgentRunList
+		if err := cr.Client.List(context.Background(), &runs); err != nil {
+			t.Fatalf("list runs: %v", err)
+		}
+		if len(runs.Items) != 0 {
+			t.Errorf("expected no AgentRun after denial, got %d", len(runs.Items))
+		}
+	})
+
+	t.Run("Note: prefix — no denial, falls through to receiver AgentRun", func(t *testing.T) {
+		cr, bus := newRouter(t)
+		cr.handleInbound(context.Background(), inboundEvent("Note: this is not a persona"))
+		// No denial should be published.
+		for _, text := range outboundTexts(t, bus) {
+			if len(text) > 0 {
+				t.Errorf("expected no denial for word: prefix, got %q", text)
+			}
+		}
+		// A run should be created for the original receiver (not routed away).
+		var runs sympoziumv1alpha1.AgentRunList
+		if err := cr.Client.List(context.Background(), &runs); err != nil {
+			t.Fatalf("list runs: %v", err)
+		}
+		if len(runs.Items) == 0 {
+			t.Fatal("expected AgentRun to be created for receiver, got none")
+		}
+		got := runs.Items[0].Spec.AgentRef
+		if got != receiverName {
+			t.Errorf("AgentRun.Spec.AgentRef = %q, want %q (receiver)", got, receiverName)
+		}
+	})
 }

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -71,6 +71,36 @@ func TestExtractNameMention(t *testing.T) {
 			wantRemainder: "@winston review",
 			wantMention:   true,
 		},
+		// ISI-1561 #3 — trailing punctuation stripped from the @token so
+		// exact-name matching still succeeds.
+		{
+			name:          "@persona with trailing comma",
+			text:          "@billing, refund please",
+			wantName:      "billing",
+			wantRemainder: "refund please",
+			wantMention:   true,
+		},
+		{
+			name:          "@persona with trailing question mark",
+			text:          "@architect? can you review",
+			wantName:      "architect",
+			wantRemainder: "can you review",
+			wantMention:   true,
+		},
+		{
+			name:          "@persona with trailing period at end",
+			text:          "please ask @billing.",
+			wantName:      "billing",
+			wantRemainder: "please ask",
+			wantMention:   true,
+		},
+		{
+			name:          "@persona with trailing colon",
+			text:          "@billing: help",
+			wantName:      "billing",
+			wantRemainder: "help",
+			wantMention:   true,
+		},
 		// Email/URL negative controls — '@' not on a word boundary, no match
 		{
 			name:          "email address — @ not a mention",
@@ -652,5 +682,228 @@ func TestHandleInbound_UnknownMentionMutedChannel(t *testing.T) {
 	}
 	if len(runs.Items) != 0 {
 		t.Errorf("expected no AgentRun on muted channel, got %d", len(runs.Items))
+	}
+}
+
+// TestHandleInbound_FrontDoorAccessControl verifies ISI-1561 #1: a blocked
+// sender must NOT bypass access control by @mentioning a delegate persona.
+// Access is evaluated against the front door (the SlackListener that owns the
+// channel + rules), never against the delegate, which typically has no channel
+// spec and would otherwise allow-all.
+func TestHandleInbound_FrontDoorAccessControl(t *testing.T) {
+	const (
+		ns           = "default"
+		ensembleName = "myteam"
+		receiverName = "myteam-triage"
+		delegateName = "myteam-billing"
+	)
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: ensembleName, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "triage", SlackListener: true},
+				{Name: "billing"},
+			},
+		},
+	}
+
+	// Front-door persona denies "blocked-user" on Slack.
+	receiver := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: receiverName, Namespace: ns,
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     ensembleName,
+				"sympozium.ai/agent-config": "triage",
+			},
+		},
+		Spec: sympoziumv1alpha1.AgentSpec{
+			Channels: []sympoziumv1alpha1.ChannelSpec{
+				{
+					Type: "slack",
+					AccessControl: &sympoziumv1alpha1.ChannelAccessControl{
+						DeniedSenders: []string{"blocked-user"},
+						DenyMessage:   "You are not permitted to use this bot.",
+					},
+				},
+			},
+		},
+	}
+	// Delegate persona has NO channel spec → checkChannelAccess would allow-all.
+	delegate := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: delegateName, Namespace: ns,
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     ensembleName,
+				"sympozium.ai/agent-config": "billing",
+			},
+		},
+	}
+
+	bus := &recordingEventBus{}
+	c := fake.NewClientBuilder().
+		WithScheme(handleInboundScheme(t)).
+		WithObjects(ensemble, receiver, delegate).
+		Build()
+	cr := &ChannelRouter{Client: c, EventBus: bus, Log: logr.Discard()}
+
+	msg := channelpkg.InboundMessage{
+		InstanceName: receiverName,
+		Channel:      "slack",
+		ChatID:       "C1",
+		SenderID:     "blocked-user",
+		Text:         "@billing please refund me",
+	}
+	ev, _ := eventbus.NewEvent(eventbus.TopicChannelMessageRecv, nil, msg)
+	cr.handleInbound(context.Background(), ev)
+
+	// The message must be denied (front-door rule), and no AgentRun created —
+	// the @billing delegate must not launder the blocked sender past access.
+	var runs sympoziumv1alpha1.AgentRunList
+	if err := cr.Client.List(context.Background(), &runs); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs.Items) != 0 {
+		t.Fatalf("blocked sender bypassed access control via @delegate: %d AgentRun(s) created", len(runs.Items))
+	}
+	// A denial should have been published back to the channel.
+	sawDenial := false
+	for _, text := range outboundTexts(t, bus) {
+		if len(text) > 0 {
+			sawDenial = true
+		}
+	}
+	if !sawDenial {
+		t.Errorf("expected a denial response for the blocked sender, got none")
+	}
+}
+
+// TestHandleInbound_NonSlackSkipsRouting verifies ISI-1561 #2: @name and
+// SlackListener routing are Slack-only. A Telegram message containing "@john"
+// must not be denied or rerouted; it flows to the receiving Agent unchanged.
+func TestHandleInbound_NonSlackSkipsRouting(t *testing.T) {
+	const (
+		ns           = "default"
+		ensembleName = "myteam"
+		receiverName = "myteam-triage"
+	)
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: ensembleName, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "triage", SlackListener: true},
+				{Name: "billing"},
+			},
+		},
+	}
+	receiver := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: receiverName, Namespace: ns,
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     ensembleName,
+				"sympozium.ai/agent-config": "triage",
+			},
+		},
+	}
+
+	bus := &recordingEventBus{}
+	c := fake.NewClientBuilder().
+		WithScheme(handleInboundScheme(t)).
+		WithObjects(ensemble, receiver).
+		Build()
+	cr := &ChannelRouter{Client: c, EventBus: bus, Log: logr.Discard()}
+
+	msg := channelpkg.InboundMessage{
+		InstanceName: receiverName,
+		Channel:      "telegram", // NOT slack — routing must be skipped
+		ChatID:       "T1",
+		Text:         "@john are you there",
+	}
+	ev, _ := eventbus.NewEvent(eventbus.TopicChannelMessageRecv, nil, msg)
+	cr.handleInbound(context.Background(), ev)
+
+	// No denial on a non-Slack channel even though "@john" matches no persona.
+	for _, text := range outboundTexts(t, bus) {
+		if len(text) > 0 {
+			t.Errorf("expected no denial on non-Slack channel, got %q", text)
+		}
+	}
+	// The run should target the receiving Agent with the original, unstripped text.
+	var runs sympoziumv1alpha1.AgentRunList
+	if err := cr.Client.List(context.Background(), &runs); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs.Items) != 1 {
+		t.Fatalf("expected exactly 1 AgentRun for the receiver, got %d", len(runs.Items))
+	}
+	if got := runs.Items[0].Spec.AgentRef; got != receiverName {
+		t.Errorf("AgentRun.Spec.AgentRef = %q, want %q (receiver)", got, receiverName)
+	}
+	if got := runs.Items[0].Spec.Task; got != "@john are you there" {
+		t.Errorf("AgentRun.Spec.Task = %q, want the original unstripped text", got)
+	}
+}
+
+// TestHandleInbound_EmptyTaskAfterMention verifies ISI-1561 #6: a bare
+// "@persona" with no body must not create an AgentRun with an empty Task.
+func TestHandleInbound_EmptyTaskAfterMention(t *testing.T) {
+	const (
+		ns           = "default"
+		ensembleName = "myteam"
+		receiverName = "myteam-triage"
+		delegateName = "myteam-billing"
+	)
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: ensembleName, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "triage", SlackListener: true},
+				{Name: "billing"},
+			},
+		},
+	}
+	receiver := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: receiverName, Namespace: ns,
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     ensembleName,
+				"sympozium.ai/agent-config": "triage",
+			},
+		},
+	}
+	delegate := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: delegateName, Namespace: ns,
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     ensembleName,
+				"sympozium.ai/agent-config": "billing",
+			},
+		},
+	}
+
+	bus := &recordingEventBus{}
+	c := fake.NewClientBuilder().
+		WithScheme(handleInboundScheme(t)).
+		WithObjects(ensemble, receiver, delegate).
+		Build()
+	cr := &ChannelRouter{Client: c, EventBus: bus, Log: logr.Discard()}
+
+	msg := channelpkg.InboundMessage{
+		InstanceName: receiverName,
+		Channel:      "slack",
+		ChatID:       "C1",
+		Text:         "@billing", // bare mention, empty remainder
+	}
+	ev, _ := eventbus.NewEvent(eventbus.TopicChannelMessageRecv, nil, msg)
+	cr.handleInbound(context.Background(), ev)
+
+	var runs sympoziumv1alpha1.AgentRunList
+	if err := cr.Client.List(context.Background(), &runs); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs.Items) != 0 {
+		t.Errorf("expected no AgentRun for a bare @persona with empty task, got %d", len(runs.Items))
 	}
 }

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -478,4 +478,48 @@ func TestHandleInbound_NameRouting(t *testing.T) {
 			t.Errorf("AgentRun.Spec.AgentRef = %q, want %q (receiver)", got, receiverName)
 		}
 	})
+
+	// ISI-1499 M1: the load-bearing SlackListener swap branch — an unaddressed
+	// inbound message arrives at a NON-listener instance (myteam-billing) and
+	// must be redirected to the slackListener=true persona (myteam-triage),
+	// carrying the listener's persona name in AgentRef and run labels.
+	t.Run("unaddressed inbound at non-listener — swaps to SlackListener persona", func(t *testing.T) {
+		cr, bus := newRouter(t)
+		msg := channelpkg.InboundMessage{
+			InstanceName: delegateName, // arrives at the non-listener billing inst
+			Channel:      "slack",
+			ChatID:       "C1",
+			Text:         "hello, I have a general question",
+		}
+		ev, _ := eventbus.NewEvent(eventbus.TopicChannelMessageRecv, nil, msg)
+		cr.handleInbound(context.Background(), ev)
+
+		// No denial should be published on a plain, unaddressed message.
+		for _, text := range outboundTexts(t, bus) {
+			if len(text) > 0 {
+				t.Errorf("expected no denial for unaddressed message, got %q", text)
+			}
+		}
+
+		var runs sympoziumv1alpha1.AgentRunList
+		if err := cr.Client.List(context.Background(), &runs); err != nil {
+			t.Fatalf("list runs: %v", err)
+		}
+		if len(runs.Items) == 0 {
+			t.Fatal("expected AgentRun to be created for the SlackListener persona, got none")
+		}
+		run := runs.Items[0]
+		if got := run.Spec.AgentRef; got != receiverName {
+			t.Errorf("AgentRun.Spec.AgentRef = %q, want %q (SlackListener persona)", got, receiverName)
+		}
+		if got := run.Labels["sympozium.ai/agent-config"]; got != "triage" {
+			t.Errorf("run label agent-config = %q, want %q (listener persona)", got, "triage")
+		}
+		if got := run.Labels["sympozium.ai/ensemble"]; got != ensembleName {
+			t.Errorf("run label ensemble = %q, want %q", got, ensembleName)
+		}
+		if got := run.Labels["sympozium.ai/instance"]; got != receiverName {
+			t.Errorf("run label instance = %q, want %q (swapped listener inst)", got, receiverName)
+		}
+	})
 }

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -1,0 +1,174 @@
+//go:build isi1497
+
+// Tests for ISI-1497 Slack agent routing: designated receiver selection and
+// @name → delegation resolution.  Build tag keeps these out of standard CI
+// until the SlackListener CRD field (C1) and router functions (C2/C3) land.
+// Remove the build tag in the same PR that ships C1+C2+C3.
+
+package controller
+
+import (
+	"testing"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// resolveSlackReceiver returns the AgentConfigSpec marked slackListener=true.
+// If none is set it returns nil (caller falls back to first Slack-bound agent).
+// If more than one is set, the first match is used.
+//
+// This function is implemented in C2 (internal/controller/channel_router.go).
+
+func TestResolveSlackReceiver(t *testing.T) {
+	tests := []struct {
+		name        string
+		agentCfgs   []sympoziumv1alpha1.AgentConfigSpec
+		wantName    string // empty = expect nil
+		wantNil     bool
+	}{
+		{
+			name:    "no agents — nil",
+			wantNil: true,
+		},
+		{
+			name: "no slackListener flag set — nil (fallback to first)",
+			agentCfgs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "alpha"},
+				{Name: "beta"},
+			},
+			wantNil: true,
+		},
+		{
+			name: "single slackListener=true — returns that agent",
+			agentCfgs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "triage", SlackListener: true},
+				{Name: "billing"},
+			},
+			wantName: "triage",
+		},
+		{
+			name: "slackListener on non-first agent — still found",
+			agentCfgs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "billing"},
+				{Name: "triage", SlackListener: true},
+				{Name: "engineering"},
+			},
+			wantName: "triage",
+		},
+		{
+			name: "multiple slackListener=true — first match wins",
+			agentCfgs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "a", SlackListener: true},
+				{Name: "b", SlackListener: true},
+			},
+			wantName: "a",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveSlackReceiver(tc.agentCfgs)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %q", got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", tc.wantName)
+			}
+			if got.Name != tc.wantName {
+				t.Errorf("expected %q, got %q", tc.wantName, got.Name)
+			}
+		})
+	}
+}
+
+// resolveNamedDelegate matches a bare @name token against AgentConfigSpec.Name
+// and AgentConfigSpec.DisplayName (case-insensitive).  Returns nil when no
+// match is found (unknown-name fallback: stay on receiver).
+//
+// This function is implemented in C3 (internal/controller/channel_router.go).
+
+func TestResolveNamedDelegate(t *testing.T) {
+	configs := []sympoziumv1alpha1.AgentConfigSpec{
+		{Name: "triage", DisplayName: "Support Triage", SlackListener: true},
+		{Name: "billing", DisplayName: "Billing Support"},
+		{Name: "engineering", DisplayName: "Engineering Support"},
+		{Name: "docs", DisplayName: "Documentation"},
+	}
+
+	tests := []struct {
+		name     string
+		mention  string // raw token after stripping leading @
+		wantName string // expected AgentConfigSpec.Name; empty = nil
+	}{
+		{
+			name:     "exact Name match",
+			mention:  "billing",
+			wantName: "billing",
+		},
+		{
+			name:     "Name match case-insensitive",
+			mention:  "BILLING",
+			wantName: "billing",
+		},
+		{
+			name:     "DisplayName match",
+			mention:  "Billing Support",
+			wantName: "billing",
+		},
+		{
+			name:     "DisplayName match case-insensitive",
+			mention:  "engineering support",
+			wantName: "engineering",
+		},
+		{
+			name:     "partial Name — no match (must be exact)",
+			mention:  "bill",
+			wantName: "",
+		},
+		{
+			name:     "unknown name — nil (stay on receiver)",
+			mention:  "finance",
+			wantName: "",
+		},
+		{
+			name:     "empty mention — nil",
+			mention:  "",
+			wantName: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveNamedDelegate(configs, tc.mention)
+			if tc.wantName == "" {
+				if got != nil {
+					t.Errorf("expected nil, got %q", got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", tc.wantName)
+			}
+			if got.Name != tc.wantName {
+				t.Errorf("expected %q, got %q", tc.wantName, got.Name)
+			}
+		})
+	}
+}
+
+// TestNoListenerFallback verifies that when slackListener is absent the router
+// behaves exactly as before ISI-1497: the first agent is used.
+func TestNoListenerFallback(t *testing.T) {
+	configs := []sympoziumv1alpha1.AgentConfigSpec{
+		{Name: "alpha"},
+		{Name: "beta"},
+	}
+	got := resolveSlackReceiver(configs)
+	if got != nil {
+		t.Errorf("expected nil for no-listener ensemble, got %q", got.Name)
+	}
+	// Caller interprets nil as "use first agent" — no extra assertion needed here.
+}

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -9,6 +9,135 @@ import (
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 )
 
+func TestExtractNameMention(t *testing.T) {
+	tests := []struct {
+		name          string
+		text          string
+		wantName      string
+		wantRemainder string
+		wantMention   bool // true = @word form; false = word: form or no match
+	}{
+		// @word form — isMention=true
+		{
+			name:          "@persona with body",
+			text:          "@billing please check my invoice",
+			wantName:      "billing",
+			wantRemainder: "please check my invoice",
+			wantMention:   true,
+		},
+		{
+			name:          "@persona only (no body)",
+			text:          "@engineering",
+			wantName:      "engineering",
+			wantRemainder: "",
+			wantMention:   true,
+		},
+		{
+			name:          "@unknown persona",
+			text:          "@finance help",
+			wantName:      "finance",
+			wantRemainder: "help",
+			wantMention:   true,
+		},
+		// Slack keywords — must return no match (fall through, not deny)
+		{
+			name:          "@here — Slack keyword, no match",
+			text:          "@here anyone around?",
+			wantName:      "",
+			wantRemainder: "@here anyone around?",
+			wantMention:   false,
+		},
+		{
+			name:          "@channel — Slack keyword, no match",
+			text:          "@channel important update",
+			wantName:      "",
+			wantRemainder: "@channel important update",
+			wantMention:   false,
+		},
+		{
+			name:          "@everyone — Slack keyword, no match",
+			text:          "@everyone heads up",
+			wantName:      "",
+			wantRemainder: "@everyone heads up",
+			wantMention:   false,
+		},
+		{
+			name:          "@HERE case-insensitive Slack keyword",
+			text:          "@HERE please read",
+			wantName:      "",
+			wantRemainder: "@HERE please read",
+			wantMention:   false,
+		},
+		// word: prefix form — isMention=false (fall through on no persona match)
+		{
+			name:          "word: prefix",
+			text:          "billing: check my account",
+			wantName:      "billing",
+			wantRemainder: "check my account",
+			wantMention:   false,
+		},
+		{
+			name:          "Note: — should not deny",
+			text:          "Note: this is important",
+			wantName:      "Note",
+			wantRemainder: "this is important",
+			wantMention:   false,
+		},
+		{
+			name:          "TODO: — should not deny",
+			text:          "TODO: fix the bug",
+			wantName:      "TODO",
+			wantRemainder: "fix the bug",
+			wantMention:   false,
+		},
+		// URL — word: prefix but word is "https" (no slash in candidate)
+		{
+			name:          "https:// URL — no match (slash after colon, candidate ok but remainder starts with //)",
+			text:          "https://example.com",
+			wantName:      "https",
+			wantRemainder: "//example.com",
+			wantMention:   false,
+		},
+		// Plain text — no prefix at all
+		{
+			name:          "plain message, no prefix",
+			text:          "hello world",
+			wantName:      "",
+			wantRemainder: "hello world",
+			wantMention:   false,
+		},
+		{
+			name:          "empty string",
+			text:          "",
+			wantName:      "",
+			wantRemainder: "",
+			wantMention:   false,
+		},
+		{
+			name:          "text with colons mid-sentence",
+			text:          "hello: world: foo",
+			wantName:      "hello",
+			wantRemainder: "world: foo",
+			wantMention:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotName, gotRemainder, gotMention := extractNameMention(tc.text)
+			if gotName != tc.wantName {
+				t.Errorf("name = %q, want %q", gotName, tc.wantName)
+			}
+			if gotRemainder != tc.wantRemainder {
+				t.Errorf("remainder = %q, want %q", gotRemainder, tc.wantRemainder)
+			}
+			if gotMention != tc.wantMention {
+				t.Errorf("isMention = %v, want %v", gotMention, tc.wantMention)
+			}
+		})
+	}
+}
+
 // resolveSlackReceiver returns the AgentConfigSpec marked slackListener=true.
 // If none is set it returns nil (caller falls back to first Slack-bound agent).
 // If more than one is set, the first match is used.
@@ -17,10 +146,10 @@ import (
 
 func TestResolveSlackReceiver(t *testing.T) {
 	tests := []struct {
-		name        string
-		agentCfgs   []sympoziumv1alpha1.AgentConfigSpec
-		wantName    string // empty = expect nil
-		wantNil     bool
+		name      string
+		agentCfgs []sympoziumv1alpha1.AgentConfigSpec
+		wantName  string // empty = expect nil
+		wantNil   bool
 	}{
 		{
 			name:    "no agents — nil",

--- a/internal/controller/channel_router_slack_routing_test.go
+++ b/internal/controller/channel_router_slack_routing_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -48,6 +49,43 @@ func TestExtractNameMention(t *testing.T) {
 			wantName:      "finance",
 			wantRemainder: "help",
 			wantMention:   true,
+		},
+		// ISI-1497 C7 — @mention honoured anywhere, not only leading token
+		{
+			name:          "@persona mid-message (numbered list)",
+			text:          "1. @architect please review",
+			wantName:      "architect",
+			wantRemainder: "1. please review",
+			wantMention:   true,
+		},
+		{
+			name:          "@persona mid-message (trailing token)",
+			text:          "please review this @architect",
+			wantName:      "architect",
+			wantRemainder: "please review this",
+			wantMention:   true,
+		},
+		{
+			name:          "multiple @mentions — first wins",
+			text:          "@architect @winston review",
+			wantName:      "architect",
+			wantRemainder: "@winston review",
+			wantMention:   true,
+		},
+		// Email/URL negative controls — '@' not on a word boundary, no match
+		{
+			name:          "email address — @ not a mention",
+			text:          "email me at henrik@perfbytes.com please",
+			wantName:      "",
+			wantRemainder: "email me at henrik@perfbytes.com please",
+			wantMention:   false,
+		},
+		{
+			name:          "URL with userinfo @ — not a mention",
+			text:          "see https://user@host/path for details",
+			wantName:      "",
+			wantRemainder: "see https://user@host/path for details",
+			wantMention:   false,
 		},
 		// Slack keywords — must return no match (fall through, not deny)
 		{
@@ -313,6 +351,9 @@ func TestNoListenerFallback(t *testing.T) {
 func handleInboundScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
 	if err := sympoziumv1alpha1.AddToScheme(s); err != nil {
 		t.Fatalf("add sympoziumv1alpha1: %v", err)
 	}
@@ -522,4 +563,97 @@ func TestHandleInbound_NameRouting(t *testing.T) {
 			t.Errorf("run label instance = %q, want %q (swapped listener inst)", got, receiverName)
 		}
 	})
+}
+
+// TestHandleInbound_UnknownMentionMutedChannel verifies ISI-1524: an unknown
+// @persona mention on a muted channel must NOT emit a denial response.
+// The deferred denial only fires after access/mute checks pass.
+func TestHandleInbound_UnknownMentionMutedChannel(t *testing.T) {
+	const (
+		ns           = "default"
+		ensembleName = "myteam"
+		receiverName = "myteam-triage"
+	)
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: ensembleName, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "triage", SlackListener: true},
+				{Name: "billing"},
+			},
+		},
+	}
+
+	// Receiver agent with a stop keyword trigger configured.
+	receiver := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      receiverName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     ensembleName,
+				"sympozium.ai/agent-config": "triage",
+			},
+		},
+		Spec: sympoziumv1alpha1.AgentSpec{
+			Channels: []sympoziumv1alpha1.ChannelSpec{
+				{
+					Type: "slack",
+					Triggers: &sympoziumv1alpha1.ChannelTriggerSpec{
+						StopKeywords:  []string{"stop"},
+						StartKeywords: []string{"start"},
+					},
+				},
+			},
+		},
+	}
+
+	// Pre-create the channel-state ConfigMap with the chat muted.
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      receiverName + "-channel-state",
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			channelMuteKey("slack", "C1"): channelMuteValue,
+		},
+	}
+
+	bus := &recordingEventBus{}
+	c := fake.NewClientBuilder().
+		WithScheme(handleInboundScheme(t)).
+		WithObjects(ensemble, receiver, cm).
+		Build()
+
+	cr := &ChannelRouter{
+		Client:   c,
+		EventBus: bus,
+		Log:      logr.Discard(),
+		seen:     make(map[string]time.Time),
+	}
+
+	msg := channelpkg.InboundMessage{
+		InstanceName: receiverName,
+		Channel:      "slack",
+		ChatID:       "C1",
+		Text:         "@finance help me",
+	}
+	ev, _ := eventbus.NewEvent(eventbus.TopicChannelMessageRecv, nil, msg)
+	cr.handleInbound(context.Background(), ev)
+
+	// No denial should be emitted because the channel is muted.
+	for _, text := range outboundTexts(t, bus) {
+		if len(text) > 0 {
+			t.Errorf("expected no outbound denial on muted channel, got %q", text)
+		}
+	}
+
+	// No AgentRun should be created either (chat is muted).
+	var runs sympoziumv1alpha1.AgentRunList
+	if err := cr.Client.List(context.Background(), &runs); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs.Items) != 0 {
+		t.Errorf("expected no AgentRun on muted channel, got %d", len(runs.Items))
+	}
 }

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -321,6 +321,26 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 			needsUpdate = true
 		}
 
+		// Propagate slackListener label and annotation.
+		if existingInst.Labels == nil {
+			existingInst.Labels = map[string]string{}
+		}
+		if existingInst.Annotations == nil {
+			existingInst.Annotations = map[string]string{}
+		}
+		const slackListenerKey = "sympozium.io/slack-listener"
+		haveSlackListener := existingInst.Labels[slackListenerKey] == "true"
+		if persona.SlackListener != haveSlackListener {
+			if persona.SlackListener {
+				existingInst.Labels[slackListenerKey] = "true"
+				existingInst.Annotations[slackListenerKey] = "true"
+			} else {
+				delete(existingInst.Labels, slackListenerKey)
+				delete(existingInst.Annotations, slackListenerKey)
+			}
+			needsUpdate = true
+		}
+
 		// Propagate authRefs changes.
 		if !authRefsEqual(existingInst.Spec.AuthRefs, pack.Spec.AuthRefs) {
 			existingInst.Spec.AuthRefs = pack.Spec.AuthRefs
@@ -606,12 +626,21 @@ func (r *EnsembleReconciler) buildAgent(
 	if persona.Provider != "" {
 		labels["sympozium.ai/provider"] = persona.Provider
 	}
+	if persona.SlackListener {
+		labels["sympozium.io/slack-listener"] = "true"
+	}
+
+	annotations := map[string]string{}
+	if persona.SlackListener {
+		annotations["sympozium.io/slack-listener"] = "true"
+	}
 
 	inst := &sympoziumv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instanceName,
-			Namespace: pack.Namespace,
-			Labels:    labels,
+			Name:        instanceName,
+			Namespace:   pack.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: sympoziumv1alpha1.AgentSpec{
 			Agents: sympoziumv1alpha1.AgentsSpec{

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -27,6 +27,40 @@ import (
 
 const ensembleFinalizer = "sympozium.ai/ensemble-finalizer"
 
+// slackListenerKey labels/annotates the generated Agent CR of the persona
+// designated as the Slack receiver (ISI-1497). It is stamped for observability
+// and kubectl selectability; the channel router resolves the receiver by
+// reading the Ensemble CR, not this label (see resolveSlackReceiver).
+const slackListenerKey = "sympozium.ai/slack-listener"
+
+// setSlackListenerMetadata drives the slackListenerKey on both the label and
+// annotation maps to match the desired state, returning true when either map
+// changed. Keeping label and annotation in lockstep lets the reconcile loop
+// self-heal independent drift instead of only correcting the label (ISI-1498 L2).
+func setSlackListenerMetadata(labels, annotations map[string]string, on bool) bool {
+	changed := false
+	if on {
+		if labels[slackListenerKey] != "true" {
+			labels[slackListenerKey] = "true"
+			changed = true
+		}
+		if annotations[slackListenerKey] != "true" {
+			annotations[slackListenerKey] = "true"
+			changed = true
+		}
+	} else {
+		if _, ok := labels[slackListenerKey]; ok {
+			delete(labels, slackListenerKey)
+			changed = true
+		}
+		if _, ok := annotations[slackListenerKey]; ok {
+			delete(annotations, slackListenerKey)
+			changed = true
+		}
+	}
+	return changed
+}
+
 // EnsembleReconciler reconciles Ensemble objects.
 // It stamps out Agents, SympoziumSchedules, and memory
 // ConfigMaps for each persona defined in the pack.
@@ -225,6 +259,21 @@ func (r *EnsembleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
+	// Warn if more than one persona is designated the Slack receiver (ISI-1497).
+	// CEL validation on agentConfigs rejects this at admission, but older CRDs
+	// may predate that rule, so surface it here too. resolveSlackReceiver
+	// deterministically picks the first such persona in declaration order.
+	var slackListeners []string
+	for _, persona := range pack.Spec.AgentConfigs {
+		if persona.SlackListener {
+			slackListeners = append(slackListeners, persona.Name)
+		}
+	}
+	if len(slackListeners) > 1 {
+		log.Info("More than one persona sets slackListener=true; the first in declaration order is used as the Slack receiver",
+			"listeners", slackListeners, "receiver", slackListeners[0])
+	}
+
 	// Reconcile each persona → instance + schedule + memory
 	var installed []sympoziumv1alpha1.InstalledAgentConfig
 	var installErr error
@@ -328,16 +377,7 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 		if existingInst.Annotations == nil {
 			existingInst.Annotations = map[string]string{}
 		}
-		const slackListenerKey = "sympozium.io/slack-listener"
-		haveSlackListener := existingInst.Labels[slackListenerKey] == "true"
-		if persona.SlackListener != haveSlackListener {
-			if persona.SlackListener {
-				existingInst.Labels[slackListenerKey] = "true"
-				existingInst.Annotations[slackListenerKey] = "true"
-			} else {
-				delete(existingInst.Labels, slackListenerKey)
-				delete(existingInst.Annotations, slackListenerKey)
-			}
+		if setSlackListenerMetadata(existingInst.Labels, existingInst.Annotations, persona.SlackListener) {
 			needsUpdate = true
 		}
 
@@ -626,14 +666,8 @@ func (r *EnsembleReconciler) buildAgent(
 	if persona.Provider != "" {
 		labels["sympozium.ai/provider"] = persona.Provider
 	}
-	if persona.SlackListener {
-		labels["sympozium.io/slack-listener"] = "true"
-	}
-
 	annotations := map[string]string{}
-	if persona.SlackListener {
-		annotations["sympozium.io/slack-listener"] = "true"
-	}
+	setSlackListenerMetadata(labels, annotations, persona.SlackListener)
 
 	inst := &sympoziumv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/ensemble_controller_test.go
+++ b/internal/controller/ensemble_controller_test.go
@@ -244,6 +244,80 @@ func TestReconcileAgentConfig_UpdatesSubagentsOnExistingAgent(t *testing.T) {
 	}
 }
 
+// ── SlackListener label/annotation stamping (ISI-1497 C1 / ISI-1498 L1,L2) ──
+
+func TestBuildAgent_SlackListenerStamp(t *testing.T) {
+	r := &EnsembleReconciler{}
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pack", Namespace: "default"},
+	}
+
+	cases := []struct {
+		name        string
+		listener    bool
+		wantStamped bool
+	}{
+		{"listener stamps label and annotation", true, true},
+		{"non-listener leaves no stamp", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			persona := &sympoziumv1alpha1.AgentConfigSpec{
+				Name:          "receiver",
+				SystemPrompt:  "You are the receiver.",
+				SlackListener: tc.listener,
+			}
+			inst := r.buildAgent(pack, persona, "test-pack-receiver", "")
+
+			_, labelOK := inst.Labels["sympozium.ai/slack-listener"]
+			_, annOK := inst.Annotations["sympozium.ai/slack-listener"]
+			if labelOK != tc.wantStamped || annOK != tc.wantStamped {
+				t.Errorf("slack-listener label=%v annotation=%v, want stamped=%v",
+					labelOK, annOK, tc.wantStamped)
+			}
+			// Guard against a regression of the H1 wrong-domain typo.
+			if _, wrong := inst.Labels["sympozium.io/slack-listener"]; wrong {
+				t.Error("found legacy sympozium.io/slack-listener label (H1 regression)")
+			}
+		})
+	}
+}
+
+func TestSetSlackListenerMetadata(t *testing.T) {
+	cases := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		on          bool
+		wantChanged bool
+		wantLabel   bool
+		wantAnn     bool
+	}{
+		{"stamp both from empty", map[string]string{}, map[string]string{}, true, true, true, true},
+		{"already stamped is no-op", map[string]string{slackListenerKey: "true"}, map[string]string{slackListenerKey: "true"}, true, false, true, true},
+		{"unstamp both", map[string]string{slackListenerKey: "true"}, map[string]string{slackListenerKey: "true"}, false, true, false, false},
+		{"already clear is no-op", map[string]string{}, map[string]string{}, false, false, false, false},
+		// L2: annotation drifted away while label is correct → helper self-heals it.
+		{"self-heal missing annotation", map[string]string{slackListenerKey: "true"}, map[string]string{}, true, true, true, true},
+		// L2 inverse: stale annotation lingers after flag turned off → cleared.
+		{"self-heal stale annotation", map[string]string{}, map[string]string{slackListenerKey: "true"}, false, true, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := setSlackListenerMetadata(tc.labels, tc.annotations, tc.on)
+			if changed != tc.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tc.wantChanged)
+			}
+			if _, ok := tc.labels[slackListenerKey]; ok != tc.wantLabel {
+				t.Errorf("label present = %v, want %v", ok, tc.wantLabel)
+			}
+			if _, ok := tc.annotations[slackListenerKey]; ok != tc.wantAnn {
+				t.Errorf("annotation present = %v, want %v", ok, tc.wantAnn)
+			}
+		})
+	}
+}
+
 // ── Relationship graph validation tests ────────────────────────────────────
 
 func testPersonas(names ...string) []sympoziumv1alpha1.AgentConfigSpec {


### PR DESCRIPTION
## Summary

Allows an Ensemble to designate one persona as the Slack receiver via a `slackListener` boolean flag on `AgentConfigSpec`, and re-routes inbound messages addressed with `@<name>` to the named persona rather than the receiver.

Closes #257

## Changes

### CRD
- `AgentConfigSpec.SlackListener bool` (`json:"slackListener,omitempty"`) — marks exactly one persona as the inbound Slack receiver
- CEL `XValidation` enforces at most one `slackListener: true` per Ensemble; a warning log is emitted when the constraint is violated so the operator surfaces misconfigurations without hard-failing
- `sympozium.ai/slack-listener` label + annotation stamped on the receiver's Agent CR; self-healed by `setSlackListenerMetadata` on every reconcile

### Channel router
- `resolveSlackReceiver` — scans `AgentConfigs` for the first `SlackListener: true` entry and swaps the AgentRun target to that persona's Agent CR; falls back to the inbound-receiving pod when no listener is configured
- `extractNameMention` — scans the message for the first boundary-anchored `@<token>` anywhere in the text (not leading-only); email addresses, URLs, and Slack keywords (`@here`, `@channel`, `@everyone`) are excluded
- `resolveNamedDelegate` — matches the extracted mention against each persona's `Name` and `DisplayName` (case-insensitive); first match wins
- `handleInbound`: `@name` routing checked first; if matched, AgentRun is created for the named delegate; if the mention exists but matches no persona and the channel is not muted/inaccessible, a denial is sent back to Slack; unaddressed messages fall through to `resolveSlackReceiver`

### Outbound attribution
- `agentDisplayName` helper reads the `sympozium.ai/agent-display-name` annotation from the sending Agent CR
- `chat.postMessage` now sets `username` to the resolved display name so Slack shows which persona replied

### Tests
- `TestExtractNameMention` — 13 table-driven cases covering mid-message mention, email/URL exclusion, Slack keywords, case variants
- `TestResolveNamedDelegate` — 7 cases: exact Name, case-insensitive Name, DisplayName, partial-no-match, unknown-nil, empty-nil
- `TestHandleInbound_NameRouting` — 4 integration cases: known mention creates delegate AgentRun, unknown mention sends denial, non-mention prefix falls through to receiver, unaddressed falls through to listener swap
- `TestBuildAgent_SlackListenerStamp` — listener vs non-listener label/annotation stamping
- `TestSetSlackListenerMetadata` — 6 self-heal subtests

## Compatibility

- No changes to existing AgentRun spec, Ensemble spec fields other than the additive `slackListener` flag
- Ensembles without `slackListener: true` on any persona continue to route to the inbound-receiving pod (backward compatible)
- `@name` routing requires the inbound message to arrive at a pod that belongs to an Ensemble; standalone Agents are unaffected
