### PR TITLE
feat(harness): reference an approved AgentRuntime from a run

### DIFF
--- a/api/v1alpha1/agentruntime_types.go
+++ b/api/v1alpha1/agentruntime_types.go
@@ -5,6 +5,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// AgentRuntimeReadyCondition is the condition type the AgentRuntime controller
+// sets when the spec validates (image digest-pinned, capabilities supported).
+// Admission and the AgentRun reconciler check it before binding a runtime to a
+// run, so a runtime referenced by name fails closed until it is Ready.
+const AgentRuntimeReadyCondition = "Ready"
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Digest",type=string,JSONPath=`.status.resolvedImageDigest`

--- a/docs/modes/harness.md
+++ b/docs/modes/harness.md
@@ -90,9 +90,10 @@ spec:
 
 | Parameter | Required | Meaning |
 |---|---|---|
-| `image` | yes | The adapter image that becomes the pod's primary process. Must be **digest-pinned** (`@sha256:…`); a mutable tag is rejected. Bounded by `SympoziumPolicy.imagePolicy.allowedRegistries`. |
+| `image` | one of `image`/`runtime` | The adapter image that becomes the pod's primary process. Must be **digest-pinned** (`@sha256:…`); a mutable tag is rejected. Bounded by `SympoziumPolicy.imagePolicy.allowedRegistries`. |
+| `runtime` | one of `image`/`runtime` | The name of an admin-approved [`AgentRuntime`](#the-agentruntime-resource) in the run's namespace. The runtime supplies the digest-pinned image and capabilities. Mutually exclusive with `image`. |
 | `prompt` | yes | The task text. Object-form tasks carry no top-level prompt field, so harness mode takes it from here and sets `TASK` from it. |
-| `capabilities` | no | Comma-separated list of what the image honours. Empty means it claims nothing. |
+| `capabilities` | no | Comma-separated list of what the image honours. Empty means it claims nothing. Ignored when `runtime` is set — the runtime's own declaration wins. |
 | `args` | no | Extra argv, as a **JSON array string** (`'["--profile","headless"]'`). `parameters` is `map[string]string`, so an array has to travel encoded. |
 
 The image keeps its own `ENTRYPOINT`. Sympozium has no argv to impose on a binary it did not
@@ -387,9 +388,24 @@ condition. The same rules as inline harness mode apply: the image must be digest
 `outputSchema` / `subagents` / `resume` are rejected because no external runtime can implement
 them safely yet.
 
+A run references a runtime by name instead of repeating its image and capability claims:
+
+```yaml
+task:
+  mode: harness
+  parameters:
+    runtime: codex-v1
+    prompt: "Review the latest pull request"
+```
+
+Admission and the controller resolve the runtime into its image and capabilities before any
+other check, so the image allowlist, digest recording, and capability gating apply to the
+resolved values exactly as they do for an inline image. A runtime that does not exist or is
+not `Ready` is rejected at admission.
+
 Binding a runtime to an Agent — so channels, schedules, ensembles, the API and the UI inherit
-it without object-form task authoring — is the next step on the epic and is **not** wired up
-yet. Until then, runs still author the task inline.
+it without authoring `task.parameters.runtime` per run — is the next step on the epic and is
+**not** wired up yet.
 
 ## Graceful degradation
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -676,6 +676,21 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		agentRun.Spec.Model.AuthSecretRef = "" // cluster-internal, no auth needed
 	}
 
+	// Resolve a harness runtime reference into inline image/capabilities so the
+	// policy check, task-mode dispatch, and pod build all see resolved values
+	// instead of a runtime name.
+	if normalized, err := taskmodes.NormalizeHarnessTask(agentRun.Namespace, agentRun.Spec.Task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
+		var rt sympoziumv1alpha1.AgentRuntime
+		if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &rt); err != nil {
+			return nil, err
+		}
+		return &rt, nil
+	}); err != nil {
+		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("runtime resolution failed: %v", err))
+	} else {
+		agentRun.Spec.Task = normalized
+	}
+
 	// Validate against policy
 	if err := r.validatePolicy(ctx, agentRun); err != nil {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("policy validation failed: %v", err))

--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -16,8 +16,6 @@ import (
 	"github.com/sympozium-ai/sympozium/internal/controller/taskmodes"
 )
 
-const agentRuntimeReadyCondition = "Ready"
-
 // AgentRuntimeReconciler reconciles AgentRuntime objects. It is a validation
 // gate, not a deployment controller: the runtime is an external image
 // Sympozium does not run, so the reconciler's job is to verify the spec is
