### PR TITLE
fix(agent-runner): skip empty-task seed in prompt-server mode + polymorphic task API

### DIFF
--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -53,16 +53,21 @@ func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, too
 		anthropicTools = append(anthropicTools, tool)
 	}
 
+	var seed []anthropic.MessageParam
+	if task != "" {
+		seed = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(task)),
+		}
+	}
+
 	return &anthropicProvider{
 		client:      anthropic.NewClient(opts...),
 		model:       model,
 		system:      systemPrompt,
 		initialTask: task,
-		messages: []anthropic.MessageParam{
-			anthropic.NewUserMessage(anthropic.NewTextBlock(task)),
-		},
-		tools:      anthropicTools,
-		toolsBytes: jsonBytes(anthropicTools),
+		messages:    seed,
+		tools:       anthropicTools,
+		toolsBytes:  jsonBytes(anthropicTools),
 	}
 }
 
@@ -197,8 +202,12 @@ func (p *anthropicProvider) ReplaceToolResults(replacements map[string]string) {
 // ResetContext rebuilds the message slice to the seed state so
 // the next Chat or Prompt call behaves as if the conversation just began.
 func (p *anthropicProvider) ResetContext() {
-	p.messages = []anthropic.MessageParam{
-		anthropic.NewUserMessage(anthropic.NewTextBlock(p.initialTask)),
+	if p.initialTask != "" {
+		p.messages = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(p.initialTask)),
+		}
+	} else {
+		p.messages = nil
 	}
 }
 

--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -94,18 +94,22 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 		}))
 	}
 
+	seed := []openai.ChatCompletionMessageParamUnion{
+		openai.SystemMessage(systemPrompt),
+	}
+	if task != "" {
+		seed = append(seed, openai.UserMessage(task))
+	}
+
 	p := &openaiProvider{
 		client:      openai.NewClient(opts...),
 		provider:    provider,
 		model:       model,
 		system:      systemPrompt,
 		initialTask: task,
-		messages: []openai.ChatCompletionMessageParamUnion{
-			openai.SystemMessage(systemPrompt),
-			openai.UserMessage(task),
-		},
-		tools:      oaiTools,
-		toolsBytes: jsonBytes(oaiTools),
+		messages:    seed,
+		tools:       oaiTools,
+		toolsBytes:  jsonBytes(oaiTools),
 	}
 	return p, nil
 }
@@ -260,7 +264,9 @@ func (p *openaiProvider) ReplaceToolResults(replacements map[string]string) {
 func (p *openaiProvider) ResetContext() {
 	p.messages = []openai.ChatCompletionMessageParamUnion{
 		openai.SystemMessage(p.system),
-		openai.UserMessage(p.initialTask),
+	}
+	if p.initialTask != "" {
+		p.messages = append(p.messages, openai.UserMessage(p.initialTask))
 	}
 }
 

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -883,14 +883,17 @@ func (s *Server) getRun(w http.ResponseWriter, r *http.Request) {
 }
 
 // CreateRunRequest is the request body for creating a new AgentRun.
+// Task accepts both a JSON string (legacy prompt) and a JSON object
+// (sidecar-driven mode: {mode, tool, parameters}), matching the polymorphic
+// TaskSpec on the CRD.
 type CreateRunRequest struct {
-	AgentRef   string `json:"agentRef"`
-	Task       string `json:"task"`
-	AgentID    string `json:"agentId,omitempty"`
-	SessionKey string `json:"sessionKey,omitempty"`
-	Model      string `json:"model,omitempty"`
-	Timeout    string `json:"timeout,omitempty"`
-	Backend    string `json:"backend,omitempty"`
+	AgentRef   string          `json:"agentRef"`
+	Task       json.RawMessage `json:"task"`
+	AgentID    string          `json:"agentId,omitempty"`
+	SessionKey string          `json:"sessionKey,omitempty"`
+	Model      string          `json:"model,omitempty"`
+	Timeout    string          `json:"timeout,omitempty"`
+	Backend    string          `json:"backend,omitempty"`
 }
 
 func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
@@ -905,8 +908,14 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.AgentRef == "" || req.Task == "" {
+	if req.AgentRef == "" || len(req.Task) == 0 {
 		http.Error(w, "agentRef and task are required", http.StatusBadRequest)
+		return
+	}
+
+	var taskSpec sympoziumv1alpha1.TaskSpec
+	if err := json.Unmarshal(req.Task, &taskSpec); err != nil {
+		http.Error(w, "task must be a string or object: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -986,7 +995,7 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 			AgentRef:   req.AgentRef,
 			AgentID:    req.AgentID,
 			SessionKey: req.SessionKey,
-			Task:       sympoziumv1alpha1.NewStringTask(req.Task),
+			Task:       &taskSpec,
 			Backend:    req.Backend,
 			Model: sympoziumv1alpha1.ModelSpec{
 				Provider:                 provider,


### PR DESCRIPTION
## Summary

Two related fixes for sidecar-driven (prompt-server) mode:

1. **Skip empty-task seed message** — in prompt-server mode, `task=""` is intentional (the sidecar passes prompts via `/ipc/prompts/`). Both providers seeded the message history with an empty-task user message, which Anthropic rejects as HTTP 400 (`"messages: text content blocks must be non-empty"`). OpenAI silently accepted it but wasted a conversation turn.

2. **Accept polymorphic task in CreateRun API** — the CRD already accepts both string and object-form tasks via `TaskSpec`, but the REST API's `CreateRunRequest.Task` was typed as `string`. Sidecars that trigger other agents (e.g. a collector triggering a parser) use the REST API, so they couldn't create sidecar-driven runs.

## Changes

### Commit 1: Empty-task seed fix

**`cmd/agent-runner/provider_anthropic.go`** and **`cmd/agent-runner/provider_openai.go`**

Guard both the constructor and `ResetContext()`: only seed the task message when the task string is non-empty.

```go
// Before (both providers):
messages: []MessageParam{
    NewUserMessage(NewTextBlock(task)),  // task="" → empty content block
}

// After:
var seed []MessageParam
if task != "" {
    seed = []MessageParam{NewUserMessage(NewTextBlock(task))}
}
```

### Commit 2: Polymorphic task API

**`internal/apiserver/server.go`**

- `CreateRunRequest.Task`: `string` → `json.RawMessage`
- Parse via `TaskSpec.UnmarshalJSON` (existing polymorphic handler)
- Set `&taskSpec` directly on the AgentRun instead of `NewStringTask(req.Task)`
- Backward compatible: callers sending `"task": "do the thing"` still work

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/agent-runner/ -short` passes
- [x] `go test ./internal/apiserver/ -short` passes
- [x] `gofmt -l` clean
- [x] E2E tested: sidecar-driven runs with `useContext=true` succeed on both Anthropic and OpenAI providers
- [x] E2E tested: REST API accepts both string and object-form task, creates correct AgentRun