### PR TITLE
feat(observability): emit OpenTelemetry gen_ai.* semantic conventions on agent spans

### DIFF
--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -354,12 +354,7 @@ func main() {
 		log.Println("TRACEPARENT env var not set")
 	}
 
-	ctx, runSpan := obs.startRunSpan(ctx,
-		attribute.String("instance", getEnv("INSTANCE_NAME", "")),
-		attribute.String("tenant.namespace", getEnv("AGENT_NAMESPACE", "")),
-		attribute.String("model", modelName),
-		attribute.String("task.summary", truncate(task, 200)),
-	)
+	ctx, runSpan := obs.startRunSpan(ctx, getEnv("INSTANCE_NAME",""), getEnv("AGENT_NAMESPACE",""), modelName, truncate(task,200))
 	writeTraceContextMetadata(ctx)
 	logWithTrace(ctx, "info", "agent run started", map[string]any{
 		"instance":  getEnv("INSTANCE_NAME", ""),
@@ -581,7 +576,7 @@ func main() {
 // backward-compatible test coverage.
 func callAnthropic(ctx context.Context, apiKey, baseURL, model, systemPrompt, task string, tools []ToolDef, headers map[string]string) (string, int, int, int, error) {
 	p := newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task, tools, headers)
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, systemPrompt)
 }
 
 // callOpenAI dispatches an agent run to the OpenAI-compatible provider path
@@ -591,7 +586,7 @@ func callOpenAI(ctx context.Context, provider, apiKey, baseURL, model, systemPro
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, systemPrompt)
 }
 
 // callBedrock dispatches an agent run to the AWS Bedrock provider.
@@ -600,7 +595,7 @@ func callBedrock(ctx context.Context, model, systemPrompt, task string, tools []
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, systemPrompt)
 }
 
 // callBedrockWithClient accepts a pre-built client; used by tests to inject
@@ -610,7 +605,7 @@ func callBedrockWithClient(ctx context.Context, client bedrockClientAPI, model, 
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, systemPrompt)
 }
 
 func writeJSON(path string, v any) {

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -17,6 +17,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/sympozium-ai/sympozium/internal/ipc"
+	"github.com/sympozium-ai/sympozium/pkg/genaiattrs"
 )
 
 // maxToolIterations is the maximum number of LLM reasoning rounds before
@@ -354,7 +355,7 @@ func main() {
 		log.Println("TRACEPARENT env var not set")
 	}
 
-	ctx, runSpan := obs.startRunSpan(ctx, getEnv("INSTANCE_NAME",""), getEnv("AGENT_NAMESPACE",""), modelName, truncate(task,200))
+	ctx, runSpan := obs.startRunSpan(ctx, getEnv("INSTANCE_NAME", ""), getEnv("AGENT_NAMESPACE", ""), modelName, truncate(task, 200))
 	writeTraceContextMetadata(ctx)
 	logWithTrace(ctx, "info", "agent run started", map[string]any{
 		"instance":  getEnv("INSTANCE_NAME", ""),
@@ -461,6 +462,11 @@ func main() {
 	}
 
 	_ = os.MkdirAll("/ipc/output", 0o755)
+
+	// Attach the fully-assembled system prompt once on the run span rather than
+	// on every per-round gen_ai.chat span (persona prompts are large; repeating
+	// them per round bloats span payload).
+	runSpan.SetAttributes(genaiattrs.SystemInstructions(systemPrompt))
 
 	start := time.Now()
 
@@ -576,7 +582,7 @@ func main() {
 // backward-compatible test coverage.
 func callAnthropic(ctx context.Context, apiKey, baseURL, model, systemPrompt, task string, tools []ToolDef, headers map[string]string) (string, int, int, int, error) {
 	p := newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task, tools, headers)
-	return runAgentLoop(ctx, p, systemPrompt)
+	return runAgentLoop(ctx, p)
 }
 
 // callOpenAI dispatches an agent run to the OpenAI-compatible provider path
@@ -586,7 +592,7 @@ func callOpenAI(ctx context.Context, provider, apiKey, baseURL, model, systemPro
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p, systemPrompt)
+	return runAgentLoop(ctx, p)
 }
 
 // callBedrock dispatches an agent run to the AWS Bedrock provider.
@@ -595,7 +601,7 @@ func callBedrock(ctx context.Context, model, systemPrompt, task string, tools []
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p, systemPrompt)
+	return runAgentLoop(ctx, p)
 }
 
 // callBedrockWithClient accepts a pre-built client; used by tests to inject
