### PR TITLE
Make elided output directly recoverable via read_file

### DIFF
--- a/cmd/agent-runner/context_policy.go
+++ b/cmd/agent-runner/context_policy.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -17,6 +19,12 @@ const (
 	// as it did before unless one of the CONTEXT_* vars is set.
 	defaultToolResultMaxBytes = 0
 	defaultKeepRecentResults  = 3
+
+	// defaultElisionSpillDir is where elided tool output is parked so the model
+	// can read it back. It sits under the same /workspace/.sympozium prefix the
+	// runner already uses for trace-context.json, and is only ever created when
+	// elision actually fires.
+	defaultElisionSpillDir = "/workspace/.sympozium/elided"
 )
 
 // contextPolicy bounds how much tool-result content accumulates in the
@@ -39,6 +47,11 @@ const (
 //     batched: we elide all the way down to HistoryLowBytes in one pass rather
 //     than trimming a little each round. That pays one cache write and then
 //     runs every remaining round against a much smaller prefix.
+//
+// Elision moves output out of the conversation; it does not destroy it. The
+// full result is written to SpillDir first and the placeholder names that path,
+// so the model recovers detail with read_file (which paginates) instead of
+// re-running a tool whose side effects may not be repeatable.
 type contextPolicy struct {
 	// ToolResultMaxBytes clamps a single tool result at insertion. 0 disables.
 	ToolResultMaxBytes int
@@ -51,6 +64,10 @@ type contextPolicy struct {
 	// those are what the model is actively reasoning over. The current round's
 	// results are protected regardless of this value; see protectedCutoff.
 	KeepRecent int
+	// SpillDir is where an elided result's full output is written so the model
+	// can recover it with read_file instead of re-running the tool. Empty
+	// disables spilling, and elision falls back to a bare placeholder.
+	SpillDir string
 }
 
 // elisionEnabled reports whether retroactive elision is configured.
@@ -66,6 +83,12 @@ func loadContextPolicy() contextPolicy {
 		HistoryBudgetBytes: envInt("CONTEXT_HISTORY_BUDGET_BYTES", 0),
 		HistoryLowBytes:    envInt("CONTEXT_HISTORY_BUDGET_LOW_BYTES", 0),
 		KeepRecent:         envInt("CONTEXT_KEEP_RECENT_RESULTS", defaultKeepRecentResults),
+		SpillDir:           getEnv("CONTEXT_ELISION_SPILL_DIR", defaultElisionSpillDir),
+	}
+	// "off" is the explicit opt-out: an empty env var is indistinguishable from
+	// an unset one, so it cannot carry that meaning.
+	if cp.SpillDir == "off" {
+		cp.SpillDir = ""
 	}
 	if cp.ToolResultMaxBytes < 0 {
 		cp.ToolResultMaxBytes = 0
@@ -144,13 +167,85 @@ func (cp contextPolicy) clampToolResult(tool, content string) (string, int) {
 		dropped, len(content), tool), dropped
 }
 
-// elisionStub is the placeholder left in history in place of an elided result.
-// It names the tool and the reclaimed size so the model can decide whether to
-// re-run rather than assuming the tool returned nothing.
+// elisionStub is the placeholder left in history in place of an elided result
+// whose output could not be spilled to disk. It names the tool and the
+// reclaimed size so the model can decide whether to re-run rather than assuming
+// the tool returned nothing.
 func elisionStub(tool string, size int) string {
 	return fmt.Sprintf(
 		"[earlier %s result elided to reclaim context — %d bytes. Re-run the tool if you still need this output.]",
 		tool, size)
+}
+
+// elisionStubSpilled is the placeholder for a result whose full output was
+// written to path. Every elided entry carries one of these for the rest of the
+// run, so it stays terse: read_file's own description covers pagination, and
+// re-running the tool is not worth suggesting once the output is on disk.
+func elisionStubSpilled(tool string, size int, path string) string {
+	return fmt.Sprintf("[earlier %s result elided — %d bytes saved to %s; read_file to recover.]",
+		tool, size, path)
+}
+
+// resultSpiller persists elided tool output. Path is separate from Write so
+// selectForElision can size a stub against the path it would use before
+// committing to the write, and skip entries too small to be worth eliding
+// without leaving an orphan file behind.
+type resultSpiller interface {
+	// Path is pure and deterministic: the same seq always maps to the same
+	// location.
+	Path(seq int) string
+	// Write persists content at a path previously returned by Path, creating
+	// parent directories as needed.
+	Write(path, content string) error
+}
+
+// spillUnavailable reports why an elided result could not be read back again,
+// or "" when it can. Spilling is only worth doing if the stub's instruction is
+// actionable: read_file has to survive this run's tool policy, and the spill
+// directory has to sit under a root read_file will open. When it isn't, the
+// caller keeps the destructive placeholder rather than pointing the model at a
+// file it cannot reach.
+func spillUnavailable(dir string, tools []ToolDef) string {
+	found := false
+	for _, t := range tools {
+		if t.Name == ToolReadFile {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ToolReadFile + " is not available to this run"
+	}
+	if !underAnyPrefix(filepath.Clean(dir), readableRoots) {
+		return fmt.Sprintf("%s is outside the roots %s can read (%s)",
+			dir, ToolReadFile, strings.Join(readableRoots, ", "))
+	}
+	return ""
+}
+
+// dirSpiller writes each elided result to its own file under Dir.
+type dirSpiller struct {
+	Dir string
+}
+
+// Path names the file for the seq-th ledger entry. The filename is built
+// entirely from the ledger index — no tool name, no call ID, nothing the model
+// or an MCP server can influence — so it cannot traverse out of Dir by
+// construction rather than by sanitizing. The tool a file came from is recorded
+// where it is actually read: the stub that replaces the result, and the elision
+// log event.
+func (s dirSpiller) Path(seq int) string {
+	return filepath.Join(s.Dir, fmt.Sprintf("%04d.txt", seq))
+}
+
+// Write persists content. Permissions match the detailed logger's (0o700/0o600):
+// tool output can carry whatever a command echoed, so it stays readable only by
+// the agent container's own user.
+func (s dirSpiller) Write(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o600)
 }
 
 // ledgerEntry records one tool result that was handed to the provider.
@@ -160,6 +255,10 @@ type ledgerEntry struct {
 	bytes  int
 	round  int
 	elided bool
+	// content is the result as inserted. Held so elision can spill it; it is
+	// the same string the provider already retains, so this costs a reference
+	// rather than a copy, and is released once the entry is elided.
+	content string
 }
 
 // toolResultLedger tracks the live byte cost of every tool result inserted into
@@ -169,15 +268,26 @@ type ledgerEntry struct {
 type toolResultLedger struct {
 	entries []ledgerEntry
 	live    int
+	// spill persists elided output. Nil leaves elision destructive, which is
+	// the behaviour when no spill directory is configured.
+	spill resultSpiller
+	// spillFailed suppresses repeat logging once a write has failed — a
+	// read-only or absent /workspace fails identically for every entry.
+	spillFailed bool
 }
 
-// add records a tool result of n bytes inserted at the given round. round is
-// load-bearing, not just diagnostic: protectedCutoff uses it to keep the
-// current round's results out of the elision window. Callers must pass a
-// non-decreasing round.
-func (l *toolResultLedger) add(callID, tool string, n, round int) {
-	l.entries = append(l.entries, ledgerEntry{callID: callID, tool: tool, bytes: n, round: round})
-	l.live += n
+// add records a tool result inserted at the given round. round is load-bearing,
+// not just diagnostic: protectedCutoff uses it to keep the current round's
+// results out of the elision window. Callers must pass a non-decreasing round.
+func (l *toolResultLedger) add(callID, tool, content string, round int) {
+	l.entries = append(l.entries, ledgerEntry{
+		callID:  callID,
+		tool:    tool,
+		bytes:   len(content),
+		round:   round,
+		content: content,
+	})
+	l.live += len(content)
 }
 
 // liveBytes is the current tool-result contribution to every outgoing request.
@@ -245,17 +355,45 @@ func (l *toolResultLedger) selectForElision(cp contextPolicy) (map[string]string
 		if e.elided {
 			continue
 		}
+
+		var path string
 		stub := elisionStub(e.tool, e.bytes)
+		if l.spill != nil {
+			path = l.spill.Path(i)
+			stub = elisionStubSpilled(e.tool, e.bytes, path)
+		}
 		// Eliding a result that is already smaller than its own stub would
-		// grow the request rather than shrink it.
+		// grow the request rather than shrink it. Checked before the write so
+		// a skipped entry leaves no orphan file.
 		if len(stub) >= e.bytes {
 			continue
 		}
+
+		if l.spill != nil {
+			if err := l.spill.Write(path, e.content); err != nil {
+				if !l.spillFailed {
+					l.spillFailed = true
+					log.Printf("WARNING: cannot spill elided tool output to %s: %v — "+
+						"elision continues without it and elided results are unrecoverable", path, err)
+				}
+				// Fall back to the bare stub. It is not necessarily shorter
+				// than the spilled one (a short spill dir makes it longer), so
+				// the size guard has to be re-applied.
+				stub = elisionStub(e.tool, e.bytes)
+				if len(stub) >= e.bytes {
+					continue
+				}
+			}
+		}
+
 		replacements[e.callID] = stub
 		reclaimed += e.bytes - len(stub)
 		l.live -= e.bytes - len(stub)
 		e.elided = true
 		e.bytes = len(stub)
+		// The provider is about to drop its reference to the original; release
+		// ours so a long run does not retain every elided result.
+		e.content = ""
 	}
 
 	if len(replacements) == 0 {

--- a/cmd/agent-runner/context_policy_test.go
+++ b/cmd/agent-runner/context_policy_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -139,10 +142,13 @@ func TestClampToolResult_Disabled(t *testing.T) {
 	}
 }
 
+// body returns n bytes of filler so ledger tests can keep expressing sizes.
+func body(n int) string { return strings.Repeat("x", n) }
+
 func TestLedger_TracksLiveBytes(t *testing.T) {
 	l := &toolResultLedger{}
-	l.add("a", "execute_command", 100, 1)
-	l.add("b", "fetch_url", 250, 2)
+	l.add("a", "execute_command", body(100), 1)
+	l.add("b", "fetch_url", body(250), 2)
 	if l.liveBytes() != 350 {
 		t.Errorf("liveBytes = %d, want 350", l.liveBytes())
 	}
@@ -151,7 +157,7 @@ func TestLedger_TracksLiveBytes(t *testing.T) {
 func TestLedger_NoElisionBelowBudget(t *testing.T) {
 	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 1}
 	l := &toolResultLedger{}
-	l.add("a", "fetch_url", 300, 1)
+	l.add("a", "fetch_url", body(300), 1)
 
 	replacements, reclaimed := l.selectForElision(cp)
 	if replacements != nil || reclaimed != 0 {
@@ -162,9 +168,9 @@ func TestLedger_NoElisionBelowBudget(t *testing.T) {
 func TestLedger_ElidesOldestDownToLowWaterMark(t *testing.T) {
 	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 1}
 	l := &toolResultLedger{}
-	l.add("a", "fetch_url", 600, 1)
-	l.add("b", "fetch_url", 600, 2)
-	l.add("c", "execute_command", 400, 3) // newest — protected by KeepRecent
+	l.add("a", "fetch_url", body(600), 1)
+	l.add("b", "fetch_url", body(600), 2)
+	l.add("c", "execute_command", body(400), 3) // newest — protected by KeepRecent
 
 	replacements, reclaimed := l.selectForElision(cp)
 	if len(replacements) == 0 {
@@ -194,7 +200,7 @@ func TestLedger_ReachesLowWaterMarkWhenUnobstructed(t *testing.T) {
 	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 0}
 	l := &toolResultLedger{}
 	for i, id := range []string{"a", "b", "c", "d"} {
-		l.add(id, "fetch_url", 400, i+1)
+		l.add(id, "fetch_url", body(400), i+1)
 	}
 
 	if _, reclaimed := l.selectForElision(cp); reclaimed == 0 {
@@ -217,7 +223,7 @@ func TestLedger_CurrentRoundIsNeverElided(t *testing.T) {
 	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 3}
 	l := &toolResultLedger{}
 	for _, id := range []string{"r1-a", "r1-b", "r1-c", "r1-d", "r1-e"} {
-		l.add(id, "read_file", 400, 1)
+		l.add(id, "read_file", body(400), 1)
 	}
 
 	if replacements, reclaimed := l.selectForElision(cp); replacements != nil || reclaimed != 0 {
@@ -226,7 +232,7 @@ func TestLedger_CurrentRoundIsNeverElided(t *testing.T) {
 
 	// Once a later round arrives, round 1 becomes fair game — but only the
 	// entries outside the KeepRecent window.
-	l.add("r2-a", "read_file", 400, 2)
+	l.add("r2-a", "read_file", body(400), 2)
 	replacements, _ := l.selectForElision(cp)
 	if len(replacements) == 0 {
 		t.Fatal("expected elision once the model had a turn to read round 1")
@@ -249,9 +255,9 @@ func TestLedger_CurrentRoundIsNeverElided(t *testing.T) {
 func TestLedger_SecondPassIsNoOp(t *testing.T) {
 	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 1}
 	l := &toolResultLedger{}
-	l.add("a", "fetch_url", 600, 1)
-	l.add("b", "fetch_url", 600, 2)
-	l.add("c", "execute_command", 100, 3)
+	l.add("a", "fetch_url", body(600), 1)
+	l.add("b", "fetch_url", body(600), 2)
+	l.add("c", "execute_command", body(100), 3)
 
 	if replacements, _ := l.selectForElision(cp); len(replacements) == 0 {
 		t.Fatal("first pass should elide")
@@ -266,10 +272,10 @@ func TestLedger_SecondPassIsNoOp(t *testing.T) {
 func TestLedger_SkipsResultsSmallerThanTheirStub(t *testing.T) {
 	cp := contextPolicy{HistoryBudgetBytes: 10, HistoryLowBytes: 5, KeepRecent: 0}
 	l := &toolResultLedger{}
-	l.add("a", "execute_command", 12, 1)
+	l.add("a", "execute_command", body(12), 1)
 	// A second round so "a" is genuinely eligible and the stub-size guard is
 	// what rejects it, rather than the in-flight-round protection.
-	l.add("b", "execute_command", 12, 2)
+	l.add("b", "execute_command", body(12), 2)
 
 	replacements, _ := l.selectForElision(cp)
 	if len(replacements) != 0 {
@@ -280,7 +286,7 @@ func TestLedger_SkipsResultsSmallerThanTheirStub(t *testing.T) {
 func TestLedger_KeepRecentLargerThanHistory(t *testing.T) {
 	cp := contextPolicy{HistoryBudgetBytes: 100, HistoryLowBytes: 50, KeepRecent: 5}
 	l := &toolResultLedger{}
-	l.add("a", "fetch_url", 500, 1)
+	l.add("a", "fetch_url", body(500), 1)
 
 	if replacements, _ := l.selectForElision(cp); replacements != nil {
 		t.Error("nothing is eligible when KeepRecent covers the whole history")
@@ -293,6 +299,202 @@ func TestElisionStub_NamesToolAndSize(t *testing.T) {
 		t.Errorf("stub should name the tool and reclaimed size, got %q", stub)
 	}
 }
+
+func TestLoadContextPolicy_SpillDirDefaultsAndOptOut(t *testing.T) {
+	t.Setenv("CONTEXT_ELISION_SPILL_DIR", "")
+	if got := loadContextPolicy().SpillDir; got != defaultElisionSpillDir {
+		t.Errorf("SpillDir = %q, want default %q", got, defaultElisionSpillDir)
+	}
+
+	t.Setenv("CONTEXT_ELISION_SPILL_DIR", "off")
+	if got := loadContextPolicy().SpillDir; got != "" {
+		t.Errorf(`SpillDir = %q, want "" — "off" is the explicit opt-out`, got)
+	}
+
+	t.Setenv("CONTEXT_ELISION_SPILL_DIR", "/tmp/custom")
+	if got := loadContextPolicy().SpillDir; got != "/tmp/custom" {
+		t.Errorf("SpillDir = %q, want /tmp/custom", got)
+	}
+}
+
+// Spilling is only useful if the stub's instruction can actually be followed.
+func TestSpillUnavailable(t *testing.T) {
+	withRead := []ToolDef{{Name: ToolExecuteCommand}, {Name: ToolReadFile}}
+
+	if reason := spillUnavailable(defaultElisionSpillDir, withRead); reason != "" {
+		t.Errorf("default config should be spillable, got %q", reason)
+	}
+
+	// A tool policy that denies read_file leaves the model no way back to the file.
+	noRead := []ToolDef{{Name: ToolExecuteCommand}}
+	if reason := spillUnavailable(defaultElisionSpillDir, noRead); reason == "" {
+		t.Error("expected a reason when read_file is filtered out by tool policy")
+	} else if !strings.Contains(reason, ToolReadFile) {
+		t.Errorf("reason %q should name the missing tool", reason)
+	}
+
+	// read_file refuses paths outside its readable roots, so a spill directory
+	// there produces files the agent cannot open.
+	if reason := spillUnavailable("/var/log/agent", withRead); reason == "" {
+		t.Error("expected a reason for a spill dir outside read_file's roots")
+	}
+
+	// Every readable root is a legitimate destination.
+	for _, root := range readableRoots {
+		if reason := spillUnavailable(root+"/elided", withRead); reason != "" {
+			t.Errorf("%s should be spillable, got %q", root, reason)
+		}
+	}
+}
+
+// When the promise cannot be kept, elision must still happen — the context
+// pressure is real either way — but without pointing at an unreachable file.
+func TestRunAgentLoop_NoSpillWhenReadFileUnavailable(t *testing.T) {
+	spillDir, err := os.MkdirTemp("/tmp", "spill")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(spillDir) })
+
+	t.Setenv("CONTEXT_HISTORY_BUDGET_BYTES", "10000")
+	t.Setenv("CONTEXT_HISTORY_BUDGET_LOW_BYTES", "4000")
+	t.Setenv("CONTEXT_KEEP_RECENT_RESULTS", "1")
+	t.Setenv("CONTEXT_ELISION_SPILL_DIR", spillDir)
+
+	path := writeReadFileFixture(t, strings.Repeat("abcdefghij", 600))
+	args := `{"path":"` + path + `"}`
+	var turns []ChatResult
+	for _, id := range []string{"c1", "c2", "c3", "c4"} {
+		turns = append(turns, ChatResult{
+			ToolCalls:    []ToolCall{{ID: id, Name: "read_file", Input: args}},
+			FinishReason: "tool_calls",
+		})
+	}
+	turns = append(turns, ChatResult{Text: "done", FinishReason: "stop"})
+
+	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
+	// Tool policy stripped read_file from this run.
+	onlyExec := []ToolDef{{Name: ToolExecuteCommand}}
+	if _, _, _, _, err := runAgentLoop(context.Background(), p, onlyExec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(p.replaceLog) == 0 {
+		t.Fatal("elision must still fire when spilling is unavailable")
+	}
+	if stub := p.replaceLog[0]["c1"]; strings.Contains(stub, spillDir) {
+		t.Errorf("stub %q points at a file the run cannot read", stub)
+	}
+	if entries, err := os.ReadDir(spillDir); err == nil && len(entries) != 0 {
+		t.Errorf("wrote %d spill file(s) the run cannot read back", len(entries))
+	}
+}
+
+// The spill filename is built from the ledger index alone. Nothing the model or
+// an MCP server chooses — tool name, call ID — may reach it, so there is no
+// input to traverse with. Reintroducing such a component would break this.
+func TestDirSpiller_PathIsDerivedOnlyFromIndex(t *testing.T) {
+	const dir = "/workspace/.sympozium/elided"
+	s := dirSpiller{Dir: dir}
+
+	got := s.Path(3)
+	if want := filepath.Join(dir, "0003.txt"); got != want {
+		t.Errorf("Path(3) = %q, want %q", got, want)
+	}
+	// One path element under Dir, so filepath.Join has nothing to resolve away.
+	if filepath.Dir(got) != dir {
+		t.Errorf("Path(3) = %q, escaped the spill directory", got)
+	}
+	// Zero-padding keeps directory listings in ledger order past entry 10.
+	if base := filepath.Base(s.Path(12)); base != "0012.txt" {
+		t.Errorf("Path(12) base = %q, want 0012.txt", base)
+	}
+	if s.Path(3) == s.Path(4) {
+		t.Error("distinct ledger entries must not share a file")
+	}
+}
+
+// The whole point of the feature: an elided result is moved to disk intact,
+// and the stub tells the model where to find it.
+func TestLedger_ElisionSpillsFullOutput(t *testing.T) {
+	dir := t.TempDir()
+	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 0}
+	l := &toolResultLedger{spill: dirSpiller{Dir: dir}}
+
+	original := strings.Repeat("finding-", 100) // 800 bytes
+	l.add("a", "execute_command", original, 1)
+	l.add("b", "fetch_url", body(800), 2)
+
+	replacements, reclaimed := l.selectForElision(cp)
+	if len(replacements) == 0 {
+		t.Fatal("expected elision above budget")
+	}
+	if reclaimed <= 0 {
+		t.Fatalf("reclaimed = %d, want > 0", reclaimed)
+	}
+
+	want := dirSpiller{Dir: dir}.Path(0)
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("elided output was not spilled: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("spilled content does not match the original result (%d vs %d bytes)", len(got), len(original))
+	}
+	if !strings.Contains(replacements["a"], want) {
+		t.Errorf("stub %q should name the spill path %q", replacements["a"], want)
+	}
+
+	// The ledger must not keep holding output it has already written out.
+	if l.entries[0].content != "" {
+		t.Error("elided entry still retains its content")
+	}
+}
+
+// A read-only or absent /workspace must degrade to the old behaviour rather
+// than abandoning elision — the context pressure is real either way.
+func TestLedger_SpillFailureFallsBackToBareStub(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 0}
+	l := &toolResultLedger{spill: failingSpiller{}}
+	l.add("a", "execute_command", body(800), 1)
+	l.add("b", "fetch_url", body(800), 2)
+
+	replacements, reclaimed := l.selectForElision(cp)
+	if len(replacements) == 0 {
+		t.Fatal("elision must still happen when spilling fails")
+	}
+	if reclaimed <= 0 {
+		t.Errorf("reclaimed = %d, want > 0", reclaimed)
+	}
+	if strings.Contains(replacements["a"], "saved to") {
+		t.Errorf("stub %q promises a spill file that was never written", replacements["a"])
+	}
+	if !strings.Contains(replacements["a"], "Re-run the tool") {
+		t.Errorf("stub %q should fall back to the re-run hint", replacements["a"])
+	}
+}
+
+// An entry too small to be worth eliding must not leave a file behind.
+func TestLedger_SkippedEntryLeavesNoSpillFile(t *testing.T) {
+	dir := t.TempDir()
+	cp := contextPolicy{HistoryBudgetBytes: 10, HistoryLowBytes: 5, KeepRecent: 0}
+	l := &toolResultLedger{spill: dirSpiller{Dir: dir}}
+	l.add("a", "execute_command", body(12), 1)
+	l.add("b", "execute_command", body(12), 2)
+
+	if replacements, _ := l.selectForElision(cp); len(replacements) != 0 {
+		t.Fatalf("should skip results smaller than their stub, got %v", replacements)
+	}
+	if entries, err := os.ReadDir(dir); err == nil && len(entries) != 0 {
+		t.Errorf("skipped entry left %d orphan file(s) behind", len(entries))
+	}
+}
+
+// failingSpiller stands in for an unwritable spill directory.
+type failingSpiller struct{}
+
+func (failingSpiller) Path(seq int) string              { return "/nope/x.txt" }
+func (failingSpiller) Write(path, content string) error { return errors.New("read-only file system") }
 
 // TestRunAgentLoop_ElidesAtHighWaterMark exercises the full wiring: real tool
 // execution produces oversized results, the ledger crosses the budget, and the
@@ -315,7 +517,7 @@ func TestRunAgentLoop_ElidesAtHighWaterMark(t *testing.T) {
 	turns = append(turns, ChatResult{Text: "done", FinishReason: "stop"})
 
 	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
-	if _, _, _, _, err := runAgentLoop(context.Background(), p); err != nil {
+	if _, _, _, _, err := runAgentLoop(context.Background(), p, mockTools); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -329,6 +531,57 @@ func TestRunAgentLoop_ElidesAtHighWaterMark(t *testing.T) {
 	}
 }
 
+// End-to-end proof that elision is no longer lossy: run the loop until the
+// budget forces a rewrite, then recover the elided output through the same
+// read_file tool the stub points the model at.
+func TestRunAgentLoop_ElidedOutputRecoverableViaReadFile(t *testing.T) {
+	fixture := strings.Repeat("abcdefghij", 600) // 6000 bytes, under read_file's cap
+	path := writeReadFileFixture(t, fixture)
+
+	// The spill dir has to sit under a readable root or read_file will refuse
+	// to open it — which is exactly the constraint production runs are under.
+	spillDir, err := os.MkdirTemp("/tmp", "spill")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(spillDir) })
+
+	t.Setenv("CONTEXT_HISTORY_BUDGET_BYTES", "10000")
+	t.Setenv("CONTEXT_HISTORY_BUDGET_LOW_BYTES", "4000")
+	t.Setenv("CONTEXT_KEEP_RECENT_RESULTS", "1")
+	t.Setenv("CONTEXT_ELISION_SPILL_DIR", spillDir)
+
+	args := `{"path":"` + path + `"}`
+	var turns []ChatResult
+	for _, id := range []string{"c1", "c2", "c3", "c4"} {
+		turns = append(turns, ChatResult{
+			ToolCalls:    []ToolCall{{ID: id, Name: "read_file", Input: args}},
+			FinishReason: "tool_calls",
+		})
+	}
+	turns = append(turns, ChatResult{Text: "done", FinishReason: "stop"})
+
+	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
+	if _, _, _, _, err := runAgentLoop(context.Background(), p, mockTools); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(p.replaceLog) == 0 {
+		t.Fatal("expected elision once the budget was crossed")
+	}
+
+	// c1 is the oldest result and the first elided, so it is ledger entry 0.
+	spilled := dirSpiller{Dir: spillDir}.Path(0)
+	stub := p.replaceLog[0]["c1"]
+	if !strings.Contains(stub, spilled) {
+		t.Fatalf("stub %q should point at %q", stub, spilled)
+	}
+
+	recovered := readFileTool(map[string]any{"path": spilled})
+	if recovered != fixture {
+		t.Errorf("read_file recovered %d bytes, want the original %d", len(recovered), len(fixture))
+	}
+}
+
 // With no budget configured the loop must never rewrite history.
 func TestRunAgentLoop_NoElisionWhenBudgetUnset(t *testing.T) {
 	p := &mockProvider{
@@ -338,7 +591,7 @@ func TestRunAgentLoop_NoElisionWhenBudgetUnset(t *testing.T) {
 			{Text: "done", FinishReason: "stop"},
 		},
 	}
-	if _, _, _, _, err := runAgentLoop(context.Background(), p); err != nil {
+	if _, _, _, _, err := runAgentLoop(context.Background(), p, mockTools); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(p.replaceLog) != 0 {

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -750,7 +750,7 @@ func main() {
 // backward-compatible test coverage.
 func callAnthropic(ctx context.Context, apiKey, baseURL, model, systemPrompt, task string, tools []ToolDef, headers map[string]string) (string, int, int, int, error) {
 	p := newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task, tools, headers)
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, tools)
 }
 
 // callOpenAI dispatches an agent run to the OpenAI-compatible provider path
@@ -760,7 +760,7 @@ func callOpenAI(ctx context.Context, provider, apiKey, baseURL, model, systemPro
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, tools)
 }
 
 // callBedrock dispatches an agent run to the AWS Bedrock provider.
@@ -769,7 +769,7 @@ func callBedrock(ctx context.Context, model, systemPrompt, task string, tools []
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, tools)
 }
 
 // callBedrockWithClient accepts a pre-built client; used by tests to inject
@@ -779,7 +779,7 @@ func callBedrockWithClient(ctx context.Context, client bedrockClientAPI, model, 
 	if err != nil {
 		return "", 0, 0, 0, err
 	}
-	return runAgentLoop(ctx, p)
+	return runAgentLoop(ctx, p, tools)
 }
 
 func writeJSON(path string, v any) {

--- a/cmd/agent-runner/provider.go
+++ b/cmd/agent-runner/provider.go
@@ -120,8 +120,12 @@ type LLMProvider interface {
 // their output budget on tool-call preamble), the user still sees the
 // intermediate reasoning in the UX instead of a blank response.
 //
+// tools is the run's effective tool set, already filtered by tool policy. It is
+// consulted only to decide whether elided output can be spilled somewhere the
+// model can actually read it back from.
+//
 // Returns (responseText, inputTokens, outputTokens, toolCalls, error).
-func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, error) {
+func runAgentLoop(ctx context.Context, p LLMProvider, tools []ToolDef) (string, int, int, int, error) {
 	totalInputTokens := 0
 	totalOutputTokens := 0
 	totalCachedTokens := 0
@@ -133,8 +137,20 @@ func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, er
 	policy := loadContextPolicy()
 	ledger := &toolResultLedger{}
 	if policy.elisionEnabled() {
-		log.Printf("context policy: per-result cap=%dB budget=%dB low=%dB keep_recent=%d",
-			policy.ToolResultMaxBytes, policy.HistoryBudgetBytes, policy.HistoryLowBytes, policy.KeepRecent)
+		spillDir := policy.SpillDir
+		if spillDir != "" {
+			if reason := spillUnavailable(spillDir, tools); reason != "" {
+				log.Printf("WARNING: not spilling elided tool output — %s. "+
+					"Elision stays destructive; set CONTEXT_ELISION_SPILL_DIR to a readable root "+
+					"or allow %s to make elided results recoverable", reason, ToolReadFile)
+				spillDir = ""
+			} else {
+				ledger.spill = dirSpiller{Dir: spillDir}
+			}
+		}
+		log.Printf("context policy: per-result cap=%dB budget=%dB low=%dB keep_recent=%d spill_dir=%q",
+			policy.ToolResultMaxBytes, policy.HistoryBudgetBytes, policy.HistoryLowBytes,
+			policy.KeepRecent, spillDir)
 	}
 
 	// Report cached tokens separately rather than as a ratio: providers
@@ -279,7 +295,7 @@ func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, er
 				Content: clamped,
 				IsError: isError,
 			})
-			ledger.add(call.ID, call.Name, len(clamped), round)
+			ledger.add(call.ID, call.Name, clamped, round)
 		}
 		p.AddToolResults(results)
 

--- a/cmd/agent-runner/provider_test.go
+++ b/cmd/agent-runner/provider_test.go
@@ -12,6 +12,11 @@ import (
 // mockProvider is a deterministic LLMProvider for testing the shared loop.
 // It replays a scripted sequence of ChatResult values, one per Chat() call,
 // and records every AddToolResults invocation for assertions.
+// mockTools is the effective tool set runAgentLoop is handed in tests. Only the
+// elision path consults it, and only to confirm read_file is available to read
+// spilled output back.
+var mockTools = []ToolDef{{Name: ToolReadFile}}
+
 type mockProvider struct {
 	name        string
 	model       string
@@ -85,7 +90,7 @@ func TestRunAgentLoop_TerminalTextOnly(t *testing.T) {
 			{Text: "final answer", InputTokens: 10, OutputTokens: 5},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -121,7 +126,7 @@ func TestRunAgentLoop_ToolCallThenText(t *testing.T) {
 			{Text: "contents: hello", InputTokens: 40, OutputTokens: 10, FinishReason: "stop"},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -167,7 +172,7 @@ func TestRunAgentLoop_ToolFailuresDoNotBlock(t *testing.T) {
 	turns = append(turns, ChatResult{Text: "gave up and summarized", InputTokens: 2, OutputTokens: 3})
 
 	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
-	text, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, _, _, toolCalls, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("loop returned error despite tool failures: %v", err)
 	}
@@ -216,7 +221,7 @@ func TestRunAgentLoop_EmptyTerminalFallsBackToAccumulated(t *testing.T) {
 			{Text: "", InputTokens: 200, OutputTokens: 242, FinishReason: "stop"},
 		},
 	}
-	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p)
+	text, in, out, toolCalls, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +255,7 @@ func TestRunAgentLoop_AllTurnsEmptyReturnsEmpty(t *testing.T) {
 			{Text: "", FinishReason: "stop"},
 		},
 	}
-	text, _, _, _, err := runAgentLoop(context.Background(), p)
+	text, _, _, _, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -275,7 +280,7 @@ func TestRunAgentLoop_TerminalTextPreferredOverAccumulated(t *testing.T) {
 			{Text: "final answer is 42", FinishReason: "stop"},
 		},
 	}
-	text, _, _, _, err := runAgentLoop(context.Background(), p)
+	text, _, _, _, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -302,7 +307,7 @@ func TestRunAgentLoop_IterationBudget(t *testing.T) {
 		})
 	}
 	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
-	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
+	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p, mockTools)
 	if err == nil {
 		t.Fatal("expected budget-exceeded error")
 	}
@@ -323,7 +328,7 @@ func TestRunAgentLoop_ChatErrorPropagates(t *testing.T) {
 		turns:   []ChatResult{{}},
 		turnErr: []error{fmt.Errorf("provider rate limit")},
 	}
-	_, _, _, _, err := runAgentLoop(context.Background(), p)
+	_, _, _, _, err := runAgentLoop(context.Background(), p, mockTools)
 	if err == nil {
 		t.Fatal("expected error from Chat to propagate")
 	}
@@ -350,7 +355,7 @@ func TestRunAgentLoop_MultipleToolCallsPerTurn(t *testing.T) {
 			{Text: "done", FinishReason: "stop"},
 		},
 	}
-	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p)
+	_, _, _, toolCalls, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -396,7 +401,7 @@ func TestRunAgentLoop_MaxTokensPerRun_Halt(t *testing.T) {
 		},
 	}
 
-	text, in, out, _, err := runAgentLoop(context.Background(), p)
+	text, in, out, _, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -441,7 +446,7 @@ func TestRunAgentLoop_MaxTokensPerRun_Warn(t *testing.T) {
 		},
 	}
 
-	text, in, out, _, err := runAgentLoop(context.Background(), p)
+	text, in, out, _, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -475,7 +480,7 @@ func TestRunAgentLoop_MaxTokensPerRun_NotSet(t *testing.T) {
 		},
 	}
 
-	text, _, _, _, err := runAgentLoop(context.Background(), p)
+	text, _, _, _, err := runAgentLoop(context.Background(), p, mockTools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/docs/guides/context-cost.md
+++ b/docs/guides/context-cost.md
@@ -24,6 +24,7 @@ the model raises `maxChars`).
 | `CONTEXT_HISTORY_BUDGET_BYTES` | `0` (off) | Once live tool-result bytes exceed this, older results are replaced with short placeholders. |
 | `CONTEXT_HISTORY_BUDGET_LOW_BYTES` | half the budget | How far down to drain when elision fires. |
 | `CONTEXT_KEEP_RECENT_RESULTS` | `3` | Newest results never elided — the model is still reasoning over these. The in-flight round's results are protected on top of this window. Only applies when elision is on. |
+| `CONTEXT_ELISION_SPILL_DIR` | `/workspace/.sympozium/elided` | Where an elided result's full output is written so the model can read it back. Set to `off` to elide destructively. Only applies when elision is on. |
 
 Set them via `spec.env` on an AgentRun, or on the Agent so every run inherits them.
 
@@ -107,10 +108,55 @@ while Anthropic reports the uncached remainder in `input_tokens` and the cached
 portion separately. That is why the runner logs the two side by side rather
 than as a hit-rate percentage.
 
+## Elided output is recoverable
+
+Elision moves output out of the conversation; it does not destroy it. Before a
+result is replaced, its full text is written to `CONTEXT_ELISION_SPILL_DIR` and
+the placeholder names that path:
+
+```
+[earlier execute_command result elided — 48213 bytes saved to
+ /workspace/.sympozium/elided/0007.txt; read_file to recover.]
+```
+
+So the model pays for a path instead of a payload, and gets the detail back on
+demand — `read_file` paginates, so the size of the original does not matter.
+That is usually better than re-running the tool, whose side effects may not be
+repeatable and whose cost is paid again.
+
+Files are named by ledger position alone — deliberately nothing else, so no
+model- or MCP-supplied string reaches a filesystem path. They are written `0600`
+under a `0700` directory, and only ever created when elision actually fires.
+They live as long as the pod does — or longer with a PVC-backed workspace, where
+postRun hooks can read them too.
+
+Spilling only turns on when the placeholder's instruction can actually be
+followed. At startup the runner checks that:
+
+- **`read_file` survived the tool policy.** A run with
+  `toolPolicy.deny: [read_file]`, or an `allow` list that omits it, has no way
+  back to the file.
+- **The spill directory is under a root `read_file` will open** — `/workspace`,
+  `/skills`, `/tmp`, or `/ipc`. Pointing `CONTEXT_ELISION_SPILL_DIR` at, say,
+  `/var/log/agent` would produce files the agent cannot read.
+
+If either fails the runner logs why and elision stays destructive, rather than
+writing files nobody can reach and promising the model otherwise:
+
+```
+WARNING: not spilling elided tool output — read_file is not available to this run.
+Elision stays destructive; set CONTEXT_ELISION_SPILL_DIR to a readable root or
+allow read_file to make elided results recoverable
+```
+
+The same fallback applies per result if a write fails at runtime (a read-only or
+absent `/workspace`) — logged once, then a bare placeholder. Elision still
+happens in all these cases, because the context pressure is real either way.
+
 ## Trade-off
 
-Elided results are gone from the model's view — it sees a placeholder naming the
-tool and the reclaimed size, and can re-run the tool if it still needs the
-output. On tasks where the agent must correlate evidence gathered early with
-findings much later, set `CONTEXT_KEEP_RECENT_RESULTS` higher or leave elision
-off and rely on the per-result cap alone.
+An elided result is one `read_file` away rather than in front of the model, so
+it will not be reasoned over unless the model goes and fetches it. On tasks
+where the agent must correlate evidence gathered early with findings much later,
+set `CONTEXT_KEEP_RECENT_RESULTS` higher or leave elision off and rely on the
+per-result cap alone.


### PR DESCRIPTION
Tool results can potentially take a while to determine (think test run output) or can be time bound. Rather than completely wiping the content we can store it on disk and provide instructions to read it back if needed rather than having to re-run the tool. This provides an approach to have Context addressable via a variable.