### PR TITLE
fix(harness): require digest-pinned adapter images

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -394,6 +394,13 @@ type AgentRunStatus struct {
 	// +optional
 	TraceID string `json:"traceID,omitempty"`
 
+	// HarnessImageDigest records the digest of the external harness adapter image
+	// that executed this run. Populated only for `task.mode: harness` runs, and
+	// only once the run has been admitted and dispatched. Empty for all other
+	// modes and backends.
+	// +optional
+	HarnessImageDigest string `json:"harnessImageDigest,omitempty"`
+
 	// PostRunJobName is the name of the Job created for postRun lifecycle hooks.
 	// +optional
 	PostRunJobName string `json:"postRunJobName,omitempty"`

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -2803,6 +2803,13 @@ spec:
                   One of: approved, rejected, rewritten, timeout, error, allowed-by-default.
                   Empty when no gate hook is configured.
                 type: string
+              harnessImageDigest:
+                description: |-
+                  HarnessImageDigest records the digest of the external harness adapter image
+                  that executed this run. Populated only for `task.mode: harness` runs, and
+                  only once the run has been admitted and dispatched. Empty for all other
+                  modes and backends.
+                type: string
               jobName:
                 description: JobName is the name of the Job created for this run.
                 type: string

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -2803,6 +2803,13 @@ spec:
                   One of: approved, rejected, rewritten, timeout, error, allowed-by-default.
                   Empty when no gate hook is configured.
                 type: string
+              harnessImageDigest:
+                description: |-
+                  HarnessImageDigest records the digest of the external harness adapter image
+                  that executed this run. Populated only for `task.mode: harness` runs, and
+                  only once the run has been admitted and dispatched. Empty for all other
+                  modes and backends.
+                type: string
               jobName:
                 description: JobName is the name of the Job created for this run.
                 type: string

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -2803,6 +2803,13 @@ spec:
                   One of: approved, rejected, rewritten, timeout, error, allowed-by-default.
                   Empty when no gate hook is configured.
                 type: string
+              harnessImageDigest:
+                description: |-
+                  HarnessImageDigest records the digest of the external harness adapter image
+                  that executed this run. Populated only for `task.mode: harness` runs, and
+                  only once the run has been admitted and dispatched. Empty for all other
+                  modes and backends.
+                type: string
               jobName:
                 description: JobName is the name of the Job created for this run.
                 type: string

--- a/config/samples/agentrun_harness.yaml
+++ b/config/samples/agentrun_harness.yaml
@@ -18,8 +18,8 @@ spec:
     enabled: true
   imagePolicy:
     allowedRegistries:
-      # This sample uses an exact tag. Prefer an exact digest in production.
-      - ghcr.io/acme/my-harness:v1
+      # Digest-pinned: harness images must be pinned, never a mutable tag.
+      - ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ---
 apiVersion: sympozium.ai/v1alpha1
 kind: Agent
@@ -49,8 +49,8 @@ spec:
     parameters:
       # Required. The adapter image that becomes the pod's primary process.
       # It keeps its own ENTRYPOINT — Sympozium imposes no argv on a binary it
-      # did not build.
-      image: ghcr.io/acme/my-harness:v1
+      # did not build. Digest-pinned (@sha256:…): a mutable tag is rejected.
+      image: ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       # Required. The task text. Object-form tasks have no top-level prompt
       # field, so harness mode takes it from here and sets TASK from it.
       prompt: "Review the latest pull request and provide feedback on code quality"

--- a/docs/modes/harness-adapters.md
+++ b/docs/modes/harness-adapters.md
@@ -170,12 +170,14 @@ concatenation is an injection hole.
 ## Publishing one
 
 Adapters are ordinary container images. Publish yours wherever you like and tell operators to
-add it to `SympoziumPolicy.imagePolicy.allowedRegistries`.
+add it to `SympoziumPolicy.imagePolicy.allowedRegistries` **by digest**. Harness images must be
+digest-pinned (`@sha256:…`) — a mutable tag is rejected at admission and by the controller —
+so publish a stable digest and give operators that, not `:latest`.
 
 Give them a **specific** prefix to add, not just the registry host. That list is matched by
-string prefix, so `docker.io/` admits all of Docker Hub while `ghcr.io/you/my-harness:` admits
-only your releases. Ending the entry at a `/`, a full tag or a digest is what makes it mean
-what it looks like.
+string prefix, so `docker.io/` admits all of Docker Hub while `ghcr.io/you/my-harness@sha256:`
+admits only your releases. Ending the entry at a `/`, a full tag or a digest is what makes it
+mean what it looks like.
 
 Two things worth putting in the README, because operators cannot discover them from the image:
 

--- a/docs/modes/harness.md
+++ b/docs/modes/harness.md
@@ -50,7 +50,7 @@ spec:
     enabled: true
   imagePolicy:
     allowedRegistries:
-      - ghcr.io/acme/my-harness:v1
+      - ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ---
 apiVersion: sympozium.ai/v1alpha1
 kind: Agent
@@ -75,7 +75,7 @@ spec:
   task:
     mode: harness
     parameters:
-      image: ghcr.io/acme/my-harness:v1
+      image: ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       prompt: "Review the latest pull request and comment on code quality"
       capabilities: "persona"
   systemPrompt: "You are a careful reviewer."
@@ -90,7 +90,7 @@ spec:
 
 | Parameter | Required | Meaning |
 |---|---|---|
-| `image` | yes | The adapter image that becomes the pod's primary process. Bounded by `SympoziumPolicy.imagePolicy.allowedRegistries`. |
+| `image` | yes | The adapter image that becomes the pod's primary process. Must be **digest-pinned** (`@sha256:…`); a mutable tag is rejected. Bounded by `SympoziumPolicy.imagePolicy.allowedRegistries`. |
 | `prompt` | yes | The task text. Object-form tasks carry no top-level prompt field, so harness mode takes it from here and sets `TASK` from it. |
 | `capabilities` | no | Comma-separated list of what the image honours. Empty means it claims nothing. |
 | `args` | no | Extra argv, as a **JSON array string** (`'["--profile","headless"]'`). `parameters` is `map[string]string`, so an array has to travel encoded. |
@@ -347,6 +347,12 @@ The harness gate and the image allowlist are separate controls:
 | `harnessPolicy.enabled: true`, but no `imagePolicy` | Harness execution is enabled with no image restriction. This is experimental-only and not recommended for shared clusters. |
 | `harnessPolicy.enabled: true` and `allowedRegistries` is empty | Harness execution is enabled with no image restriction. |
 
+A third, independent control always applies to the image itself: **it must be digest-pinned.**
+A tag-only or otherwise unpinned reference is rejected regardless of the allowlist, because
+`v1` can be retagged under the operator and the harness image is the pod's primary process.
+The digest Sympozium admitted is recorded on `status.harnessImageDigest`, so run detail and
+audit can show exactly which artifact executed rather than which tag was requested.
+
 The check runs in **both** the admission webhook and the controller. The webhook gives the
 better error, at `kubectl apply` time; the controller repeats it because the webhook is a
 separate, optional deployment, and a cluster without it would otherwise have no bound at all
@@ -359,6 +365,7 @@ on which external harness executes. A rejection there fails the run with the ima
 |---|---|
 | `parameters.image` missing | Run fails validation in the controller with the missing-parameter name; no pod is created. |
 | Image outside `allowedRegistries` | **Denied at admission**, naming the image; and again in the controller, which fails the run without creating a Job. |
+| Image not digest-pinned (`:tag`, bare name, truncated digest) | **Denied at admission and by the controller**, naming the digest-pinning requirement; no pod is created. |
 | No explicit `harnessPolicy.enabled: true` | **Denied at admission and by the controller**; no pod is created. |
 | Explicit opt-in but no image allowlist | Admitted with no image restriction; use only for controlled experimentation. |
 | A capability is requested but not declared | **Denied at admission**, naming the mode and the capability. |

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -787,6 +787,13 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		ar.Status.JobName = job.Name
 		ar.Status.StartedAt = &now
 
+		// Record the exact harness artifact that is about to execute, so run
+		// detail and audit can show which digest ran rather than which tag was
+		// requested.
+		if d := taskmodes.HarnessImageDigest(agentRun.Spec.Task); d != "" {
+			ar.Status.HarnessImageDigest = d
+		}
+
 		// Set the trace ID so operators can look up the full distributed trace.
 		if sc := span.SpanContext(); sc.HasTraceID() {
 			ar.Status.TraceID = sc.TraceID().String()

--- a/internal/controller/agentrun_harness_mode_test.go
+++ b/internal/controller/agentrun_harness_mode_test.go
@@ -40,8 +40,10 @@ func harnessModeRun(params map[string]string) *sympoziumv1alpha1.AgentRun {
 	return r
 }
 
-// harnessTestImage stands in for any operator-supplied adapter image.
-const harnessTestImage = "ghcr.io/acme/my-harness:v1"
+// harnessTestImage stands in for any operator-supplied adapter image. It is
+// digest-pinned because harness images must be: the digest is the trust anchor
+// that admission and the controller record.
+const harnessTestImage = "ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 func containerByName(cs []corev1.Container, name string) *corev1.Container {
 	for i := range cs {

--- a/internal/controller/taskmodes/harness.go
+++ b/internal/controller/taskmodes/harness.go
@@ -75,6 +75,46 @@ const (
 	harnessIPCOutPath   = "/ipc/output"
 )
 
+// digestAlgorithms maps the digest algorithms Sympozium accepts on an external
+// harness image reference to the expected lowercase-hex length of that digest.
+// Only well-known OCI algorithms are accepted; anything else is treated as
+// unpinned and rejected rather than guessed at.
+var digestAlgorithms = map[string]int{
+	"sha256": 64,
+	"sha384": 96,
+	"sha512": 128,
+}
+
+// parseImageDigest returns the digest (algorithm:hex) of a digest-pinned OCI
+// image reference, or ("", false) when the reference carries no valid digest.
+//
+// A reference may name a tag as well as a digest ("name:tag@sha256:…"); the
+// digest is the part after the last "@", and is the authoritative identifier
+// for a pull. The strict form check matters: an external harness image becomes
+// the pod's primary process, so a typo'd or truncated digest must not be read
+// as "pinned".
+func parseImageDigest(image string) (string, bool) {
+	at := strings.LastIndex(image, "@")
+	if at < 0 || at == len(image)-1 {
+		return "", false
+	}
+	digest := image[at+1:]
+	algo, hex, ok := strings.Cut(digest, ":")
+	if !ok {
+		return "", false
+	}
+	want, known := digestAlgorithms[algo]
+	if !known || len(hex) != want {
+		return "", false
+	}
+	for _, c := range hex {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return "", false
+		}
+	}
+	return digest, true
+}
+
 // Task parameter keys recognised by harness mode.
 const (
 	// harnessParamPrompt carries the task text. Object-form tasks have no
@@ -146,6 +186,14 @@ func (h *HarnessHandler) Validate(task *sympoziumv1alpha1.TaskSpec) error {
 	if strings.TrimSpace(task.Parameters[harnessParamImage]) == "" {
 		return fmt.Errorf("harness: task.parameters.%s is required (the adapter image that becomes the pod's primary process; Sympozium ships none)",
 			harnessParamImage)
+	}
+
+	// The image becomes the pod's primary process and receives the run's model
+	// and MCP credentials, so a mutable tag is not an acceptable trust anchor:
+	// "v1" can be retagged under the operator. Require a digest-pinned reference
+	// so the exact artifact is fixed and can be recorded on the run.
+	if _, ok := parseImageDigest(strings.TrimSpace(task.Parameters[harnessParamImage])); !ok {
+		return fmt.Errorf("harness: task.parameters.%s must be a digest-pinned OCI reference (e.g. \"ghcr.io/acme/my-harness@sha256:<64-hex>\"); tag-only or unpinned references are rejected", harnessParamImage)
 	}
 
 	if strings.TrimSpace(task.Parameters[harnessParamPrompt]) == "" {
@@ -277,6 +325,18 @@ func HarnessImage(task *sympoziumv1alpha1.TaskSpec) string {
 		return ""
 	}
 	return strings.TrimSpace(task.Parameters[harnessParamImage])
+}
+
+// HarnessImageDigest returns the digest of a digest-pinned harness image, or ""
+// when the task is not harness mode or the image carries no digest. The
+// controller records this on AgentRun.status.harnessImageDigest so operators can
+// see exactly which artifact executed.
+func HarnessImageDigest(task *sympoziumv1alpha1.TaskSpec) string {
+	if task == nil || task.IsString() || task.GetMode() != Harness {
+		return ""
+	}
+	digest, _ := parseImageDigest(strings.TrimSpace(task.Parameters[harnessParamImage]))
+	return digest
 }
 
 // harnessArgs parses task.parameters.args, a JSON array of strings appended

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -23,6 +23,11 @@ func TestRegistry_HarnessRegistered(t *testing.T) {
 	}
 }
 
+// harnessTestImage is a digest-pinned harness reference for fixtures. Harness
+// images must be digest-pinned — see HarnessHandler.Validate — so the default
+// here carries a well-formed sha256 digest.
+const harnessTestImage = "ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 // harnessTask builds an object-form harness task. Every harness task names an
 // image — Sympozium builds none — so the helper defaults one.
 func harnessTask(params map[string]string) *sympoziumv1alpha1.TaskSpec {
@@ -33,7 +38,7 @@ func harnessTask(params map[string]string) *sympoziumv1alpha1.TaskSpec {
 		params[harnessParamPrompt] = "summarise the incident"
 	}
 	if _, ok := params[harnessParamImage]; !ok {
-		params[harnessParamImage] = "ghcr.io/acme/my-harness:v1"
+		params[harnessParamImage] = harnessTestImage
 	}
 	return &sympoziumv1alpha1.TaskSpec{
 		Mode:       Harness,
@@ -70,13 +75,56 @@ func TestHarnessHandler_Validate_RequiresPrompt(t *testing.T) {
 	h := NewHarnessHandler()
 	err := h.Validate(&sympoziumv1alpha1.TaskSpec{
 		Mode:       Harness,
-		Parameters: map[string]string{harnessParamImage: "ghcr.io/acme/my-harness:v1"},
+		Parameters: map[string]string{harnessParamImage: harnessTestImage},
 	})
 	if err == nil {
 		t.Fatal("Validate(no prompt) returned nil; expected error")
 	}
 	if !strings.Contains(err.Error(), harnessParamPrompt) {
 		t.Errorf("error should name the missing parameter, got: %v", err)
+	}
+}
+
+// The image becomes the pod's primary process and receives the run's model and
+// MCP credentials, so a mutable tag is not an acceptable trust anchor. Every
+// tag-only or otherwise unpinned reference must be rejected, not silently
+// pinned to whatever the tag resolves to today.
+func TestHarnessHandler_Validate_RejectsUnpinnedImage(t *testing.T) {
+	h := NewHarnessHandler()
+	for _, tc := range []struct {
+		name  string
+		image string
+	}{
+		{name: "tag-only", image: "ghcr.io/acme/my-harness:v1"},
+		{name: "bare-name", image: "ghcr.io/acme/my-harness"},
+		{name: "truncated-digest", image: "ghcr.io/acme/my-harness@sha256:deadbeef"},
+		{name: "uppercase-hex", image: "ghcr.io/acme/my-harness@sha256:" + strings.Repeat("A", 64)},
+		{name: "unknown-algorithm", image: "ghcr.io/acme/my-harness@md5:" + strings.Repeat("0", 32)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := h.Validate(harnessTask(map[string]string{harnessParamImage: tc.image}))
+			if err == nil {
+				t.Fatalf("Validate(%q) returned nil; expected digest-pinning rejection", tc.image)
+			}
+			if !strings.Contains(err.Error(), "digest-pinned") {
+				t.Errorf("error should mention the digest-pinning requirement, got: %v", err)
+			}
+		})
+	}
+}
+
+// A well-formed digest-pinned reference is accepted, including the legitimate
+// name:tag@digest form where the digest remains authoritative.
+func TestHarnessHandler_Validate_AcceptsDigestPinnedImage(t *testing.T) {
+	h := NewHarnessHandler()
+	for _, image := range []string{
+		harnessTestImage,
+		"ghcr.io/acme/my-harness:v1@sha256:" + strings.Repeat("b", 64),
+		"registry.local/adapter@sha512:" + strings.Repeat("c", 128),
+	} {
+		if err := h.Validate(harnessTask(map[string]string{harnessParamImage: image})); err != nil {
+			t.Errorf("Validate(%q) returned error: %v", image, err)
+		}
 	}
 }
 
@@ -223,7 +271,7 @@ func TestHarnessHandler_Override_UsesSuppliedImageAndItsOwnEntrypoint(t *testing
 	if err != nil {
 		t.Fatalf("OverrideAgentContainer returned error: %v", err)
 	}
-	if override.Image != "ghcr.io/acme/my-harness:v1" {
+	if override.Image != harnessTestImage {
 		t.Errorf("Image = %q, want the operator's reference", override.Image)
 	}
 	// Sympozium has no argv to impose on a binary it did not build.
@@ -420,7 +468,7 @@ func TestReplacesAgentContainer(t *testing.T) {
 // ── HarnessImage (admission's image-policy hook) ────────────────────────────
 
 func TestHarnessImage(t *testing.T) {
-	if got := HarnessImage(harnessTask(nil)); got != "ghcr.io/acme/my-harness:v1" {
+	if got := HarnessImage(harnessTask(nil)); got != harnessTestImage {
 		t.Errorf("HarnessImage = %q, want the operator's reference for imagePolicy to check", got)
 	}
 	if got := HarnessImage(&sympoziumv1alpha1.TaskSpec{Mode: SidecarDriven, Tool: "primary"}); got != "" {
@@ -431,6 +479,26 @@ func TestHarnessImage(t *testing.T) {
 	}
 	if got := HarnessImage(nil); got != "" {
 		t.Errorf("HarnessImage(nil) = %q, want empty", got)
+	}
+}
+
+func TestHarnessImageDigest(t *testing.T) {
+	if got := HarnessImageDigest(harnessTask(nil)); got != "sha256:"+strings.Repeat("a", 64) {
+		t.Errorf("HarnessImageDigest = %q, want the pinned sha256 digest", got)
+	}
+	if got := HarnessImageDigest(&sympoziumv1alpha1.TaskSpec{Mode: SidecarDriven, Tool: "primary"}); got != "" {
+		t.Errorf("HarnessImageDigest(other mode) = %q, want empty", got)
+	}
+	if got := HarnessImageDigest(sympoziumv1alpha1.NewStringTask("do it")); got != "" {
+		t.Errorf("HarnessImageDigest(string form) = %q, want empty", got)
+	}
+	if got := HarnessImageDigest(nil); got != "" {
+		t.Errorf("HarnessImageDigest(nil) = %q, want empty", got)
+	}
+	// A tag-only reference has no digest to record.
+	unpinned := harnessTask(map[string]string{harnessParamImage: "ghcr.io/acme/my-harness:v1"})
+	if got := HarnessImageDigest(unpinned); got != "" {
+		t.Errorf("HarnessImageDigest(tag-only) = %q, want empty", got)
 	}
 }
 

--- a/internal/webhook/task_mode_capabilities_test.go
+++ b/internal/webhook/task_mode_capabilities_test.go
@@ -61,7 +61,7 @@ func harnessTaskSpec(params map[string]string) *sympoziumv1alpha1.TaskSpec {
 		params["prompt"] = "summarise the incident"
 	}
 	if _, ok := params["image"]; !ok {
-		params["image"] = "ghcr.io/acme/my-harness:v1"
+		params["image"] = "ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	}
 	return &sympoziumv1alpha1.TaskSpec{
 		Mode:       taskmodes.Harness,
@@ -113,6 +113,21 @@ func TestPolicyEnforcer_RejectsUnmediatedHarnessCapabilityClaim(t *testing.T) {
 	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))
 	if resp.Allowed || !strings.Contains(resp.Result.Message, taskmodes.CapabilityResume) {
 		t.Fatalf("response allowed=%v message=%q, want unsupported claim denial", resp.Allowed, resp.Result.Message)
+	}
+}
+
+// A harness image must be digest-pinned: a tag can be retagged under the
+// operator, so it is not an acceptable trust anchor for the pod's primary
+// process. The denial must happen at admission, before any pod exists.
+func TestPolicyEnforcer_RejectsUnpinnedHarnessImage(t *testing.T) {
+	pe := capabilityEnforcer(t)
+	run := capabilityRun(harnessTaskSpec(map[string]string{
+		"image": "ghcr.io/acme/my-harness:v1",
+	}))
+
+	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))
+	if resp.Allowed || !strings.Contains(resp.Result.Message, "digest-pinned") {
+		t.Fatalf("response allowed=%v message=%q, want digest-pinning denial", resp.Allowed, resp.Result.Message)
 	}
 }
 
@@ -305,7 +320,7 @@ func TestPolicyEnforcer_DeniesHarnessImageOutsideAllowedRegistries(t *testing.T)
 	pe := &PolicyEnforcer{Client: cl, Log: logr.Discard(), Decoder: decoderFor(t, scheme)}
 
 	run := capabilityRun(harnessTaskSpec(map[string]string{
-		"image": "docker.io/someone/unvetted-harness:latest",
+		"image": "docker.io/someone/unvetted-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}))
 
 	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))
@@ -340,7 +355,7 @@ func TestPolicyEnforcer_AllowsHarnessImageInsideAllowedRegistries(t *testing.T) 
 	pe := &PolicyEnforcer{Client: cl, Log: logr.Discard(), Decoder: decoderFor(t, scheme)}
 
 	run := capabilityRun(harnessTaskSpec(map[string]string{
-		"image": "ghcr.io/acme/my-harness:v1",
+		"image": "ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}))
 
 	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))

--- a/test/integration/test-harness-mode.sh
+++ b/test/integration/test-harness-mode.sh
@@ -33,8 +33,10 @@ POLICY_NAME="${INSTANCE_NAME}-policy"
 HARNESS_AUTH_SECRET="${HARNESS_AUTH_SECRET:-}"
 
 # Sympozium builds no harness images, so the test supplies its own. The
-# stand-in below is the smallest thing that honours the adapter contract.
-STANDIN_IMAGE="${HARNESS_STANDIN_IMAGE:-alpine:3.20}"
+# stand-in below is the smallest thing that honours the adapter contract, and
+# it is digest-pinned because harness images must be (a mutable tag is
+# rejected). Override with HARNESS_STANDIN_IMAGE to point at a real adapter.
+STANDIN_IMAGE="${HARNESS_STANDIN_IMAGE:-alpine@sha256:c64c687cbea9300178b30c95835354e34c4e4febc4badfe27102879de0483b5e}"
 
 # LM Studio via node-probe proxy — only used for the Agent's model config; the
 # harness itself is what answers.
@@ -300,6 +302,15 @@ else
   fail "status.tokenUsage is present (${TOKEN_USAGE}); the adapter should omit metrics it cannot source"
 fi
 
+# 6b. The exact artifact that ran is recorded, not the mutable tag.
+EXPECTED_DIGEST="${STANDIN_IMAGE##*@}"
+ACTUAL_DIGEST="$(kubectl get agentrun "$RUN_NAME" -n "$NAMESPACE" -o jsonpath='{.status.harnessImageDigest}' 2>/dev/null || echo "")"
+if [[ "$ACTUAL_DIGEST" == "$EXPECTED_DIGEST" ]]; then
+  pass "status.harnessImageDigest records the exact artifact (${ACTUAL_DIGEST})"
+else
+  fail "status.harnessImageDigest = '${ACTUAL_DIGEST}' (expected '${EXPECTED_DIGEST}')"
+fi
+
 # ── 7. An undeclared capability is rejected at admission ─────────────────────
 #
 # The image below declares only `persona`, so a run that also sets
@@ -382,6 +393,45 @@ else
   fail "admission ACCEPTED mode: harness on backend: celln; the harness image would be silently ignored"
 fi
 rm -f "$CELLNCHECK_STDERR"
+
+# ── 9. A tag-only harness image is rejected at admission ──────────────────────
+#
+# The image becomes the pod's primary process, so a mutable tag is not an
+# acceptable trust anchor. A tag-only reference must be denied before any pod
+# exists, not silently pinned to whatever the tag resolves to today.
+
+info "Checking that a tag-only harness image is rejected at admission"
+TAGCHECK_STDERR="$(mktemp)"
+cat <<EOF | kubectl create --dry-run=server -n "$NAMESPACE" -f - >/dev/null 2>"$TAGCHECK_STDERR" || true
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: ${RUN_NAME}-tagcheck
+spec:
+  agentRef: ${INSTANCE_NAME}
+  agentId: primary
+  sessionKey: harness-tagcheck
+  task:
+    mode: harness
+    parameters:
+      prompt: "anything"
+      image: alpine:3.20
+  model:
+    provider: openai-compatible
+    model: ${LM_STUDIO_MODEL}
+    baseURL: ${LM_STUDIO_BASE_URL}
+    authSecretRef: ""
+  timeout: "1m"
+EOF
+
+if grep -q "digest-pinned" "$TAGCHECK_STDERR"; then
+  pass "admission denied the tag-only image, naming the digest-pinning requirement"
+elif [[ -s "$TAGCHECK_STDERR" ]]; then
+  fail "run was rejected, but not for the digest-pinning requirement: $(head -c 300 "$TAGCHECK_STDERR")"
+else
+  fail "admission ACCEPTED a tag-only harness image; it must be rejected"
+fi
+rm -f "$TAGCHECK_STDERR"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

First follow-up slice of #349, stacked on #350. Closes the "canonical, digest-pinned OCI references" and "record the resolved digest" P0 items.

An external harness image becomes the pod's primary process and receives the run's model and MCP credentials, so a mutable tag (`:v1`, `:latest`) is not an acceptable trust anchor — it can be retagged under the operator. This requires a digest-pinned reference and records what actually ran.

## Changes

- **Require digest-pinned images**: `HarnessHandler.Validate` rejects tag-only, bare-name, truncated, non-hex, and unknown-algorithm references. Enforcement lives in the handler, so it applies at admission (`taskmodes.ValidateTask`) and again in the controller (`resolveTaskModeAdjustments`) without duplicating the check.
- **Record the digest**: new `status.harnessImageDigest` field, set by the controller at the Running transition, so run detail and audit show the exact artifact that executed.
- **Tests**: handler accept/reject matrix, `HarnessImageDigest` accessor, webhook admission denial for unpinned images, plus an integration assertion that `status.harnessImageDigest` matches the admitted digest and that a tag-only image is denied at admission.
- **Docs + sample**: harness.md / harness-adapters.md updated; BYO sample and integration stand-in switched to digest-pinned references.

## Notes

- Signature/attestation policy is intentionally **not** in this slice; digest-pinning is the trust anchor that later enables it.
- Runtime-profile selection remains on the epic; this is a prerequisite, since a profile cannot pin an adapter until digests are the canonical form.