@@ -80,7 +78,7 @@ func (r *AgentRuntimeReconciler) validate(runtime *sympoziumv1alpha1.AgentRuntim
 func (r *AgentRuntimeReconciler) updateStatus(ctx context.Context, runtime *sympoziumv1alpha1.AgentRuntime, digest, reason string) (ctrl.Result, error) {
 	if digest != "" {
 		meta.SetStatusCondition(&runtime.Status.Conditions, metav1.Condition{
-			Type:               agentRuntimeReadyCondition,
+			Type:               sympoziumv1alpha1.AgentRuntimeReadyCondition,
 			Status:             metav1.ConditionTrue,
 			Reason:             "Validated",
 			Message:            "spec validated; runtime is ready to bind",
@@ -89,7 +87,7 @@ func (r *AgentRuntimeReconciler) updateStatus(ctx context.Context, runtime *symp
 		runtime.Status.ResolvedImageDigest = digest
 	} else {
 		meta.SetStatusCondition(&runtime.Status.Conditions, metav1.Condition{
-			Type:               agentRuntimeReadyCondition,
+			Type:               sympoziumv1alpha1.AgentRuntimeReadyCondition,
 			Status:             metav1.ConditionFalse,
 			Reason:             "Invalid",
 			Message:            reason,

--- a/internal/controller/taskmodes/harness.go
+++ b/internal/controller/taskmodes/harness.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
@@ -93,6 +94,10 @@ const (
 	// operator asserts their image honours. Nothing is assumed: an image
 	// Sympozium did not build gets no claims by default.
 	harnessParamCapabilities = "capabilities"
+	// harnessParamRuntime references an administrator-approved AgentRuntime in
+	// the run's namespace by name. When set, the runtime supplies the image and
+	// capabilities; it is mutually exclusive with the inline harnessParamImage.
+	harnessParamRuntime = "runtime"
 )
 
 // HarnessHandler is the TaskModeHandler for harness mode. It leaves the
@@ -143,17 +148,28 @@ func (h *HarnessHandler) Validate(task *sympoziumv1alpha1.TaskSpec) error {
 		return fmt.Errorf("harness: task is nil")
 	}
 
-	if strings.TrimSpace(task.Parameters[harnessParamImage]) == "" {
-		return fmt.Errorf("harness: task.parameters.%s is required (the adapter image that becomes the pod's primary process; Sympozium ships none)",
-			harnessParamImage)
+	image := strings.TrimSpace(task.Parameters[harnessParamImage])
+	runtimeName := strings.TrimSpace(task.Parameters[harnessParamRuntime])
+
+	if image == "" && runtimeName == "" {
+		return fmt.Errorf("harness: task.parameters requires either %q (an adapter image) or %q (an AgentRuntime reference); Sympozium ships no default",
+			harnessParamImage, harnessParamRuntime)
+	}
+	if image != "" && runtimeName != "" {
+		return fmt.Errorf("harness: set exactly one of task.parameters.%s or task.parameters.%s, not both",
+			harnessParamImage, harnessParamRuntime)
 	}
 
 	// The image becomes the pod's primary process and receives the run's model
 	// and MCP credentials, so a mutable tag is not an acceptable trust anchor:
 	// "v1" can be retagged under the operator. Require a digest-pinned reference
-	// so the exact artifact is fixed and can be recorded on the run.
-	if _, ok := sympoziumv1alpha1.ParseImageDigest(strings.TrimSpace(task.Parameters[harnessParamImage])); !ok {
-		return fmt.Errorf("harness: task.parameters.%s must be a digest-pinned OCI reference (e.g. \"ghcr.io/acme/my-harness@sha256:<64-hex>\"); tag-only or unpinned references are rejected", harnessParamImage)
+	// so the exact artifact is fixed and can be recorded on the run. A runtime
+	// reference skips this here: its image is checked after NormalizeHarnessTask
+	// substitutes it (and the AgentRuntime controller already vets it).
+	if image != "" {
+		if _, ok := sympoziumv1alpha1.ParseImageDigest(image); !ok {
+			return fmt.Errorf("harness: task.parameters.%s must be a digest-pinned OCI reference (e.g. \"ghcr.io/acme/my-harness@sha256:<64-hex>\"); tag-only or unpinned references are rejected", harnessParamImage)
+		}
 	}
 
 	if strings.TrimSpace(task.Parameters[harnessParamPrompt]) == "" {
@@ -297,6 +313,47 @@ func HarnessImageDigest(task *sympoziumv1alpha1.TaskSpec) string {
 	}
 	digest, _ := sympoziumv1alpha1.ParseImageDigest(strings.TrimSpace(task.Parameters[harnessParamImage]))
 	return digest
+}
+
+// NormalizeHarnessTask resolves a harness task's runtime reference into its
+// canonical inline form, so the rest of the pipeline (Validate, image policy,
+// OverrideAgentContainer, digest recording) sees only resolved values. When the
+// task names parameters.runtime, getRuntime fetches the AgentRuntime, its image
+// and capabilities are substituted, and the runtime reference is dropped. A
+// runtime that does not exist or is not Ready fails closed here. Non-harness
+// tasks, string-form tasks, and inline-image harness tasks are returned
+// unchanged.
+func NormalizeHarnessTask(namespace string, task *sympoziumv1alpha1.TaskSpec, getRuntime func(namespace, name string) (*sympoziumv1alpha1.AgentRuntime, error)) (*sympoziumv1alpha1.TaskSpec, error) {
+	if task == nil || task.IsString() || task.GetMode() != Harness {
+		return task, nil
+	}
+	runtimeName := strings.TrimSpace(task.Parameters[harnessParamRuntime])
+	if runtimeName == "" {
+		return task, nil
+	}
+
+	rt, err := getRuntime(namespace, runtimeName)
+	if err != nil {
+		return nil, fmt.Errorf("harness: resolving runtime %q: %w", runtimeName, err)
+	}
+	if !meta.IsStatusConditionTrue(rt.Status.Conditions, sympoziumv1alpha1.AgentRuntimeReadyCondition) {
+		return nil, fmt.Errorf("harness: runtime %q is not Ready; fix the AgentRuntime or choose another", runtimeName)
+	}
+
+	normalized := *task
+	params := make(map[string]string, len(task.Parameters)+2)
+	for k, v := range task.Parameters {
+		if k == harnessParamRuntime {
+			continue
+		}
+		params[k] = v
+	}
+	params[harnessParamImage] = rt.Spec.Image
+	if len(rt.Spec.Capabilities) > 0 {
+		params[harnessParamCapabilities] = strings.Join(rt.Spec.Capabilities, ",")
+	}
+	normalized.Parameters = params
+	return &normalized, nil
 }
 
 // harnessArgs parses task.parameters.args, a JSON array of strings appended

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -1,11 +1,13 @@
 package taskmodes
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
@@ -82,6 +84,39 @@ func TestHarnessHandler_Validate_RequiresPrompt(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), harnessParamPrompt) {
 		t.Errorf("error should name the missing parameter, got: %v", err)
+	}
+}
+
+// A harness task must name exactly one of an inline image or a runtime
+// reference. Naming both is ambiguous, naming neither means Sympozium has no
+// primary process to run.
+func TestHarnessHandler_Validate_RequiresExactlyOneOfImageOrRuntime(t *testing.T) {
+	h := NewHarnessHandler()
+	if err := h.Validate(&sympoziumv1alpha1.TaskSpec{
+		Mode:       Harness,
+		Parameters: map[string]string{harnessParamPrompt: "do it"},
+	}); err == nil {
+		t.Fatal("Validate(neither) returned nil; expected error")
+	}
+	if err := h.Validate(&sympoziumv1alpha1.TaskSpec{
+		Mode: Harness,
+		Parameters: map[string]string{
+			harnessParamPrompt:  "do it",
+			harnessParamImage:   harnessTestImage,
+			harnessParamRuntime: "codex-v1",
+		},
+	}); err == nil {
+		t.Fatal("Validate(both) returned nil; expected error")
+	}
+	// A runtime reference alone is acceptable: the image is resolved later.
+	if err := h.Validate(&sympoziumv1alpha1.TaskSpec{
+		Mode: Harness,
+		Parameters: map[string]string{
+			harnessParamPrompt:  "do it",
+			harnessParamRuntime: "codex-v1",
+		},
+	}); err != nil {
+		t.Errorf("Validate(runtime only) returned error: %v", err)
 	}
 }
 
@@ -499,6 +534,101 @@ func TestHarnessImageDigest(t *testing.T) {
 	unpinned := harnessTask(map[string]string{harnessParamImage: "ghcr.io/acme/my-harness:v1"})
 	if got := HarnessImageDigest(unpinned); got != "" {
 		t.Errorf("HarnessImageDigest(tag-only) = %q, want empty", got)
+	}
+}
+
+// readyRuntime returns an AgentRuntime whose Ready condition is true, so
+// NormalizeHarnessTask accepts it.
+func readyRuntime(name string, capabilities ...string) *sympoziumv1alpha1.AgentRuntime {
+	rt := &sympoziumv1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: sympoziumv1alpha1.AgentRuntimeSpec{
+			Image:        "ghcr.io/acme/my-harness@sha256:" + strings.Repeat("a", 64),
+			Capabilities: capabilities,
+		},
+	}
+	meta.SetStatusCondition(&rt.Status.Conditions, metav1.Condition{
+		Type:    sympoziumv1alpha1.AgentRuntimeReadyCondition,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Validated",
+		Message: "spec validated",
+	})
+	return rt
+}
+
+func TestNormalizeHarnessTask_ResolvesRuntimeIntoInlineForm(t *testing.T) {
+	runtimes := map[string]*sympoziumv1alpha1.AgentRuntime{"codex-v1": readyRuntime("codex-v1", "persona")}
+	task := &sympoziumv1alpha1.TaskSpec{
+		Mode:       Harness,
+		Parameters: map[string]string{harnessParamPrompt: "do it", harnessParamRuntime: "codex-v1"},
+	}
+
+	got, err := NormalizeHarnessTask("default", task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
+		rt, ok := runtimes[name]
+		if !ok {
+			return nil, fmt.Errorf("not found")
+		}
+		return rt, nil
+	})
+	if err != nil {
+		t.Fatalf("NormalizeHarnessTask returned error: %v", err)
+	}
+	if got.Parameters[harnessParamImage] != "ghcr.io/acme/my-harness@sha256:"+strings.Repeat("a", 64) {
+		t.Errorf("normalized image = %q", got.Parameters[harnessParamImage])
+	}
+	if got.Parameters[harnessParamCapabilities] != "persona" {
+		t.Errorf("normalized capabilities = %q, want persona", got.Parameters[harnessParamCapabilities])
+	}
+	if _, present := got.Parameters[harnessParamRuntime]; present {
+		t.Error("runtime reference was not dropped from the normalized task")
+	}
+	// The original task is not mutated.
+	if _, present := task.Parameters[harnessParamImage]; present {
+		t.Error("NormalizeHarnessTask mutated the input task's parameters")
+	}
+}
+
+func TestNormalizeHarnessTask_RejectsMissingOrNotReadyRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		runtime *sympoziumv1alpha1.AgentRuntime
+		found   bool
+	}{
+		{name: "missing"},
+		{name: "not-ready", runtime: &sympoziumv1alpha1.AgentRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: "codex-v1", Namespace: "default"},
+			Spec:       sympoziumv1alpha1.AgentRuntimeSpec{Image: "ghcr.io/acme/my-harness@sha256:" + strings.Repeat("a", 64)},
+		}, found: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &sympoziumv1alpha1.TaskSpec{
+				Mode:       Harness,
+				Parameters: map[string]string{harnessParamPrompt: "do it", harnessParamRuntime: "codex-v1"},
+			}
+			_, err := NormalizeHarnessTask("default", task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
+				if !tc.found {
+					return nil, fmt.Errorf("not found")
+				}
+				return tc.runtime, nil
+			})
+			if err == nil {
+				t.Fatal("NormalizeHarnessTask accepted a missing/not-ready runtime")
+			}
+		})
+	}
+}
+
+func TestNormalizeHarnessTask_PassesThroughNonRuntimeTasks(t *testing.T) {
+	inline := harnessTask(nil)
+	if got, err := NormalizeHarnessTask("default", inline, nil); err != nil || got != inline {
+		t.Fatalf("inline harness task should pass through unchanged: %v, %v", got, err)
+	}
+	sidecar := &sympoziumv1alpha1.TaskSpec{Mode: SidecarDriven, Tool: "primary"}
+	if got, err := NormalizeHarnessTask("default", sidecar, nil); err != nil || got != sidecar {
+		t.Fatalf("non-harness task should pass through unchanged: %v, %v", got, err)
+	}
+	if got, err := NormalizeHarnessTask("default", nil, nil); err != nil || got != nil {
+		t.Fatalf("nil task should pass through unchanged: %v, %v", got, err)
 	}
 }
 

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -92,6 +92,21 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Allowed("run is being deleted; skipping policy validation")
 	}
 
