### PR TITLE
fix(agent-runner): gate delegate_to_persona on delegation edges (Fix A, #288)

### DIFF
--- a/cmd/agent-runner/main_test.go
+++ b/cmd/agent-runner/main_test.go
@@ -1142,20 +1142,91 @@ func TestDefaultTools_SubagentsEnabledWhenSet(t *testing.T) {
 
 func TestDefaultTools_AlwaysIncludesCoreTool(t *testing.T) {
 	tools := defaultTools()
-	var hasExec, hasDelegate bool
+	var hasExec bool
 	for _, tool := range tools {
 		if tool.Name == ToolExecuteCommand {
 			hasExec = true
-		}
-		if tool.Name == ToolDelegateToPersona {
-			hasDelegate = true
 		}
 	}
 	if !hasExec {
 		t.Error("execute_command tool should always be registered")
 	}
-	if !hasDelegate {
-		t.Error("delegate_to_persona tool should always be registered")
+}
+
+func TestDefaultTools_DelegateAbsentWithoutEdges(t *testing.T) {
+	t.Setenv("ENSEMBLE_RELATIONSHIPS", "")
+	tools := defaultTools()
+	for _, tool := range tools {
+		if tool.Name == ToolDelegateToPersona {
+			t.Error("delegate_to_persona tool should not be registered when ENSEMBLE_RELATIONSHIPS is not set")
+		}
+	}
+}
+
+func TestDefaultTools_DelegateAbsentWithSupervisionEdgeOnly(t *testing.T) {
+	t.Setenv("ENSEMBLE_RELATIONSHIPS", `[{"target":"supervisor","type":"supervision"}]`)
+	tools := defaultTools()
+	for _, tool := range tools {
+		if tool.Name == ToolDelegateToPersona {
+			t.Error("delegate_to_persona tool should not be registered for supervision-only edges")
+		}
+	}
+}
+
+func TestDefaultTools_DelegateRegisteredWithDelegationEdge(t *testing.T) {
+	t.Setenv("ENSEMBLE_RELATIONSHIPS", `[{"target":"writer","type":"delegation"}]`)
+	tools := defaultTools()
+	var found bool
+	for _, tool := range tools {
+		if tool.Name == ToolDelegateToPersona {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("delegate_to_persona tool should be registered when a delegation edge is present")
+	}
+}
+
+func TestDefaultTools_DelegateRegisteredWithSequentialEdge(t *testing.T) {
+	t.Setenv("ENSEMBLE_RELATIONSHIPS", `[{"target":"reviewer","type":"sequential"}]`)
+	tools := defaultTools()
+	var found bool
+	for _, tool := range tools {
+		if tool.Name == ToolDelegateToPersona {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("delegate_to_persona tool should be registered when a sequential edge is present")
+	}
+}
+
+func TestDefaultTools_DelegateEnumeratesValidTargets(t *testing.T) {
+	t.Setenv("ENSEMBLE_RELATIONSHIPS", `[{"target":"writer","type":"delegation"},{"target":"reviewer","type":"sequential"}]`)
+	tools := defaultTools()
+	var delegateTool *ToolDef
+	for i := range tools {
+		if tools[i].Name == ToolDelegateToPersona {
+			delegateTool = &tools[i]
+			break
+		}
+	}
+	if delegateTool == nil {
+		t.Fatal("delegate_to_persona tool not registered")
+	}
+	props, _ := delegateTool.Parameters["properties"].(map[string]any)
+	targetParam, _ := props["targetPersona"].(map[string]any)
+	enum, _ := targetParam["enum"].([]string)
+	if len(enum) != 2 {
+		t.Fatalf("expected 2 enum values, got %d: %v", len(enum), enum)
+	}
+	wantTargets := map[string]bool{"writer": true, "reviewer": true}
+	for _, v := range enum {
+		if !wantTargets[v] {
+			t.Errorf("unexpected enum value %q", v)
+		}
 	}
 }
 

--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -244,19 +244,24 @@ func defaultTools() []ToolDef {
 				"required": []string{"name", "action"},
 			},
 		},
-		{
+	}
+
+	// Conditionally add delegate_to_persona tool when outgoing delegation/sequential edges exist.
+	if targets := delegationTargets(); len(targets) > 0 {
+		targetList := strings.Join(targets, ", ")
+		tools = append(tools, ToolDef{
 			Name: ToolDelegateToPersona,
 			Description: "Delegate a task to another persona in your team (Ensemble). " +
 				"Use this when your task requires expertise from another team member. " +
 				"The target persona will receive the task, execute it, and the result will be " +
-				"delivered back to you. Only personas defined in the same Ensemble with a " +
-				"delegation or sequential relationship can be targeted.",
+				"delivered back to you. Valid targets for this Ensemble: " + targetList + ".",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"targetPersona": map[string]any{
 						"type":        "string",
-						"description": "The name of the persona to delegate to (e.g. 'writer', 'reviewer'). Must be a persona in the same Ensemble.",
+						"description": "The name of the persona to delegate to. Must be one of: " + targetList + ".",
+						"enum":        targets,
 					},
 					"task": map[string]any{
 						"type":        "string",
@@ -265,7 +270,7 @@ func defaultTools() []ToolDef {
 				},
 				"required": []string{"targetPersona", "task"},
 			},
-		},
+		})
 	}
 
 	// Conditionally add spawn_subagents tool when subagents are enabled.
@@ -329,6 +334,31 @@ func defaultTools() []ToolDef {
 	}
 
 	return tools
+}
+
+
+// delegationTargets parses ENSEMBLE_RELATIONSHIPS and returns the persona names
+// reachable via delegation or sequential edges. Returns nil when no outgoing
+// delegation edges are defined — callers use len(targets) > 0 to gate registration.
+func delegationTargets() []string {
+	relJSON := os.Getenv("ENSEMBLE_RELATIONSHIPS")
+	if relJSON == "" {
+		return nil
+	}
+	var rels []struct {
+		Target string `json:"target"`
+		Type   string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(relJSON), &rels); err != nil {
+		return nil
+	}
+	var targets []string
+	for _, r := range rels {
+		if r.Type == "delegation" || r.Type == "sequential" {
+			targets = append(targets, r.Target)
+		}
+	}
+	return targets
 }
 
 // executeToolCall dispatches a tool call and returns the result string.


### PR DESCRIPTION
## Summary

Fixes #288 (Fix A): `delegate_to_persona` was unconditionally advertised to every agent persona even when no delegation edges existed in the Ensemble. This PR gates its registration on `ENSEMBLE_RELATIONSHIPS` containing at least one `delegation` or `sequential` edge — mirroring the existing `SUBAGENTS_ENABLED` pattern used for `spawn_subagents`.

**Bonus**: the tool schema's `targetPersona` field now includes an `"enum"` of valid targets, so the LLM sees exactly who it can delegate to rather than an open-ended string.

## Changes

**`cmd/agent-runner/tools.go`**
- Remove `ToolDelegateToPersona` from the unconditional base tool slice
- Add conditional registration block gated on `delegationTargets()` returning at least one target
- Add `delegationTargets()` helper: parses `ENSEMBLE_RELATIONSHIPS`, returns `[]string` of persona names reachable via `delegation` or `sequential` edges; returns `nil` (not registered) when the env var is unset, empty, or contains only `supervision` edges

**`cmd/agent-runner/main_test.go`**
- Update `TestDefaultTools_AlwaysIncludesCoreTool` — remove the assertion that `delegate_to_persona` is always present (it no longer is)
- Add 5 new tests:
  - `TestDefaultTools_DelegateAbsentWithoutEdges` — not registered when `ENSEMBLE_RELATIONSHIPS` is unset
  - `TestDefaultTools_DelegateAbsentWithSupervisionEdgeOnly` — not registered for supervision-only edges
  - `TestDefaultTools_DelegateRegisteredWithDelegationEdge` — registered when a delegation edge is present
  - `TestDefaultTools_DelegateRegisteredWithSequentialEdge` — registered when a sequential edge is present
  - `TestDefaultTools_DelegateEnumeratesValidTargets` — `"enum"` field contains exactly the reachable persona names

## Test plan

- [ ] `go test -race ./cmd/agent-runner/...` passes (all 5 new tests + updated existing test)
- [ ] `go vet ./...` clean
- [ ] `gofmt` produces no diff
- [ ] Manually verify: an agent with no outgoing edges does not see `delegate_to_persona` in its tool list
- [ ] Manually verify: an agent with a `delegation` edge sees `delegate_to_persona` with correct `enum` targets