### PR TITLE
feat: add Databricks AI Gateway provider

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -3796,8 +3796,11 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	provider := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("provider")))
+
 	// Resolve hostname and check for disallowed IPs.
 	hostname := parsed.Hostname()
+	isDatabricks := provider == "databricks" && isDatabricksHostname(hostname)
 	ips, err := net.LookupHost(hostname)
 	if err != nil {
 		http.Error(w, "cannot resolve baseURL hostname", http.StatusBadRequest)
@@ -3813,19 +3816,25 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 		// kube-apiserver or any in-cluster service. This is a best-effort check;
 		// a DNS-rebinding name can still change between resolution here and the
 		// client's own re-resolution below.
-		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-			ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() {
+		if (ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+			ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified()) && !isDatabricks {
 			http.Error(w, "baseURL resolves to a disallowed address", http.StatusForbidden)
 			return
 		}
 	}
 
-	provider := r.URL.Query().Get("provider")
 	apiKey := r.Header.Get("X-Provider-Api-Key")
+	secretName := strings.TrimSpace(r.URL.Query().Get("secretName"))
 
 	// Determine the models endpoint URL.
 	modelsURL := ""
-	if provider == "ollama" || strings.Contains(baseURL, ":11434") {
+	if provider == "databricks" {
+		if !isDatabricks {
+			http.Error(w, "Databricks provider requires a databricks.com baseURL", http.StatusBadRequest)
+			return
+		}
+		modelsURL = databricksWorkspaceRoot(parsed) + "/api/2.0/serving-endpoints"
+	} else if provider == "ollama" || strings.Contains(baseURL, ":11434") {
 		// Ollama uses /api/tags.
 		modelsURL = strings.TrimRight(baseURL, "/")
 		// If baseURL ends with /v1, strip it for the Ollama native API.
@@ -3849,6 +3858,24 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 	if apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
+	if provider == "databricks" && secretName != "" {
+		ns := r.URL.Query().Get("namespace")
+		if ns == "" {
+			ns = "default"
+		}
+		var secret corev1.Secret
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: secretName, Namespace: ns}, &secret); err != nil {
+			if k8serrors.IsNotFound(err) {
+				http.Error(w, fmt.Sprintf("secret %q not found in namespace %q", secretName, ns), http.StatusBadRequest)
+				return
+			}
+			http.Error(w, "failed to read provider secret: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if auth := providerAuthorization(&secret); auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, "failed to reach provider: "+err.Error(), http.StatusBadGateway)
@@ -3869,6 +3896,9 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 
 	// Parse models from response.
 	models := parseProviderModels(body)
+	if provider == "databricks" {
+		models = parseDatabricksServingEndpoints(body)
+	}
 
 	writeJSON(w, ProviderModelsResponse{
 		Models: models,
@@ -3941,6 +3971,77 @@ func (s *Server) listBedrockModels(w http.ResponseWriter, r *http.Request) {
 		Models: models,
 		Source: "live",
 	})
+}
+
+func isDatabricksHostname(hostname string) bool {
+	hostname = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(hostname), "."))
+	return hostname == "databricks.com" || strings.HasSuffix(hostname, ".databricks.com")
+}
+
+func databricksWorkspaceRoot(parsed *url.URL) string {
+	return parsed.Scheme + "://" + parsed.Host
+}
+
+func providerAuthorization(secret *corev1.Secret) string {
+	for key, value := range secret.Data {
+		if strings.EqualFold(key, "Authorization") {
+			return strings.TrimSpace(string(value))
+		}
+	}
+	for _, key := range []string{"DATABRICKS_TOKEN", "API_KEY", "PROVIDER_API_KEY", "OPENAI_API_KEY"} {
+		if value := strings.TrimSpace(string(secret.Data[key])); value != "" {
+			return "Bearer " + value
+		}
+	}
+	return ""
+}
+
+func parseDatabricksServingEndpoints(body []byte) []string {
+	var response struct {
+		Endpoints []struct {
+			Name  string `json:"name"`
+			State struct {
+				Ready string `json:"ready"`
+			} `json:"state"`
+			Config struct {
+				ServedEntities []struct {
+					EntityName    string `json:"entity_name"`
+					ExternalModel *struct {
+						Task string `json:"task"`
+					} `json:"external_model"`
+				} `json:"served_entities"`
+			} `json:"config"`
+		} `json:"endpoints"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	models := make([]string, 0, len(response.Endpoints))
+	for _, endpoint := range response.Endpoints {
+		if endpoint.Name == "" || (endpoint.State.Ready != "" && endpoint.State.Ready != "READY") {
+			continue
+		}
+		embeddingOnly := false
+		for _, entity := range endpoint.Config.ServedEntities {
+			if entity.ExternalModel != nil && entity.ExternalModel.Task == "llm/v1/embeddings" {
+				embeddingOnly = true
+				break
+			}
+		}
+		lowerName := strings.ToLower(endpoint.Name)
+		if embeddingOnly || strings.Contains(lowerName, "embedding") || strings.Contains(lowerName, "embed-") {
+			continue
+		}
+		if _, exists := seen[endpoint.Name]; exists {
+			continue
+		}
+		seen[endpoint.Name] = struct{}{}
+		models = append(models, endpoint.Name)
+	}
+	sort.Strings(models)
+	return models
 }
 
 // parseProviderModels extracts model names from a JSON response.

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"sort"
@@ -41,6 +42,20 @@ import (
 )
 
 const systemNamespace = "sympozium-system"
+
+var disallowedProviderPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001:db8::/32"),
+}
 
 // memoryProxyClient is used when the apiserver proxies UI/API requests to a
 // per-Ensemble shared memory server (/list, /provenance). The otelhttp
@@ -3779,9 +3794,45 @@ func (s *Server) listProviderNodes(w http.ResponseWriter, r *http.Request) {
 
 // proxyProviderModels proxies a model listing request to an in-cluster or node-based inference provider.
 func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
-	baseURL := r.URL.Query().Get("baseURL")
+	baseURL := strings.TrimSpace(r.URL.Query().Get("baseURL"))
+	provider := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("provider")))
+	agentRef := strings.TrimSpace(r.URL.Query().Get("agentRef"))
+	providerSecretName := ""
+	providerSecretNamespace := ""
+
+	if agentRef != "" {
+		if !s.authEnabled {
+			http.Error(w, "Secret-backed model discovery requires API authentication", http.StatusForbidden)
+			return
+		}
+		if provider != "databricks" {
+			http.Error(w, "agentRef model discovery is only supported for Databricks", http.StatusBadRequest)
+			return
+		}
+		ns := r.URL.Query().Get("namespace")
+		if ns == "" {
+			ns = "default"
+		}
+		var agent sympoziumv1alpha1.Agent
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: agentRef, Namespace: ns}, &agent); err != nil {
+			if k8serrors.IsNotFound(err) {
+				http.Error(w, fmt.Sprintf("agent %q not found in namespace %q", agentRef, ns), http.StatusNotFound)
+				return
+			}
+			http.Error(w, "failed to read agent: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		baseURL = strings.TrimSpace(agent.Spec.Agents.Default.BaseURL)
+		providerSecretName = providerSecretRef(&agent, provider)
+		if providerSecretName == "" {
+			http.Error(w, fmt.Sprintf("agent %q has no %s authRef", agentRef, provider), http.StatusBadRequest)
+			return
+		}
+		providerSecretNamespace = agent.Namespace
+	}
+
 	if baseURL == "" {
-		http.Error(w, "baseURL query parameter is required", http.StatusBadRequest)
+		http.Error(w, "baseURL query parameter is required when agentRef is not set", http.StatusBadRequest)
 		return
 	}
 
@@ -3791,16 +3842,13 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid baseURL", http.StatusBadRequest)
 		return
 	}
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		http.Error(w, "baseURL must use http or https scheme", http.StatusBadRequest)
+	if err := validateProviderURL(parsed, provider); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	provider := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("provider")))
-
 	// Resolve hostname and check for disallowed IPs.
 	hostname := parsed.Hostname()
-	isDatabricks := provider == "databricks" && isDatabricksHostname(hostname)
 	ips, err := net.LookupHost(hostname)
 	if err != nil {
 		http.Error(w, "cannot resolve baseURL hostname", http.StatusBadRequest)
@@ -3811,28 +3859,20 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 		if ip == nil {
 			continue
 		}
-		// Block SSRF targets: link-local (cloud metadata), loopback, private,
-		// and unspecified ranges — otherwise this handler can be steered at the
-		// kube-apiserver or any in-cluster service. This is a best-effort check;
-		// a DNS-rebinding name can still change between resolution here and the
-		// client's own re-resolution below.
-		if (ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-			ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified()) && !isDatabricks {
+		// Block SSRF targets before constructing the outbound request. The HTTP
+		// client's dialer repeats this check against the actual connected peer,
+		// so a DNS change between lookup and connection is also rejected.
+		if isDisallowedProviderIP(ip) {
 			http.Error(w, "baseURL resolves to a disallowed address", http.StatusForbidden)
 			return
 		}
 	}
 
 	apiKey := r.Header.Get("X-Provider-Api-Key")
-	secretName := strings.TrimSpace(r.URL.Query().Get("secretName"))
 
 	// Determine the models endpoint URL.
 	modelsURL := ""
 	if provider == "databricks" {
-		if !isDatabricks {
-			http.Error(w, "Databricks provider requires a databricks.com baseURL", http.StatusBadRequest)
-			return
-		}
 		modelsURL = databricksWorkspaceRoot(parsed) + "/api/2.0/serving-endpoints"
 	} else if provider == "ollama" || strings.Contains(baseURL, ":11434") {
 		// Ollama uses /api/tags.
@@ -3849,7 +3889,7 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 		modelsURL += "/models"
 	}
 
-	client := &http.Client{Timeout: 5 * time.Second}
+	client := newProviderHTTPClient()
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, modelsURL, nil)
 	if err != nil {
 		http.Error(w, "failed to build request: "+err.Error(), http.StatusInternalServerError)
@@ -3858,23 +3898,22 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 	if apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
-	if provider == "databricks" && secretName != "" {
-		ns := r.URL.Query().Get("namespace")
-		if ns == "" {
-			ns = "default"
-		}
+	if provider == "databricks" && providerSecretName != "" {
 		var secret corev1.Secret
-		if err := s.client.Get(r.Context(), types.NamespacedName{Name: secretName, Namespace: ns}, &secret); err != nil {
+		if err := s.client.Get(r.Context(), types.NamespacedName{Name: providerSecretName, Namespace: providerSecretNamespace}, &secret); err != nil {
 			if k8serrors.IsNotFound(err) {
-				http.Error(w, fmt.Sprintf("secret %q not found in namespace %q", secretName, ns), http.StatusBadRequest)
+				http.Error(w, fmt.Sprintf("agent %q auth secret not found", agentRef), http.StatusBadRequest)
 				return
 			}
 			http.Error(w, "failed to read provider secret: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if auth := providerAuthorization(&secret); auth != "" {
-			req.Header.Set("Authorization", auth)
+		auth := databricksAuthorization(&secret)
+		if auth == "" {
+			http.Error(w, fmt.Sprintf("agent %q auth secret has no Databricks token", agentRef), http.StatusBadRequest)
+			return
 		}
+		req.Header.Set("Authorization", auth)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -3894,10 +3933,11 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse models from response.
-	models := parseProviderModels(body)
+	var models []string
 	if provider == "databricks" {
 		models = parseDatabricksServingEndpoints(body)
+	} else {
+		models = parseProviderModels(body)
 	}
 
 	writeJSON(w, ProviderModelsResponse{
@@ -3978,18 +4018,114 @@ func isDatabricksHostname(hostname string) bool {
 	return hostname == "databricks.com" || strings.HasSuffix(hostname, ".databricks.com")
 }
 
+func validateProviderURL(parsed *url.URL, provider string) error {
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("baseURL must use http or https scheme")
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("baseURL must include a hostname")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("baseURL must not include credentials")
+	}
+	if parsed.Fragment != "" {
+		return fmt.Errorf("baseURL must not include a fragment")
+	}
+	if provider == "databricks" {
+		if parsed.Scheme != "https" {
+			return fmt.Errorf("Databricks baseURL must use https")
+		}
+		if !isDatabricksHostname(parsed.Hostname()) {
+			return fmt.Errorf("Databricks provider requires a databricks.com baseURL")
+		}
+		if port := parsed.Port(); port != "" && port != "443" {
+			return fmt.Errorf("Databricks baseURL must use port 443")
+		}
+	}
+	return nil
+}
+
+func isDisallowedProviderIP(ip net.IP) bool {
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return true
+	}
+	addr = addr.Unmap()
+	if !addr.IsGlobalUnicast() || addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast() {
+		return true
+	}
+	for _, prefix := range disallowedProviderPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func newProviderHTTPClient() *http.Client {
+	dialer := &net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}
+	transport := &http.Transport{
+		Proxy:                  nil,
+		ForceAttemptHTTP2:      true,
+		DisableKeepAlives:      true,
+		TLSHandshakeTimeout:    5 * time.Second,
+		ResponseHeaderTimeout:  5 * time.Second,
+		ExpectContinueTimeout:  time.Second,
+		MaxResponseHeaderBytes: 64 << 10,
+	}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		conn, err := dialer.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		remote, ok := conn.RemoteAddr().(*net.TCPAddr)
+		if !ok || isDisallowedProviderIP(remote.IP) {
+			_ = conn.Close()
+			return nil, fmt.Errorf("provider connection resolved to a disallowed address")
+		}
+		return conn, nil
+	}
+	return &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 func databricksWorkspaceRoot(parsed *url.URL) string {
 	return parsed.Scheme + "://" + parsed.Host
 }
 
-func providerAuthorization(secret *corev1.Secret) string {
-	for key, value := range secret.Data {
-		if strings.EqualFold(key, "Authorization") {
-			return strings.TrimSpace(string(value))
+func providerSecretRef(agent *sympoziumv1alpha1.Agent, provider string) string {
+	for _, ref := range agent.Spec.AuthRefs {
+		if strings.EqualFold(strings.TrimSpace(ref.Provider), provider) {
+			return strings.TrimSpace(ref.Secret)
 		}
 	}
-	for _, key := range []string{"DATABRICKS_TOKEN", "API_KEY", "PROVIDER_API_KEY", "OPENAI_API_KEY"} {
+	return ""
+}
+
+func databricksAuthorization(secret *corev1.Secret) string {
+	for key, value := range secret.Data {
+		if strings.EqualFold(key, "Authorization") {
+			auth := strings.TrimSpace(string(value))
+			if len(auth) <= len("Bearer ") || !strings.EqualFold(auth[:len("Bearer ")], "Bearer ") {
+				return ""
+			}
+			token := strings.TrimSpace(auth[len("Bearer "):])
+			if token == "" || strings.ContainsAny(token, "\r\n") {
+				return ""
+			}
+			return "Bearer " + token
+		}
+	}
+	for _, key := range []string{"DATABRICKS_TOKEN", "PROVIDER_API_KEY"} {
 		if value := strings.TrimSpace(string(secret.Data[key])); value != "" {
+			if strings.ContainsAny(value, "\r\n") {
+				return ""
+			}
 			return "Bearer " + value
 		}
 	}

--- a/internal/apiserver/server_providers_test.go
+++ b/internal/apiserver/server_providers_test.go
@@ -2,8 +2,10 @@ package apiserver
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -215,6 +217,76 @@ func TestProxyProviderModels_InvalidScheme(t *testing.T) {
 	}
 }
 
+func TestProxyProviderModels_SecretBackedDiscoveryRequiresAuth(t *testing.T) {
+	srv := newProviderTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/providers/models?provider=databricks&agentRef=example", nil)
+	rec := httptest.NewRecorder()
+	srv.buildMux(nil, nil).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestValidateProviderURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		provider string
+		wantErr  bool
+	}{
+		{name: "databricks https", rawURL: "https://workspace.cloud.databricks.com/ai-gateway/mlflow/v1", provider: "databricks"},
+		{name: "databricks explicit 443", rawURL: "https://workspace.cloud.databricks.com:443/v1", provider: "databricks"},
+		{name: "databricks plaintext", rawURL: "http://workspace.cloud.databricks.com/v1", provider: "databricks", wantErr: true},
+		{name: "databricks nonstandard port", rawURL: "https://workspace.cloud.databricks.com:8443/v1", provider: "databricks", wantErr: true},
+		{name: "databricks wrong host", rawURL: "https://example.com/v1", provider: "databricks", wantErr: true},
+		{name: "embedded credentials", rawURL: "https://user:password@example.com/v1", provider: "custom", wantErr: true},
+		{name: "fragment", rawURL: "https://example.com/v1#internal", provider: "custom", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := url.Parse(tt.rawURL)
+			if err != nil {
+				t.Fatalf("parse URL: %v", err)
+			}
+			err = validateProviderURL(parsed, tt.provider)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateProviderURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsDisallowedProviderIP(t *testing.T) {
+	tests := []struct {
+		ip         string
+		disallowed bool
+	}{
+		{ip: "127.0.0.1", disallowed: true},
+		{ip: "169.254.169.254", disallowed: true},
+		{ip: "10.0.0.1", disallowed: true},
+		{ip: "100.64.0.1", disallowed: true},
+		{ip: "198.18.0.1", disallowed: true},
+		{ip: "::1", disallowed: true},
+		{ip: "fc00::1", disallowed: true},
+		{ip: "8.8.8.8", disallowed: false},
+		{ip: "2606:4700:4700::1111", disallowed: false},
+	}
+	for _, tt := range tests {
+		if got := isDisallowedProviderIP(net.ParseIP(tt.ip)); got != tt.disallowed {
+			t.Errorf("isDisallowedProviderIP(%s) = %v, want %v", tt.ip, got, tt.disallowed)
+		}
+	}
+}
+
+func TestProviderHTTPClientRejectsRedirects(t *testing.T) {
+	client := newProviderHTTPClient()
+	if err := client.CheckRedirect(&http.Request{}, []*http.Request{{}}); err != http.ErrUseLastResponse {
+		t.Errorf("CheckRedirect error = %v, want http.ErrUseLastResponse", err)
+	}
+}
+
 func TestParseProviderModels_OllamaFormat(t *testing.T) {
 	body := `{"models":[{"name":"llama3:latest"},{"name":"codellama:7b"}]}`
 	models := parseProviderModels([]byte(body))
@@ -269,12 +341,58 @@ func TestParseDatabricksServingEndpoints(t *testing.T) {
 	}
 }
 
-func TestProviderAuthorization(t *testing.T) {
+func TestDatabricksAuthorization(t *testing.T) {
 	secret := &corev1.Secret{Data: map[string][]byte{
 		"Authorization": []byte("Bearer db-token"),
 		"API_KEY":       []byte("fallback-token"),
 	}}
-	if got := providerAuthorization(secret); got != "Bearer db-token" {
+	if got := databricksAuthorization(secret); got != "Bearer db-token" {
 		t.Errorf("authorization = %q, want Bearer db-token", got)
+	}
+}
+
+func TestDatabricksAuthorizationIgnoresUnrelatedKeys(t *testing.T) {
+	secret := &corev1.Secret{Data: map[string][]byte{
+		"API_KEY":        []byte("generic-token"),
+		"OPENAI_API_KEY": []byte("openai-token"),
+	}}
+	if got := databricksAuthorization(secret); got != "" {
+		t.Errorf("authorization = %q, want empty", got)
+	}
+}
+
+func TestDatabricksAuthorizationRejectsUnsafeValues(t *testing.T) {
+	tests := []corev1.Secret{
+		{Data: map[string][]byte{"Authorization": []byte("Basic credentials")}},
+		{Data: map[string][]byte{"Authorization": []byte("Bearer token\r\nX-Injected: value")}},
+		{Data: map[string][]byte{"DATABRICKS_TOKEN": []byte("token\nX-Injected: value")}},
+	}
+	for i := range tests {
+		if got := databricksAuthorization(&tests[i]); got != "" {
+			t.Errorf("case %d authorization = %q, want empty", i, got)
+		}
+	}
+}
+
+func TestDatabricksAuthorizationProviderAPIKey(t *testing.T) {
+	secret := &corev1.Secret{Data: map[string][]byte{
+		"PROVIDER_API_KEY": []byte("db-token"),
+	}}
+	if got := databricksAuthorization(secret); got != "Bearer db-token" {
+		t.Errorf("authorization = %q, want Bearer db-token", got)
+	}
+}
+
+func TestProviderSecretRefMatchesProvider(t *testing.T) {
+	agent := &sympoziumv1alpha1.Agent{
+		Spec: sympoziumv1alpha1.AgentSpec{
+			AuthRefs: []sympoziumv1alpha1.SecretRef{
+				{Provider: "openai", Secret: "openai-secret"},
+				{Provider: "databricks", Secret: "databricks-secret"},
+			},
+		},
+	}
+	if got := providerSecretRef(agent, "databricks"); got != "databricks-secret" {
+		t.Errorf("secret ref = %q, want databricks-secret", got)
 	}
 }

--- a/internal/apiserver/server_providers_test.go
+++ b/internal/apiserver/server_providers_test.go
@@ -246,3 +246,35 @@ func TestParseProviderModels_InvalidJSON(t *testing.T) {
 		t.Errorf("expected empty for invalid JSON, got %v", models)
 	}
 }
+
+func TestParseDatabricksServingEndpoints(t *testing.T) {
+	body := `{
+  "endpoints": [
+    {"name":"databricks-claude-sonnet-4-6","state":{"ready":"READY"},"config":{"served_entities":[{"entity_name":"system.ai.databricks-claude-sonnet-4-6"}]}},
+    {"name":"gpt-4-1","state":{"ready":"READY"},"config":{"served_entities":[{"external_model":{"task":"llm/v1/chat"}}]}},
+    {"name":"azure-cohere-embed-v-4-0","state":{"ready":"READY"},"config":{"served_entities":[{"external_model":{"task":"llm/v1/embeddings"}}]}},
+    {"name":"starting-model","state":{"ready":"NOT_READY"},"config":{}}
+  ]
+}`
+
+	models := parseDatabricksServingEndpoints([]byte(body))
+	want := []string{"databricks-claude-sonnet-4-6", "gpt-4-1"}
+	if len(models) != len(want) {
+		t.Fatalf("models = %v, want %v", models, want)
+	}
+	for i := range want {
+		if models[i] != want[i] {
+			t.Errorf("models[%d] = %q, want %q", i, models[i], want[i])
+		}
+	}
+}
+
+func TestProviderAuthorization(t *testing.T) {
+	secret := &corev1.Secret{Data: map[string][]byte{
+		"Authorization": []byte("Bearer db-token"),
+		"API_KEY":       []byte("fallback-token"),
+	}}
+	if got := providerAuthorization(secret); got != "Bearer db-token" {
+		t.Errorf("authorization = %q, want Bearer db-token", got)
+	}
+}

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -143,6 +143,13 @@ export const PROVIDERS = [
     icon: AWSIcon,
   },
   {
+    value: "databricks",
+    label: "Databricks AI Gateway",
+    defaultModel: "databricks-claude-sonnet-4-6",
+    defaultBaseURL: "",
+    icon: Cloud,
+  },
+  {
     value: "custom",
     label: "Custom",
     defaultModel: "",
@@ -341,6 +348,7 @@ function ModelSelector({
   provider,
   apiKey,
   baseURL,
+  secretName,
   value,
   onChange,
   bedrockCredentials,
@@ -348,6 +356,7 @@ function ModelSelector({
   provider: string;
   apiKey: string;
   baseURL?: string;
+  secretName?: string;
   value: string;
   onChange: (v: string) => void;
   bedrockCredentials?: import("@/hooks/use-model-list").BedrockCredentials;
@@ -357,6 +366,7 @@ function ModelSelector({
     apiKey,
     baseURL,
     bedrockCredentials,
+    secretName,
   );
   const [search, setSearch] = useState("");
 
@@ -944,6 +954,7 @@ export function OnboardingWizard({
 
             {/* In-cluster service: manual Base URL input */}
             {(form.provider === "azure-openai" ||
+              form.provider === "databricks" ||
               (isLocalProvider && inferenceMode === "workload")) && (
               <div className="space-y-2">
                 <Label>Base URL</Label>
@@ -953,7 +964,9 @@ export function OnboardingWizard({
                     setForm({ ...form, baseURL: e.target.value })
                   }
                   placeholder={
-                    form.provider === "ollama"
+                    form.provider === "databricks"
+                      ? "https://workspace.cloud.databricks.com/ai-gateway/mlflow/v1"
+                      : form.provider === "ollama"
                       ? "http://ollama.default.svc:11434/v1"
                       : form.provider === "lm-studio"
                         ? "http://localhost:1234/v1"
@@ -1181,6 +1194,7 @@ export function OnboardingWizard({
               provider={form.provider}
               apiKey={form.apiKey}
               baseURL={form.baseURL}
+              secretName={form.secretName}
               value={form.model}
               onChange={(v) => setForm({ ...form, model: v })}
               bedrockCredentials={

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -348,7 +348,6 @@ function ModelSelector({
   provider,
   apiKey,
   baseURL,
-  secretName,
   value,
   onChange,
   bedrockCredentials,
@@ -356,7 +355,6 @@ function ModelSelector({
   provider: string;
   apiKey: string;
   baseURL?: string;
-  secretName?: string;
   value: string;
   onChange: (v: string) => void;
   bedrockCredentials?: import("@/hooks/use-model-list").BedrockCredentials;
@@ -366,7 +364,6 @@ function ModelSelector({
     apiKey,
     baseURL,
     bedrockCredentials,
-    secretName,
   );
   const [search, setSearch] = useState("");
 
@@ -1194,7 +1191,6 @@ export function OnboardingWizard({
               provider={form.provider}
               apiKey={form.apiKey}
               baseURL={form.baseURL}
-              secretName={form.secretName}
               value={form.model}
               onChange={(v) => setForm({ ...form, model: v })}
               bedrockCredentials={

--- a/web/src/hooks/use-model-list.ts
+++ b/web/src/hooks/use-model-list.ts
@@ -88,13 +88,13 @@ async function fetchProviderModelsViaProxy(
   baseURL: string,
   apiKey?: string,
   provider?: string,
-  secretName?: string,
+  agentRef?: string,
 ): Promise<string[]> {
   const res = await api.providers.models(
     baseURL,
     apiKey,
     provider,
-    secretName,
+    agentRef,
   );
   return res.models;
 }
@@ -146,7 +146,7 @@ export function useModelList(
   apiKey: string,
   baseURL?: string,
   bedrockCredentials?: BedrockCredentials,
-  secretName?: string,
+  agentRef?: string,
 ) {
   const isLocalProvider =
     provider === "ollama" ||
@@ -163,7 +163,7 @@ export function useModelList(
     !!bedrockCredentials?.accessKeyId &&
     !!bedrockCredentials?.secretAccessKey;
   const canFetchDatabricks =
-    provider === "databricks" && !!baseURL && (!!apiKey || !!secretName);
+    provider === "databricks" && !!baseURL && (!!apiKey || !!agentRef);
 
   const query = useQuery<string[]>({
     queryKey: [
@@ -173,7 +173,7 @@ export function useModelList(
       baseURL,
       bedrockCredentials?.region,
       bedrockCredentials?.accessKeyId,
-      secretName,
+      agentRef,
     ],
     queryFn: async () => {
       if (canFetchDatabricks)
@@ -181,7 +181,7 @@ export function useModelList(
           baseURL!,
           apiKey || undefined,
           provider,
-          secretName,
+          agentRef,
         );
       if (canFetchLocal)
         return fetchLocalProviderModels(baseURL!, apiKey || undefined);

--- a/web/src/hooks/use-model-list.ts
+++ b/web/src/hooks/use-model-list.ts
@@ -87,8 +87,15 @@ async function fetchProviderModelsDirect(baseURL: string): Promise<string[]> {
 async function fetchProviderModelsViaProxy(
   baseURL: string,
   apiKey?: string,
+  provider?: string,
+  secretName?: string,
 ): Promise<string[]> {
-  const res = await api.providers.models(baseURL, apiKey);
+  const res = await api.providers.models(
+    baseURL,
+    apiKey,
+    provider,
+    secretName,
+  );
   return res.models;
 }
 
@@ -139,6 +146,7 @@ export function useModelList(
   apiKey: string,
   baseURL?: string,
   bedrockCredentials?: BedrockCredentials,
+  secretName?: string,
 ) {
   const isLocalProvider =
     provider === "ollama" ||
@@ -154,6 +162,8 @@ export function useModelList(
     !!bedrockCredentials?.region &&
     !!bedrockCredentials?.accessKeyId &&
     !!bedrockCredentials?.secretAccessKey;
+  const canFetchDatabricks =
+    provider === "databricks" && !!baseURL && (!!apiKey || !!secretName);
 
   const query = useQuery<string[]>({
     queryKey: [
@@ -163,8 +173,16 @@ export function useModelList(
       baseURL,
       bedrockCredentials?.region,
       bedrockCredentials?.accessKeyId,
+      secretName,
     ],
     queryFn: async () => {
+      if (canFetchDatabricks)
+        return fetchProviderModelsViaProxy(
+          baseURL!,
+          apiKey || undefined,
+          provider,
+          secretName,
+        );
       if (canFetchLocal)
         return fetchLocalProviderModels(baseURL!, apiKey || undefined);
       if (canFetchBedrock) return fetchBedrockModels(bedrockCredentials!);
@@ -173,7 +191,8 @@ export function useModelList(
         return fetchAnthropicModels(apiKey);
       throw new Error("no-fetch");
     },
-    enabled: canFetchLocal || canFetchCloud || canFetchBedrock,
+    enabled:
+      canFetchLocal || canFetchCloud || canFetchBedrock || canFetchDatabricks,
     staleTime: 5 * 60 * 1000, // cache 5 min
     retry: false,
   });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -84,6 +84,8 @@ export interface GateVerdictRequest {
 export interface AgentConfig {
   model: string;
   baseURL?: string;
+  providerHeaders?: Record<string, string>;
+  providerHeadersSecretRef?: string;
   thinking?: string;
   nodeSelector?: Record<string, string>;
   agentSandbox?: AgentSandboxInstanceSpec;
@@ -1543,11 +1545,20 @@ export const api = {
 
   providers: {
     nodes: () => apiFetch<ProviderNode[]>("/api/v1/providers/nodes"),
-    models: (baseURL: string, apiKey?: string) =>
-      apiFetch<ProviderModelsResponse>(
-        `/api/v1/providers/models?baseURL=${encodeURIComponent(baseURL)}`,
+    models: (
+      baseURL: string,
+      apiKey?: string,
+      provider?: string,
+      secretName?: string,
+    ) => {
+      const params = new URLSearchParams({ baseURL });
+      if (provider) params.set("provider", provider);
+      if (secretName) params.set("secretName", secretName);
+      return apiFetch<ProviderModelsResponse>(
+        `/api/v1/providers/models?${params.toString()}`,
         apiKey ? { headers: { "X-Provider-Api-Key": apiKey } } : undefined,
-      ),
+      );
+    },
     bedrockModels: (data: {
       region: string;
       accessKeyId: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1549,11 +1549,11 @@ export const api = {
       baseURL: string,
       apiKey?: string,
       provider?: string,
-      secretName?: string,
+      agentRef?: string,
     ) => {
       const params = new URLSearchParams({ baseURL });
       if (provider) params.set("provider", provider);
-      if (secretName) params.set("secretName", secretName);
+      if (agentRef) params.set("agentRef", agentRef);
       return apiFetch<ProviderModelsResponse>(
         `/api/v1/providers/models?${params.toString()}`,
         apiKey ? { headers: { "X-Provider-Api-Key": apiKey } } : undefined,

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -97,9 +97,6 @@ export function RunsPage() {
   const selectedProvider = selectedBaseURL.includes("databricks.com")
     ? "databricks"
     : selectedAuthRef?.provider || "";
-  const selectedSecretName =
-    selectedAgent?.spec.agents.default.providerHeadersSecretRef ||
-    selectedAuthRef?.secret;
   const {
     models: availableModels,
     isLoading: modelsLoading,
@@ -109,7 +106,7 @@ export function RunsPage() {
     "",
     selectedBaseURL || undefined,
     undefined,
-    selectedSecretName,
+    selectedAgent?.metadata.name,
   );
 
   // Mark all runs as seen after a short delay so "new" dots are visible briefly.

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -46,6 +46,7 @@ import {
   Check,
   X,
   AlertTriangle,
+  Loader2,
 } from "lucide-react";
 import {
   costTooltip,
@@ -57,6 +58,7 @@ import {
 } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useRunsSeen } from "@/hooks/use-runs-seen";
+import { useModelList } from "@/hooks/use-model-list";
 import type { AgentRun } from "@/lib/api";
 
 /** Returns true when a run is in PostRunning with a gate hook awaiting a verdict. */
@@ -85,6 +87,30 @@ export function RunsPage() {
     timeout: "5m",
     backend: "job",
   });
+  const selectedAgent = (instances.data || []).find(
+    (agent) => agent.metadata.name === form.agentRef,
+  );
+  const selectedBaseURL = selectedAgent?.spec.agents.default.baseURL || "";
+  const selectedAuthRef = selectedAgent?.spec.authRefs?.find(
+    (ref) => ref.provider,
+  );
+  const selectedProvider = selectedBaseURL.includes("databricks.com")
+    ? "databricks"
+    : selectedAuthRef?.provider || "";
+  const selectedSecretName =
+    selectedAgent?.spec.agents.default.providerHeadersSecretRef ||
+    selectedAuthRef?.secret;
+  const {
+    models: availableModels,
+    isLoading: modelsLoading,
+    isLive: modelsLive,
+  } = useModelList(
+    selectedProvider,
+    "",
+    selectedBaseURL || undefined,
+    undefined,
+    selectedSecretName,
+  );
 
   // Mark all runs as seen after a short delay so "new" dots are visible briefly.
   useEffect(() => {
@@ -152,7 +178,9 @@ export function RunsPage() {
                 <Label>Instance</Label>
                 <Select
                   value={form.agentRef}
-                  onValueChange={(v) => setForm({ ...form, agentRef: v })}
+                  onValueChange={(v) =>
+                    setForm({ ...form, agentRef: v, model: "" })
+                  }
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select agent" />
@@ -181,13 +209,55 @@ export function RunsPage() {
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label>Model (optional)</Label>
+                  <Select
+                    value={form.model || "__agent_default__"}
+                    onValueChange={(value) =>
+                      setForm({
+                        ...form,
+                        model: value === "__agent_default__" ? "" : value,
+                      })
+                    }
+                    disabled={!selectedAgent || modelsLoading}
+                  >
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={
+                          modelsLoading ? "Loading models…" : "Agent default"
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__agent_default__">
+                        Agent default
+                        {selectedAgent?.spec.agents.default.model
+                          ? ` (${selectedAgent.spec.agents.default.model})`
+                          : ""}
+                      </SelectItem>
+                      {availableModels.map((model) => (
+                        <SelectItem key={model} value={model}>
+                          {model}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {modelsLoading && (
+                    <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Loader2 className="h-3 w-3 animate-spin" /> Loading
+                      gateway models…
+                    </p>
+                  )}
                   <Input
                     value={form.model}
                     onChange={(e) =>
                       setForm({ ...form, model: e.target.value })
                     }
-                    placeholder="gpt-4o"
+                    placeholder="Or enter a custom model"
                   />
+                  {modelsLive && (
+                    <p className="text-[10px] text-emerald-400/70">
+                      ✓ Live models fetched from {selectedProvider}
+                    </p>
+                  )}
                 </div>
                 <div className="space-y-2">
                   <Label>Timeout</Label>


### PR DESCRIPTION
## Summary
- add Databricks AI Gateway as a provider
- discover READY chat models from Databricks serving endpoints
- expose discovered models in onboarding and AgentRun dropdowns
- support Kubernetes Secret-based Databricks authorization without exposing credentials

## Validation
- `go test ./internal/apiserver`
- `npm run build`
- live HTTP 200 invocation: `databricks-claude-opus-5`
- live HTTP 200 invocation: `databricks-gpt-5-5`

Closes #340