@@ -605,7 +611,7 @@ func callBedrockWithClient(ctx context.Context, client bedrockClientAPI, model, 
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p, systemPrompt)
+	return runAgentLoop(ctx, p)
 }
 
 func writeJSON(path string, v any) {

--- a/cmd/agent-runner/observability.go
+++ b/cmd/agent-runner/observability.go
@@ -153,18 +153,19 @@ func (o *agentObservability) startRunSpan(ctx context.Context, instance, namespa
 	return o.tracer.Start(ctx, "sympozium.agent.run", trace.WithAttributes(attrs...))
 }
 
-// startChatSpan starts a gen_ai.chat span with full semantic convention
-// attributes for the LLM call.
-func (o *agentObservability) startChatSpan(ctx context.Context, provider, model, systemPrompt string) (context.Context, trace.Span) {
+// startChatSpan starts a gen_ai.chat span with GenAI semantic convention
+// attributes for the LLM call. gen_ai.system is emitted alongside
+// gen_ai.provider.name for one release cycle (back-compat). System instructions
+// are NOT attached here — they are set once on the run span (see startRunSpan
+// callers) rather than duplicated on every per-round chat span.
+func (o *agentObservability) startChatSpan(ctx context.Context, provider, model string) (context.Context, trace.Span) {
 	if o == nil {
 		return ctx, trace.SpanFromContext(ctx)
 	}
 	attrs := []attribute.KeyValue{
 		genaiattrs.Provider(provider),
+		genaiattrs.System(provider),
 		genaiattrs.Model(model),
-	}
-	if systemPrompt != "" {
-		attrs = append(attrs, genaiattrs.SystemInstructions(systemPrompt))
 	}
 	return o.tracer.Start(ctx, "gen_ai.chat", trace.WithAttributes(attrs...))
 }

--- a/cmd/agent-runner/observability.go
+++ b/cmd/agent-runner/observability.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sympozium-ai/sympozium/pkg/genaiattrs"
 	"github.com/sympozium-ai/sympozium/pkg/telemetry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -132,30 +133,65 @@ func (o *agentObservability) initMetrics() {
 	}
 }
 
