### PR TITLE
feat(agent-runner): structured output support for Anthropic models

### DIFF
--- a/cmd/agent-runner/provider.go
+++ b/cmd/agent-runner/provider.go
@@ -108,6 +108,12 @@ type LLMProvider interface {
 	// LLM call succeeded but the model failed to emit valid schema, and
 	// callers receive an error.
 	Prompt(ctx context.Context, prompt string, useContext bool, schema json.RawMessage) (string, []byte, int, int, error)
+
+	// SupportsStrictSchema reports whether the provider's API enforces
+	// schema validation on tool definitions when Strict is set. Providers
+	// that lack grammar-constrained decoding (Ollama, LM Studio,
+	// llama-server) return false and silently ignore the flag.
+	SupportsStrictSchema() bool
 }
 
 // runAgentLoop drives a provider through iterative tool calling until the

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -50,6 +50,9 @@ func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, too
 		}
 		tool := anthropic.ToolUnionParamOfTool(schema, t.Name)
 		tool.OfTool.Description = anthropic.String(t.Description)
+		if t.Strict {
+			tool.OfTool.Strict = anthropic.Bool(true)
+		}
 		anthropicTools = append(anthropicTools, tool)
 	}
 
@@ -66,8 +69,9 @@ func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, too
 	}
 }
 