+	// Resolve a harness runtime reference into inline image/capabilities before
+	// any other check, so image policy, capability, and digest validation all
+	// see the resolved values rather than a runtime name they cannot use.
+	normalized, err := taskmodes.NormalizeHarnessTask(run.Namespace, run.Spec.Task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
+		var rt sympoziumv1alpha1.AgentRuntime
+		if err := pe.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &rt); err != nil {
+			return nil, err
+		}
+		return &rt, nil
+	})
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+	run.Spec.Task = normalized
+
 	// Look up the owning Agent
 	var instance sympoziumv1alpha1.Agent
 	if err := pe.Client.Get(ctx, types.NamespacedName{

--- a/internal/webhook/task_mode_capabilities_test.go
+++ b/internal/webhook/task_mode_capabilities_test.go
@@ -131,6 +131,64 @@ func TestPolicyEnforcer_RejectsUnpinnedHarnessImage(t *testing.T) {
 	}
 }
 
+// A harness run may reference an admin-approved AgentRuntime by name instead of
+// naming an image. Admission resolves the runtime and applies the same image
+// and capability checks to the resolved values.
+func TestPolicyEnforcer_ResolvesRuntimeReference(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	agent := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentSpec{PolicyRef: "harness-enabled"},
+	}
+	policy := &sympoziumv1alpha1.SympoziumPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: "default"},
+		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+		},
+	}
+	runtimeObj := &sympoziumv1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "codex-v1", Namespace: "default"},
+		Spec: sympoziumv1alpha1.AgentRuntimeSpec{
+			Image:        "ghcr.io/acme/codex-adapter@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Capabilities: []string{taskmodes.CapabilityPersona},
+		},
+		Status: sympoziumv1alpha1.AgentRuntimeStatus{
+			Conditions: []metav1.Condition{{Type: sympoziumv1alpha1.AgentRuntimeReadyCondition, Status: metav1.ConditionTrue, Reason: "Validated"}},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, policy, runtimeObj).Build()
+	pe := &PolicyEnforcer{Client: cl, Log: logr.Discard(), Decoder: decoderFor(t, scheme)}
+
+	run := capabilityRun(&sympoziumv1alpha1.TaskSpec{
+		Mode:       taskmodes.Harness,
+		Parameters: map[string]string{"prompt": "do it", "runtime": "codex-v1"},
+	})
+	run.Spec.SystemPrompt = "You are a careful reviewer."
+
+	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))
+	if !resp.Allowed {
+		t.Fatalf("expected ALLOW for a ready runtime reference; denied: %s", resp.Result.Message)
+	}
+}
+
+// A run referencing a runtime that does not exist (or is not Ready) fails
+// closed at admission rather than admitting an unresolved image.
+func TestPolicyEnforcer_RejectsMissingRuntime(t *testing.T) {
+	pe := capabilityEnforcer(t)
+	run := capabilityRun(&sympoziumv1alpha1.TaskSpec{
+		Mode:       taskmodes.Harness,
+		Parameters: map[string]string{"prompt": "do it", "runtime": "nope"},
+	})
+
+	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))
+	if resp.Allowed || !strings.Contains(resp.Result.Message, "runtime") {
+		t.Fatalf("response allowed=%v message=%q, want runtime-resolution denial", resp.Allowed, resp.Result.Message)
+	}
+}
+
 // An image that declares nothing gets nothing: a run asking for enforcement
 // the image never claimed is denied rather than admitted and degraded.
 func TestPolicyEnforcer_DeniesUnsupportedCapability(t *testing.T) {


### PR DESCRIPTION
## Summary

Second half of the runtime-profile work from #349. The `AgentRuntime` CRD landed in #353; this makes it usable from object-form runs.

A harness run can now name `task.parameters.runtime` instead of an inline image. Admission and the controller resolve the `AgentRuntime` into its digest-pinned image and capabilities **before** any other check, so the image allowlist, digest recording, and capability gating all apply to the resolved values exactly as for an inline image.

## Changes

- `task.parameters.runtime` as an alternative to `task.parameters.image` (mutually exclusive; exactly one required).
- `taskmodes.NormalizeHarnessTask` resolves a runtime reference into canonical inline form (substitutes image + capabilities, drops `runtime`), failing closed on a missing or not-`Ready` runtime. Shared by admission and the controller.
- `AgentRuntimeReadyCondition` exported as a shared constant so consumers check the reconciler's `Ready` condition.
- Wiring in the admission webhook (`Handle`) and the controller reconcile path, both before validation.
- Tests: `Validate` XOR, `NormalizeHarnessTask` accept/reject, webhook resolve-and-admit + missing-runtime denial.
- Docs: `runtime` parameter and a usage example.

## Out of scope

Agent-level inheritance (`Agent.spec.runtimeRef`) so channels/schedules/ensembles/API/UI inherit a runtime without per-run authoring — that is the next slice and closes the "supported product path" half of #349.