-func (o *agentObservability) startRunSpan(ctx context.Context, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+// startRunSpan starts the top-level agent-run span with GenAI semantic
+// convention attributes alongside legacy sympozium.* attributes.
+func (o *agentObservability) startRunSpan(ctx context.Context, instance, namespace, model, taskSummary string) (context.Context, trace.Span) {
 	if o == nil {
 		return ctx, trace.SpanFromContext(ctx)
+	}
+	attrs := []attribute.KeyValue{
+		// Legacy attributes (kept for backward compatibility)
+		attribute.String("instance", instance),
+		attribute.String("tenant.namespace", namespace),
+		attribute.String("model", model),
+		attribute.String("task.summary", taskSummary),
+		// GenAI semantic conventions
+		genaiattrs.Agent(instance),
+		genaiattrs.Model(model),
+		genaiattrs.SpanKind(genaiattrs.SpanKindTask),
 	}
 	return o.tracer.Start(ctx, "sympozium.agent.run", trace.WithAttributes(attrs...))
 }
 
-func (o *agentObservability) startChatSpan(ctx context.Context, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+// startChatSpan starts a gen_ai.chat span with full semantic convention
+// attributes for the LLM call.
+func (o *agentObservability) startChatSpan(ctx context.Context, provider, model, systemPrompt string) (context.Context, trace.Span) {
 	if o == nil {
 		return ctx, trace.SpanFromContext(ctx)
+	}
+	attrs := []attribute.KeyValue{
+		genaiattrs.Provider(provider),
+		genaiattrs.Model(model),
+	}
+	if systemPrompt != "" {
+		attrs = append(attrs, genaiattrs.SystemInstructions(systemPrompt))
 	}
 	return o.tracer.Start(ctx, "gen_ai.chat", trace.WithAttributes(attrs...))
 }
 
-func (o *agentObservability) startToolSpan(ctx context.Context, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+// startToolSpan starts a gen_ai.execute_tool span with traceloop.span.kind=tool.
+func (o *agentObservability) startToolSpan(ctx context.Context, toolName, callID string) (context.Context, trace.Span) {
 	if o == nil {
 		return ctx, trace.SpanFromContext(ctx)
+	}
+	attrs := []attribute.KeyValue{
+		genaiattrs.ToolName(toolName),
+		genaiattrs.ToolCallID(callID),
+		genaiattrs.SpanKind(genaiattrs.SpanKindTool),
 	}
 	return o.tracer.Start(ctx, "gen_ai.execute_tool", trace.WithAttributes(attrs...))
 }
 
-func (o *agentObservability) startSkillSpan(ctx context.Context, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+// startSkillSpan starts a sympozium.skill.exec span with traceloop.span.kind=tool.
+func (o *agentObservability) startSkillSpan(ctx context.Context, skillName, sidecarContainer, rbacScope string) (context.Context, trace.Span) {
 	if o == nil {
 		return ctx, trace.SpanFromContext(ctx)
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("skill.name", skillName),
+		attribute.String("sidecar.container", sidecarContainer),
+		attribute.String("rbac.scope", rbacScope),
+		genaiattrs.SpanKind(genaiattrs.SpanKindTool),
 	}
 	return o.tracer.Start(ctx, "sympozium.skill.exec", trace.WithAttributes(attrs...))
 }

--- a/cmd/agent-runner/otel_test.go
+++ b/cmd/agent-runner/otel_test.go
@@ -98,8 +98,18 @@ func TestOTelSpanHierarchy(t *testing.T) {
 		if v, ok := attrs["gen_ai.system"]; !ok || v != "anthropic" {
 			t.Errorf("gen_ai.system = %q, want %q", v, "anthropic")
 		}
+		// gen_ai.provider.name is the current OTel convention, emitted alongside
+		// the deprecated gen_ai.system for one back-compat cycle.
+		if v, ok := attrs["gen_ai.provider.name"]; !ok || v != "anthropic" {
+			t.Errorf("gen_ai.provider.name = %q, want %q", v, "anthropic")
+		}
 		if v, ok := attrs["gen_ai.request.model"]; !ok || v != "claude-sonnet-4-20250514" {
 			t.Errorf("gen_ai.request.model = %q, want %q", v, "claude-sonnet-4-20250514")
+		}
+		// gen_ai.response.model reflects the model the backend reports serving
+		// (from the mock Anthropic response body).
+		if v, ok := attrs["gen_ai.response.model"]; !ok || v != "claude-sonnet-4-20250514" {
+			t.Errorf("gen_ai.response.model = %q, want %q", v, "claude-sonnet-4-20250514")
 		}
 	})
 

--- a/cmd/agent-runner/provider.go
+++ b/cmd/agent-runner/provider.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sympozium-ai/sympozium/pkg/genaiattrs"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 )
@@ -75,7 +76,7 @@ type LLMProvider interface {
 // intermediate reasoning in the UX instead of a blank response.
 //
 // Returns (responseText, inputTokens, outputTokens, toolCalls, error).
-func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, error) {
+func runAgentLoop(ctx context.Context, p LLMProvider, systemPrompt string) (string, int, int, int, error) {
 	totalInputTokens := 0
 	totalOutputTokens := 0
 	totalToolCalls := 0
@@ -100,10 +101,7 @@ func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, er
 			log.Printf("llm_round [%d/%d]", round, maxToolIterations)
 		}
 
-		chatCtx, chatSpan := obs.startChatSpan(ctx,
-			attribute.String("gen_ai.system", p.Name()),
-			attribute.String("gen_ai.request.model", p.Model()),
-		)
+		chatCtx, chatSpan := obs.startChatSpan(ctx, p.Name(), p.Model(), systemPrompt)
 		res, err := p.Chat(chatCtx)
 		if err != nil {
 			markSpanError(chatSpan, err)
@@ -114,8 +112,8 @@ func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, er
 		totalInputTokens += res.InputTokens
 		totalOutputTokens += res.OutputTokens
 		chatSpan.SetAttributes(
-			attribute.Int("gen_ai.usage.input_tokens", res.InputTokens),
-			attribute.Int("gen_ai.usage.output_tokens", res.OutputTokens),
+			genaiattrs.InputTokens(res.InputTokens),
+			genaiattrs.OutputTokens(res.OutputTokens),
 		)
 		if res.FinishReason != "" {
 			chatSpan.SetAttributes(attribute.String("gen_ai.response.finish_reasons", res.FinishReason))

--- a/cmd/agent-runner/provider.go
+++ b/cmd/agent-runner/provider.go
@@ -41,6 +41,10 @@ type ChatResult struct {
 	InputTokens  int
 	OutputTokens int
 	FinishReason string
+	// ResponseModel is the model id the backend reports having served the
+	// request (gen_ai.response.model). May differ from the requested model
+	// (aliases, routed models). Empty if the backend does not report one.
+	ResponseModel string
 }
 
 // LLMProvider is a stateful adapter for one chat conversation with a
@@ -76,7 +80,7 @@ type LLMProvider interface {
 // intermediate reasoning in the UX instead of a blank response.
 //
 // Returns (responseText, inputTokens, outputTokens, toolCalls, error).
-func runAgentLoop(ctx context.Context, p LLMProvider, systemPrompt string) (string, int, int, int, error) {
+func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, error) {
 	totalInputTokens := 0
 	totalOutputTokens := 0
 	totalToolCalls := 0
@@ -101,7 +105,7 @@ func runAgentLoop(ctx context.Context, p LLMProvider, systemPrompt string) (stri
 			log.Printf("llm_round [%d/%d]", round, maxToolIterations)
 		}
 
-		chatCtx, chatSpan := obs.startChatSpan(ctx, p.Name(), p.Model(), systemPrompt)
+		chatCtx, chatSpan := obs.startChatSpan(ctx, p.Name(), p.Model())
 		res, err := p.Chat(chatCtx)
 		if err != nil {
 			markSpanError(chatSpan, err)
@@ -115,6 +119,14 @@ func runAgentLoop(ctx context.Context, p LLMProvider, systemPrompt string) (stri
 			genaiattrs.InputTokens(res.InputTokens),
 			genaiattrs.OutputTokens(res.OutputTokens),
 		)
+		// gen_ai.response.model: what the backend reports serving. Fall back to
+		// the requested model when the backend does not echo one (e.g. Bedrock
+		// Converse), so the attribute is always present for AI Observability.
+		respModel := res.ResponseModel
+		if respModel == "" {
+			respModel = p.Model()
+		}
+		chatSpan.SetAttributes(genaiattrs.ResponseModel(respModel))
 		if res.FinishReason != "" {
 			chatSpan.SetAttributes(attribute.String("gen_ai.response.finish_reasons", res.FinishReason))
 		}

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -99,10 +99,11 @@ func (p *anthropicProvider) Chat(ctx context.Context) (ChatResult, error) {
 	}
 
 	result := ChatResult{
-		Text:         textContent.String(),
-		InputTokens:  int(msg.Usage.InputTokens),
-		OutputTokens: int(msg.Usage.OutputTokens),
-		FinishReason: string(msg.StopReason),
+		Text:          textContent.String(),
+		InputTokens:   int(msg.Usage.InputTokens),
+		OutputTokens:  int(msg.Usage.OutputTokens),
+		FinishReason:  string(msg.StopReason),
+		ResponseModel: string(msg.Model),
 	}
 
 	// Continue the loop only when the model explicitly stopped to call

--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -144,10 +144,11 @@ func (p *openaiProvider) Chat(ctx context.Context) (ChatResult, error) {
 	}
 
 	result := ChatResult{
-		Text:         text,
-		InputTokens:  int(completion.Usage.PromptTokens),
-		OutputTokens: int(completion.Usage.CompletionTokens),
-		FinishReason: choice.FinishReason,
+		Text:          text,
+		InputTokens:   int(completion.Usage.PromptTokens),
+		OutputTokens:  int(completion.Usage.CompletionTokens),
+		FinishReason:  choice.FinishReason,
+		ResponseModel: completion.Model,
 	}
 
 	// Extract tool calls whenever present, regardless of finish_reason.

--- a/cmd/agent-runner/provider_test.go
+++ b/cmd/agent-runner/provider_test.go
@@ -52,7 +52,7 @@ func TestRunAgentLoop_TerminalTextOnly(t *testing.T) {
 			{Text: "final answer", InputTokens: 10, OutputTokens: 5},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestRunAgentLoop_ToolCallThenText(t *testing.T) {
 			{Text: "contents: hello", InputTokens: 40, OutputTokens: 10, FinishReason: "stop"},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestRunAgentLoop_ToolFailuresDoNotBlock(t *testing.T) {
 	turns = append(turns, ChatResult{Text: "gave up and summarized", InputTokens: 2, OutputTokens: 3})
 
 	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
-	text, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, _, _, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("loop returned error despite tool failures: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestRunAgentLoop_EmptyTerminalFallsBackToAccumulated(t *testing.T) {
 			{Text: "", InputTokens: 200, OutputTokens: 242, FinishReason: "stop"},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestRunAgentLoop_AllTurnsEmptyReturnsEmpty(t *testing.T) {
 			{Text: "", FinishReason: "stop"},
 		},
 	}
-	text, _, _, _, err := runAgentLoop(context.Background(), p)
+	text, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestRunAgentLoop_TerminalTextPreferredOverAccumulated(t *testing.T) {
 			{Text: "final answer is 42", FinishReason: "stop"},
 		},
 	}
-	text, _, _, _, err := runAgentLoop(context.Background(), p)
+	text, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestRunAgentLoop_IterationBudget(t *testing.T) {
 		})
 	}
 	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
-	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
+	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err == nil {
 		t.Fatal("expected budget-exceeded error")
 	}
@@ -290,7 +290,7 @@ func TestRunAgentLoop_ChatErrorPropagates(t *testing.T) {
 		turns:   []ChatResult{{}},
 		turnErr: []error{fmt.Errorf("provider rate limit")},
 	}
-	_, _, _, _, err := runAgentLoop(context.Background(), p)
+	_, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err == nil {
 		t.Fatal("expected error from Chat to propagate")
 	}
@@ -317,7 +317,7 @@ func TestRunAgentLoop_MultipleToolCallsPerTurn(t *testing.T) {
 			{Text: "done", FinishReason: "stop"},
 		},
 	}
-	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
+	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestRunAgentLoop_MaxTokensPerRun_Halt(t *testing.T) {
 		},
 	}
 
-	text, in, out, _, err := runAgentLoop(context.Background(), p)
+	text, in, out, _, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestRunAgentLoop_MaxTokensPerRun_Warn(t *testing.T) {
 		},
 	}
 
-	text, in, out, _, err := runAgentLoop(context.Background(), p)
+	text, in, out, _, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestRunAgentLoop_MaxTokensPerRun_NotSet(t *testing.T) {
 		},
 	}
 
-	text, _, _, _, err := runAgentLoop(context.Background(), p)
+	text, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/agent-runner/provider_test.go
+++ b/cmd/agent-runner/provider_test.go
@@ -52,7 +52,7 @@ func TestRunAgentLoop_TerminalTextOnly(t *testing.T) {
 			{Text: "final answer", InputTokens: 10, OutputTokens: 5},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestRunAgentLoop_ToolCallThenText(t *testing.T) {
 			{Text: "contents: hello", InputTokens: 40, OutputTokens: 10, FinishReason: "stop"},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestRunAgentLoop_ToolFailuresDoNotBlock(t *testing.T) {
 	turns = append(turns, ChatResult{Text: "gave up and summarized", InputTokens: 2, OutputTokens: 3})
 
 	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
-	text, _, _, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("loop returned error despite tool failures: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestRunAgentLoop_EmptyTerminalFallsBackToAccumulated(t *testing.T) {
 			{Text: "", InputTokens: 200, OutputTokens: 242, FinishReason: "stop"},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestRunAgentLoop_AllTurnsEmptyReturnsEmpty(t *testing.T) {
 			{Text: "", FinishReason: "stop"},
 		},
 	}
-	text, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, _, _, _, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestRunAgentLoop_TerminalTextPreferredOverAccumulated(t *testing.T) {
 			{Text: "final answer is 42", FinishReason: "stop"},
 		},
 	}
-	text, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, _, _, _, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestRunAgentLoop_IterationBudget(t *testing.T) {
 		})
 	}
 	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
-	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
+	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
 	if err == nil {
 		t.Fatal("expected budget-exceeded error")
 	}
@@ -290,7 +290,7 @@ func TestRunAgentLoop_ChatErrorPropagates(t *testing.T) {
 		turns:   []ChatResult{{}},
 		turnErr: []error{fmt.Errorf("provider rate limit")},
 	}
-	_, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
+	_, _, _, _, err := runAgentLoop(context.Background(), p)
 	if err == nil {
 		t.Fatal("expected error from Chat to propagate")
 	}
@@ -317,7 +317,7 @@ func TestRunAgentLoop_MultipleToolCallsPerTurn(t *testing.T) {
 			{Text: "done", FinishReason: "stop"},
 		},
 	}
-	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p, "test prompt")
+	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestRunAgentLoop_MaxTokensPerRun_Halt(t *testing.T) {
 		},
 	}
 
-	text, in, out, _, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, in, out, _, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestRunAgentLoop_MaxTokensPerRun_Warn(t *testing.T) {
 		},
 	}
 
-	text, in, out, _, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, in, out, _, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestRunAgentLoop_MaxTokensPerRun_NotSet(t *testing.T) {
 		},
 	}
 