-func (p *anthropicProvider) Name() string  { return "anthropic" }
-func (p *anthropicProvider) Model() string { return p.model }
+func (p *anthropicProvider) Name() string              { return "anthropic" }
+func (p *anthropicProvider) Model() string              { return p.model }
+func (p *anthropicProvider) SupportsStrictSchema() bool { return true }
 
 func (p *anthropicProvider) Chat(ctx context.Context) (ChatResult, error) {
 	params := anthropic.MessageNewParams{
@@ -202,14 +206,16 @@ func (p *anthropicProvider) ResetContext() {
 	}
 }
 
-// Prompt issues a single Anthropic Messages call on behalf of a
-// sidecar. With useContext false the message slice is temporarily reset for
-// the call (and restored via defer) so the answer is stateless. With
-// useContext true the prompt is appended and the assistant reply recorded
-// so context grows across Prompt calls within the loop. Tool-use is
-// suppressed via tool_choice=none — the model is expected to answer in text
-// only; structured output (when Schema is set) is parsed by the caller from
-// the assistant's text block.
+// Prompt issues a single Anthropic Messages call on behalf of a sidecar.
+// With useContext false the message slice is temporarily reset for the call
+// (and restored via defer) so the answer is stateless. With useContext true
+// the prompt is appended and the assistant reply recorded so context grows
+// across Prompt calls within the loop.
+//
+// When a schema in json_schema wrapper format is provided, the call uses a
+// synthetic tool with tool_choice forced to that tool so the model returns
+// structured JSON via tool_use.Input. Without a schema, tool-use is
+// suppressed via tool_choice=none and the model answers in text only.
 func (p *anthropicProvider) Prompt(ctx context.Context, prompt string, useContext bool, schema json.RawMessage) (string, []byte, int, int, error) {
 	if strings.TrimSpace(prompt) == "" {
 		return "", nil, 0, 0, fmt.Errorf("prompt is empty")
@@ -224,10 +230,6 @@ func (p *anthropicProvider) Prompt(ctx context.Context, prompt string, useContex
 		}
 		defer func() { p.messages = saved }()
 	} else {
-		// Append the user turn only after the call succeeds; on API failure
-		// we pop it (see below) so a failed Prompt does not leave an orphan
-		// user turn in history. Anthropic rejects back-to-back user turns,
-		// so a single transient error would otherwise poison the run.
 		rollbackUserTurn = true
 		p.messages = append(p.messages, anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)))
 		defer func() {
@@ -237,6 +239,49 @@ func (p *anthropicProvider) Prompt(ctx context.Context, prompt string, useContex
 		}()
 	}
 
+	var parsed []byte
+	var syntheticToolName string
+	var syntheticTools []anthropic.ToolUnionParam
+
+	if len(schema) > 0 {
+		var format struct {
+			Type   string          `json:"type"`
+			Name   string          `json:"name"`
+			Schema json.RawMessage `json:"schema"`
+			Strict *bool           `json:"strict,omitempty"`
+		}
+		if err := json.Unmarshal(schema, &format); err == nil && format.Type == "json_schema" && format.Name != "" {
+			var schemaObj map[string]any
+			if err := json.Unmarshal(format.Schema, &schemaObj); err == nil {
+				syntheticToolName = format.Name
+
+				inputSchema := anthropic.ToolInputSchemaParam{}
+				if props, ok := schemaObj["properties"]; ok {
+					inputSchema.Properties = props
+				}
+				if req, ok := schemaObj["required"].([]any); ok {
+					for _, r := range req {
+						if s, ok := r.(string); ok {
+							inputSchema.Required = append(inputSchema.Required, s)
+						}
+					}
+				}
+				if addl, ok := schemaObj["additionalProperties"]; ok {
+					inputSchema.ExtraFields = map[string]any{
+						"additionalProperties": addl,
+					}
+				}
+
+				tool := anthropic.ToolUnionParamOfTool(inputSchema, format.Name)
+				tool.OfTool.Description = anthropic.String("Structured output tool")
+				if format.Strict == nil || *format.Strict {
+					tool.OfTool.Strict = anthropic.Bool(true)
+				}
+				syntheticTools = append(syntheticTools, tool)
+			}
+		}
+	}
+
 	params := anthropic.MessageNewParams{
 		Model:     anthropic.Model(p.model),
 		MaxTokens: int64(8192),
@@ -244,10 +289,18 @@ func (p *anthropicProvider) Prompt(ctx context.Context, prompt string, useContex
 			{Text: p.system},
 		},
 		Messages: p.messages,
-		// Suppress tool use so a sidecar-driven prompt returns text only.
-		ToolChoice: anthropic.ToolChoiceUnionParam{
+	}
+	if len(syntheticTools) > 0 {
+		params.Tools = syntheticTools
+		params.ToolChoice = anthropic.ToolChoiceUnionParam{
+			OfTool: &anthropic.ToolChoiceToolParam{
+				Name: syntheticToolName,
+			},
+		}
+	} else {
+		params.ToolChoice = anthropic.ToolChoiceUnionParam{
 			OfNone: &anthropic.ToolChoiceNoneParam{},
-		},
+		}
 	}
 
 	msg, err := p.client.Messages.New(ctx, params)
@@ -264,21 +317,23 @@ func (p *anthropicProvider) Prompt(ctx context.Context, prompt string, useContex
 	outTok := int(msg.Usage.OutputTokens)
 	var textContent strings.Builder
 	for _, block := range msg.Content {
-		if tb, ok := block.AsAny().(anthropic.TextBlock); ok {
-			textContent.WriteString(tb.Text)
+		switch v := block.AsAny().(type) {
+		case anthropic.TextBlock:
+			textContent.WriteString(v.Text)
+		case anthropic.ToolUseBlock:
+			if syntheticToolName != "" && v.Name == syntheticToolName {
+				parsed = []byte(v.Input)
+			}
 		}
 	}
 	text := textContent.String()
 
 	if useContext {
 		p.messages = append(p.messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(text)))
-		// Success: cancel the deferred rollback so the user turn stays in
-		// history.
 		rollbackUserTurn = false
 	}
 
-	var parsed []byte
-	if len(schema) > 0 {
+	if len(schema) > 0 && parsed == nil {
 		trimmed := strings.TrimSpace(text)
 		if json.Valid([]byte(trimmed)) {
 			parsed = []byte(trimmed)

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -329,7 +329,11 @@ func (p *anthropicProvider) Prompt(ctx context.Context, prompt string, useContex
 	text := textContent.String()
 
 	if useContext {
-		p.messages = append(p.messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(text)))
+		historyText := text
+		if historyText == "" && parsed != nil {
+			historyText = string(parsed)
+		}
+		p.messages = append(p.messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(historyText)))
 		rollbackUserTurn = false
 	}
 

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -56,16 +56,21 @@ func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, too
 		anthropicTools = append(anthropicTools, tool)
 	}
 
+	var seed []anthropic.MessageParam
+	if task != "" {
+		seed = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(task)),
+		}
+	}
+
 	return &anthropicProvider{
 		client:      anthropic.NewClient(opts...),
 		model:       model,
 		system:      systemPrompt,
 		initialTask: task,
-		messages: []anthropic.MessageParam{
-			anthropic.NewUserMessage(anthropic.NewTextBlock(task)),
-		},
-		tools:      anthropicTools,
-		toolsBytes: jsonBytes(anthropicTools),
+		messages:    seed,
+		tools:       anthropicTools,
+		toolsBytes:  jsonBytes(anthropicTools),
 	}
 }
 