-	text, _, _, _, err := runAgentLoop(context.Background(), p, "test prompt")
+	text, _, _, _, err := runAgentLoop(context.Background(), p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/agent-runner/tool_tracing.go
+++ b/cmd/agent-runner/tool_tracing.go
@@ -12,18 +12,15 @@ import (
 
 func executeToolCallWithTelemetry(ctx context.Context, name, argsJSON, callID string) string {
 	start := time.Now()
-	toolCtx, toolSpan := obs.startToolSpan(ctx,
-		attribute.String("gen_ai.tool.name", name),
-		attribute.String("gen_ai.tool.call.id", callID),
-	)
+	toolCtx, toolSpan := obs.startToolSpan(ctx, name, callID)
 
 	var result string
 	if name == ToolExecuteCommand {
 		skillStart := time.Now()
 		skillCtx, skillSpan := obs.startSkillSpan(toolCtx,
-			attribute.String("skill.name", "command-executor"),
-			attribute.String("sidecar.container", "tool-executor"),
-			attribute.String("rbac.scope", "namespace"),
+			"command-executor",
+			"tool-executor",
+			"namespace",
 		)
 		result = executeToolCall(skillCtx, name, argsJSON)
 		if strings.HasPrefix(result, "Error:") {

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -22,6 +22,7 @@ import (
 	channelpkg "github.com/sympozium-ai/sympozium/internal/channel"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
 	"github.com/sympozium-ai/sympozium/internal/ipc"
+	"github.com/sympozium-ai/sympozium/pkg/genaiattrs"
 )
 
 var routerTracer = otel.Tracer("sympozium.ai/channel-router")
@@ -210,6 +211,8 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 			attribute.String("sympozium.channel", msg.Channel),
 			attribute.String("sympozium.instance", msg.InstanceName),
 			attribute.String("sympozium.sender.id", msg.SenderID),
+			genaiattrs.Agent(msg.InstanceName),
+			genaiattrs.SpanKind(genaiattrs.SpanKindTask),
 		),
 	)
 	defer span.End()
@@ -357,6 +360,8 @@ func (cr *ChannelRouter) handleCompleted(ctx context.Context, event *eventbus.Ev
 		trace.WithAttributes(
 			attribute.String("sympozium.agentrun.id", agentRunID),
 			attribute.String("sympozium.instance", instanceName),
+			genaiattrs.Agent(instanceName),
+			genaiattrs.SpanKind(genaiattrs.SpanKindTask),
 		),
 	)
 	defer span.End()

--- a/pkg/genaiattrs/genaiattrs.go
+++ b/pkg/genaiattrs/genaiattrs.go
@@ -1,0 +1,157 @@
+// Package genaiattrs provides shared OpenTelemetry GenAI semantic convention
+// attribute keys and helpers for consistent instrumentation across Sympozium.
+//
+// These follow the OTel GenAI semantic conventions so Dynatrace AI
+// Observability can consume telemetry without custom mapping.
+//
+// Backward compatibility: existing sympozium.* attributes are kept alongside
+// the new gen_ai.* attributes for one release cycle.
+package genaiattrs
+
+import (
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// ---------------------------------------------------------------------------
+// GenAI semantic convention attribute keys
+// ---------------------------------------------------------------------------
+
+const (
+	// Provider
+	ProviderNameKey = "gen_ai.provider.name"
+
+	// Models
+	RequestModelKey  = "gen_ai.request.model"
+	ResponseModelKey = "gen_ai.response.model"
+
+	// Token usage
+	InputTokensKey  = "gen_ai.usage.input_tokens"
+	OutputTokensKey = "gen_ai.usage.output_tokens"
+
+	// Messages
+	InputMessagesKey  = "gen_ai.input.messages"
+	OutputMessagesKey = "gen_ai.output.messages"
+
+	// System / agent
+	SystemInstructionsKey = "gen_ai.system_instructions"
+	AgentNameKey          = "gen_ai.agent.name"
+
+	// Traceloop span kind (task or tool)
+	TraceloopSpanKindKey = "traceloop.span.kind"
+
+	// Content filter results
+	PromptFilterResultsKey    = "gen_ai.prompt.prompt_filter_results"
+	CompletionFilterResultsKey = "gen_ai.completion.content_filter_results"
+
+	// Tool call
+	ToolNameKey   = "gen_ai.tool.name"
+	ToolCallIDKey = "gen_ai.tool.call.id"
+)
+
+// SpanKind values for traceloop.span.kind.
+const (
+	SpanKindTask = "task"
+	SpanKindTool = "tool"
+)
+
+// ---------------------------------------------------------------------------
+// Attribute builders
+// ---------------------------------------------------------------------------
+
+// Provider returns gen_ai.provider.name.
+func Provider(name string) attribute.KeyValue {
+	return attribute.String(ProviderNameKey, name)
+}
+
+// Model returns gen_ai.request.model.
+func Model(model string) attribute.KeyValue {
+	return attribute.String(RequestModelKey, model)
+}
+
+// ResponseModel returns gen_ai.response.model.
+func ResponseModel(model string) attribute.KeyValue {
+	return attribute.String(ResponseModelKey, model)
+}
+
+// InputTokens returns gen_ai.usage.input_tokens.
+func InputTokens(n int) attribute.KeyValue {
+	return attribute.Int(InputTokensKey, n)
+}
+
+// OutputTokens returns gen_ai.usage.output_tokens.
+func OutputTokens(n int) attribute.KeyValue {
+	return attribute.Int(OutputTokensKey, n)
+}
+
+// Agent returns gen_ai.agent.name.
+func Agent(name string) attribute.KeyValue {
+	return attribute.String(AgentNameKey, name)
+}
+
+// SystemInstructions returns gen_ai.system_instructions.
+func SystemInstructions(text string) attribute.KeyValue {
+	return attribute.String(SystemInstructionsKey, text)
+}
+
+// SpanKind returns traceloop.span.kind.
+func SpanKind(kind string) attribute.KeyValue {
+	return attribute.String(TraceloopSpanKindKey, kind)
+}
+
+// ToolName returns gen_ai.tool.name.
+func ToolName(name string) attribute.KeyValue {
+	return attribute.String(ToolNameKey, name)
+}
+
+// ToolCallID returns gen_ai.tool.call.id.
+func ToolCallID(id string) attribute.KeyValue {
+	return attribute.String(ToolCallIDKey, id)
+}
+
+// ---------------------------------------------------------------------------
+// Message helpers
+// ---------------------------------------------------------------------------
+
+// Message is a simple role/content pair for JSON serialisation.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// MessagesJSON serialises a slice of messages to a JSON string for
+// gen_ai.input.messages. Falls back to a simple JSON array.
+func MessagesJSON(msgs []Message) attribute.KeyValue {
+	if len(msgs) == 0 {
+		return attribute.String(InputMessagesKey, "[]")
+	}
+	var b strings.Builder
+	b.WriteString("[")
+	for i, m := range msgs {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(fmt.Sprintf(`{"role":"%s","content":%q}`, m.Role, m.Content))
+	}
+	b.WriteString("]")
+	return attribute.String(InputMessagesKey, b.String())
+}
+
+// OutputMessagesJSON is the same as MessagesJSON but for output.
+func OutputMessagesJSON(msgs []Message) attribute.KeyValue {
+	if len(msgs) == 0 {
+		return attribute.String(OutputMessagesKey, "[]")
+	}
+	var b strings.Builder
+	b.WriteString("[")
+	for i, m := range msgs {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(fmt.Sprintf(`{"role":"%s","content":%q}`, m.Role, m.Content))
+	}
+	b.WriteString("]")
+	return attribute.String(OutputMessagesKey, b.String())
+}

--- a/pkg/genaiattrs/genaiattrs.go
+++ b/pkg/genaiattrs/genaiattrs.go
@@ -9,9 +9,6 @@
 package genaiattrs
 
 import (
-	"fmt"
-	"strings"
-
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -20,8 +17,11 @@ import (
 // ---------------------------------------------------------------------------
 
 const (
-	// Provider
+	// Provider. ProviderNameKey is the current OTel convention; SystemKey is
+	// the deprecated predecessor, kept for one release cycle for back-compat
+	// (Dynatrace AI Observability + existing dashboards still key off it).
 	ProviderNameKey = "gen_ai.provider.name"
+	SystemKey       = "gen_ai.system"
 
 	// Models
 	RequestModelKey  = "gen_ai.request.model"
@@ -31,20 +31,12 @@ const (
 	InputTokensKey  = "gen_ai.usage.input_tokens"
 	OutputTokensKey = "gen_ai.usage.output_tokens"
 
-	// Messages
-	InputMessagesKey  = "gen_ai.input.messages"
-	OutputMessagesKey = "gen_ai.output.messages"
-
 	// System / agent
 	SystemInstructionsKey = "gen_ai.system_instructions"
 	AgentNameKey          = "gen_ai.agent.name"
 
 	// Traceloop span kind (task or tool)
 	TraceloopSpanKindKey = "traceloop.span.kind"
-
-	// Content filter results
-	PromptFilterResultsKey    = "gen_ai.prompt.prompt_filter_results"
-	CompletionFilterResultsKey = "gen_ai.completion.content_filter_results"
 
 	// Tool call
 	ToolNameKey   = "gen_ai.tool.name"
@@ -64,6 +56,12 @@ const (
 // Provider returns gen_ai.provider.name.
 func Provider(name string) attribute.KeyValue {
 	return attribute.String(ProviderNameKey, name)
+}
+
+// System returns the deprecated gen_ai.system attribute. Emitted alongside
+// gen_ai.provider.name for one release cycle so existing consumers keep working.
+func System(name string) attribute.KeyValue {
+	return attribute.String(SystemKey, name)
 }
 
 // Model returns gen_ai.request.model.
@@ -111,47 +109,9 @@ func ToolCallID(id string) attribute.KeyValue {
 	return attribute.String(ToolCallIDKey, id)
 }
 
-// ---------------------------------------------------------------------------
-// Message helpers
-// ---------------------------------------------------------------------------
-
-// Message is a simple role/content pair for JSON serialisation.
-type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-// MessagesJSON serialises a slice of messages to a JSON string for
-// gen_ai.input.messages. Falls back to a simple JSON array.
-func MessagesJSON(msgs []Message) attribute.KeyValue {
-	if len(msgs) == 0 {
-		return attribute.String(InputMessagesKey, "[]")
-	}
-	var b strings.Builder
-	b.WriteString("[")
-	for i, m := range msgs {
-		if i > 0 {
-			b.WriteString(",")
-		}
-		b.WriteString(fmt.Sprintf(`{"role":"%s","content":%q}`, m.Role, m.Content))
-	}
-	b.WriteString("]")
-	return attribute.String(InputMessagesKey, b.String())
-}
-
-// OutputMessagesJSON is the same as MessagesJSON but for output.
-func OutputMessagesJSON(msgs []Message) attribute.KeyValue {
-	if len(msgs) == 0 {
-		return attribute.String(OutputMessagesKey, "[]")
-	}
-	var b strings.Builder
-	b.WriteString("[")
-	for i, m := range msgs {
-		if i > 0 {
-			b.WriteString(",")
-		}
-		b.WriteString(fmt.Sprintf(`{"role":"%s","content":%q}`, m.Role, m.Content))
-	}
-	b.WriteString("]")
-	return attribute.String(OutputMessagesKey, b.String())
-}
+// NOTE: gen_ai.input.messages / gen_ai.output.messages and the prompt/completion
+// content-filter-result attributes are intentionally NOT emitted. Capturing raw
+// message content on spans is an opt-in per OTel convention
+// (OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT) because it carries PII and
+// large payloads; Dynatrace AI Observability treats these as optional. They are
+// scoped out of this change rather than shipped as dead exported API.

--- a/pkg/genaiattrs/genaiattrs_test.go
+++ b/pkg/genaiattrs/genaiattrs_test.go
@@ -2,12 +2,25 @@ package genaiattrs
 
 import (
 	"testing"
-
 )
 
 func TestProvider(t *testing.T) {
 	kv := Provider("anthropic")
 	if kv.Key != ProviderNameKey || kv.Value.AsString() != "anthropic" {
+		t.Fatalf("unexpected: %+v", kv)
+	}
+}
+
+func TestSystem(t *testing.T) {
+	kv := System("anthropic")
+	if kv.Key != SystemKey || kv.Value.AsString() != "anthropic" {
+		t.Fatalf("unexpected: %+v", kv)
+	}
+}
+
+func TestResponseModel(t *testing.T) {
+	kv := ResponseModel("claude-sonnet-4")
+	if kv.Key != ResponseModelKey || kv.Value.AsString() != "claude-sonnet-4" {
 		t.Fatalf("unexpected: %+v", kv)
 	}
 }
@@ -30,27 +43,5 @@ func TestSpanKind(t *testing.T) {
 	kv := SpanKind(SpanKindTask)
 	if kv.Key != TraceloopSpanKindKey || kv.Value.AsString() != "task" {
 		t.Fatalf("unexpected: %+v", kv)
-	}
-}
-
-func TestMessagesJSON(t *testing.T) {
-	msgs := []Message{
-		{Role: "user", Content: "hello"},
-		{Role: "assistant", Content: "hi"},
-	}
-	kv := MessagesJSON(msgs)
-	if kv.Key != InputMessagesKey {
-		t.Fatalf("expected key %s, got %s", InputMessagesKey, kv.Key)
-	}
-	want := `[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"}]`
-	if kv.Value.AsString() != want {
-		t.Fatalf("expected %q, got %q", want, kv.Value.AsString())
-	}
-}
-
-func TestMessagesJSONEmpty(t *testing.T) {
-	kv := MessagesJSON(nil)
-	if kv.Value.AsString() != "[]" {
-		t.Fatalf("expected [], got %q", kv.Value.AsString())
 	}
 }

--- a/pkg/genaiattrs/genaiattrs_test.go
+++ b/pkg/genaiattrs/genaiattrs_test.go
@@ -1,0 +1,56 @@
+package genaiattrs
+
+import (
+	"testing"
+
+)
+
+func TestProvider(t *testing.T) {
+	kv := Provider("anthropic")
+	if kv.Key != ProviderNameKey || kv.Value.AsString() != "anthropic" {
+		t.Fatalf("unexpected: %+v", kv)
+	}
+}
+
+func TestModel(t *testing.T) {
+	kv := Model("claude-sonnet-4")
+	if kv.Key != RequestModelKey || kv.Value.AsString() != "claude-sonnet-4" {
+		t.Fatalf("unexpected: %+v", kv)
+	}
+}
+
+func TestInputTokens(t *testing.T) {
+	kv := InputTokens(42)
+	if kv.Key != InputTokensKey || kv.Value.AsInt64() != 42 {
+		t.Fatalf("unexpected: %+v", kv)
+	}
+}
+
+func TestSpanKind(t *testing.T) {
+	kv := SpanKind(SpanKindTask)
+	if kv.Key != TraceloopSpanKindKey || kv.Value.AsString() != "task" {
+		t.Fatalf("unexpected: %+v", kv)
+	}
+}
+
+func TestMessagesJSON(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi"},
+	}
+	kv := MessagesJSON(msgs)
+	if kv.Key != InputMessagesKey {
+		t.Fatalf("expected key %s, got %s", InputMessagesKey, kv.Key)
+	}
+	want := `[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"}]`
+	if kv.Value.AsString() != want {
+		t.Fatalf("expected %q, got %q", want, kv.Value.AsString())
+	}
+}
+
+func TestMessagesJSONEmpty(t *testing.T) {
+	kv := MessagesJSON(nil)
+	if kv.Value.AsString() != "[]" {
+		t.Fatalf("expected [], got %q", kv.Value.AsString())
+	}
+}


### PR DESCRIPTION
Emits OpenTelemetry [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
on agent-runner and channel-router spans, so vendors' AI-observability
tooling recognizes Sympozium agent runs as LLM interactions. Legacy
`sympozium.*` attributes are kept for one release cycle for back-compat.

### Attributes emitted
- `gen_ai.provider.name` (+ deprecated `gen_ai.system`, back-compat) on `gen_ai.chat`
- `gen_ai.request.model`, `gen_ai.response.model` (backend-reported, falls back to requested)
- `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`
- `gen_ai.agent.name`, `traceloop.span.kind` (`task` on the run span, `tool` on tool spans)
- `gen_ai.system_instructions` on the run span — set once per run, not per chat round
- A shared `pkg/genaiattrs` package with the convention keys/helpers

### Live validation (Dynatrace, provider = ollama / qwen3.6)
Deployed exactly this tip to a live cluster and drove a real agent run
 All conventions verified on-span; `gen_ai.chat`
classified under the agent-runner service so Dynatrace AI Observability
recognizes it.

| Convention | Value |
|---|---|
| gen_ai.provider.name / gen_ai.system | `ollama` / `ollama` |
| gen_ai.request.model / gen_ai.response.model | `qwen3.6:latest` / `qwen3.6:latest` |
| gen_ai.usage.input_tokens / output_tokens | `2531` / `148` |
| gen_ai.agent.name | `bmad-ensemble-cto` |
| traceloop.span.kind (run span) | `task` |

### Tests
`go test -race ./cmd/agent-runner/... ./pkg/genaiattrs/... ./internal/controller/...`
green; `gofmt`/`go vet` clean.
<img width="2023" height="1056" alt="image" src="https://github.com/user-attachments/assets/24a0528b-f2a0-49c6-94ad-f4dbe8d62793" />