@@ -201,8 +206,12 @@ func (p *anthropicProvider) ReplaceToolResults(replacements map[string]string) {
 // ResetContext rebuilds the message slice to the seed state so
 // the next Chat or Prompt call behaves as if the conversation just began.
 func (p *anthropicProvider) ResetContext() {
-	p.messages = []anthropic.MessageParam{
-		anthropic.NewUserMessage(anthropic.NewTextBlock(p.initialTask)),
+	if p.initialTask != "" {
+		p.messages = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(p.initialTask)),
+		}
+	} else {
+		p.messages = nil
 	}
 }
 

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -69,7 +69,7 @@ func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, too
 	}
 }
 
-func (p *anthropicProvider) Name() string              { return "anthropic" }
+func (p *anthropicProvider) Name() string               { return "anthropic" }
 func (p *anthropicProvider) Model() string              { return p.model }
 func (p *anthropicProvider) SupportsStrictSchema() bool { return true }
 

--- a/cmd/agent-runner/provider_bedrock.go
+++ b/cmd/agent-runner/provider_bedrock.go
@@ -91,8 +91,9 @@ func newBedrockProviderWithClient(client bedrockClientAPI, model, systemPrompt, 
 	}, nil
 }
 
-func (p *bedrockProvider) Name() string  { return "bedrock" }
-func (p *bedrockProvider) Model() string { return p.model }
+func (p *bedrockProvider) Name() string              { return "bedrock" }
+func (p *bedrockProvider) Model() string              { return p.model }
+func (p *bedrockProvider) SupportsStrictSchema() bool { return true }
 
 func (p *bedrockProvider) Chat(ctx context.Context) (ChatResult, error) {
 	input := &bedrockruntime.ConverseInput{

--- a/cmd/agent-runner/provider_bedrock.go
+++ b/cmd/agent-runner/provider_bedrock.go
@@ -93,7 +93,7 @@ func newBedrockProviderWithClient(client bedrockClientAPI, model, systemPrompt, 
 
 func (p *bedrockProvider) Name() string              { return "bedrock" }
 func (p *bedrockProvider) Model() string              { return p.model }
-func (p *bedrockProvider) SupportsStrictSchema() bool { return true }
+func (p *bedrockProvider) SupportsStrictSchema() bool { return false }
 
 func (p *bedrockProvider) Chat(ctx context.Context) (ChatResult, error) {
 	input := &bedrockruntime.ConverseInput{

--- a/cmd/agent-runner/provider_bedrock.go
+++ b/cmd/agent-runner/provider_bedrock.go
@@ -91,7 +91,7 @@ func newBedrockProviderWithClient(client bedrockClientAPI, model, systemPrompt, 
 	}, nil
 }
 
-func (p *bedrockProvider) Name() string              { return "bedrock" }
+func (p *bedrockProvider) Name() string               { return "bedrock" }
 func (p *bedrockProvider) Model() string              { return p.model }
 func (p *bedrockProvider) SupportsStrictSchema() bool { return false }
 

--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -86,6 +86,12 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 	}
 
 	supportsStrict := provider != "ollama" && provider != "lm-studio" && provider != "llama-server" && provider != "unsloth"
+	if provider == "azure-openai" {
+		apiVersion := getEnv("AZURE_OPENAI_API_VERSION", "2024-06-01")
+		if apiVersion < "2024-08-01" {
+			supportsStrict = false
+		}
+	}
 
 	var oaiTools []openai.ChatCompletionToolUnionParam
 	for _, t := range tools {
@@ -123,6 +129,9 @@ func (p *openaiProvider) SupportsStrictSchema() bool {
 	switch p.provider {
 	case "ollama", "lm-studio", "llama-server", "unsloth":
 		return false
+	case "azure-openai":
+		apiVersion := getEnv("AZURE_OPENAI_API_VERSION", "2024-06-01")
+		return apiVersion >= "2024-08-01"
 	default:
 		return true
 	}

--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -85,13 +85,19 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 		opts = append(opts, openaioption.WithHeader(k, v))
 	}
 
+	supportsStrict := provider != "ollama" && provider != "lm-studio" && provider != "llama-server" && provider != "unsloth"
+
 	var oaiTools []openai.ChatCompletionToolUnionParam
 	for _, t := range tools {
-		oaiTools = append(oaiTools, openai.ChatCompletionFunctionTool(shared.FunctionDefinitionParam{
+		fd := shared.FunctionDefinitionParam{
 			Name:        t.Name,
 			Description: openai.String(t.Description),
 			Parameters:  shared.FunctionParameters(t.Parameters),
-		}))
+		}
+		if t.Strict && supportsStrict {
+			fd.Strict = openai.Bool(true)
+		}
+		oaiTools = append(oaiTools, openai.ChatCompletionFunctionTool(fd))
 	}
 
 	p := &openaiProvider{
@@ -112,6 +118,15 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 
 func (p *openaiProvider) Name() string  { return p.provider }
 func (p *openaiProvider) Model() string { return p.model }
+
+func (p *openaiProvider) SupportsStrictSchema() bool {
+	switch p.provider {
+	case "ollama", "lm-studio", "llama-server", "unsloth":
+		return false
+	default:
+		return true
+	}
+}
 
 func (p *openaiProvider) Chat(ctx context.Context) (ChatResult, error) {
 	params := openai.ChatCompletionNewParams{

--- a/cmd/agent-runner/provider_test.go
+++ b/cmd/agent-runner/provider_test.go
@@ -26,7 +26,7 @@ type mockProvider struct {
 	replaceLog []map[string]string
 }
 
-func (p *mockProvider) Name() string              { return p.name }
+func (p *mockProvider) Name() string               { return p.name }
 func (p *mockProvider) Model() string              { return p.model }
 func (p *mockProvider) SupportsStrictSchema() bool { return true }
 

--- a/cmd/agent-runner/provider_test.go
+++ b/cmd/agent-runner/provider_test.go
@@ -26,8 +26,9 @@ type mockProvider struct {
 	replaceLog []map[string]string
 }
 
-func (p *mockProvider) Name() string  { return p.name }
-func (p *mockProvider) Model() string { return p.model }
+func (p *mockProvider) Name() string              { return p.name }
+func (p *mockProvider) Model() string              { return p.model }
+func (p *mockProvider) SupportsStrictSchema() bool { return true }
 
 func (p *mockProvider) Chat(ctx context.Context) (ChatResult, error) {
 	p.chatCalls++

--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -73,6 +73,7 @@ type ToolDef struct {
 	Name        string
 	Description string
 	Parameters  map[string]any
+	Strict      bool
 }
 
 // defaultTools returns the set of tools available to the agent.


### PR DESCRIPTION
## Summary

- Anthropic `Prompt()` path now builds a synthetic tool from the sidecar's JSON schema and forces `tool_choice` to extract structured JSON via `tool_use.Input`
- `ToolDef.Strict` field passes through to Anthropic and OpenAI tool definitions on the `Chat()` path; local providers silently drop it
- `SupportsStrictSchema()` method added to `LLMProvider` interface
- Azure OpenAI strict mode gated on API version >= 2024-08-01
- Empty seed message skipped in prompt-server mode (fixes `useContext=true` with Anthropic)
- Bedrock `SupportsStrictSchema()` returns false until strict metadata is implemented

## Test plan

- [x] Unit tests pass
- [x] Integration tested: Anthropic structured output via sidecar-driven AgentRun (useContext=true)
- [x] Integration tested: OpenAI structured output via sidecar-driven AgentRun

🤖 Generated with [Claude Code](https://claude.com/claude-code)