### PR TITLE
feat(harness): inherit an Agent runtime across all run entrypoints

### DIFF
--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -33,6 +33,15 @@ type AgentSpec struct {
 	// +optional
 	PolicyRef string `json:"policyRef,omitempty"`
 
+	// RuntimeRef references an administrator-approved AgentRuntime that
+	// replaces agent-runner as the primary process for this Agent's runs. When
+	// set, a harness run that names neither an inline image nor a runtime
+	// inherits this runtime — the mechanism by which channels, schedules,
+	// ensembles, the API, and the UI select an external runtime without
+	// object-form task authoring.
+	// +optional
+	RuntimeRef string `json:"runtimeRef,omitempty"`
+
 	// AuthRefs references secrets containing AI provider credentials.
 	// +optional
 	AuthRefs []SecretRef `json:"authRefs,omitempty"`

--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -34,11 +34,10 @@ type AgentSpec struct {
 	PolicyRef string `json:"policyRef,omitempty"`
 
 	// RuntimeRef references an administrator-approved AgentRuntime that
-	// replaces agent-runner as the primary process for this Agent's runs. When
-	// set, a harness run that names neither an inline image nor a runtime
-	// inherits this runtime — the mechanism by which channels, schedules,
-	// ensembles, the API, and the UI select an external runtime without
-	// object-form task authoring.
+	// replaces agent-runner as the primary process for this Agent's ordinary
+	// string-form runs. Those runs are dispatched through harness mode with this
+	// runtime and their original task as the prompt. An explicit object-form
+	// harness task may still select an image or runtime itself.
 	// +optional
 	RuntimeRef string `json:"runtimeRef,omitempty"`
 

--- a/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
@@ -2826,11 +2826,10 @@ spec:
               runtimeRef:
                 description: |-
                   RuntimeRef references an administrator-approved AgentRuntime that
-                  replaces agent-runner as the primary process for this Agent's runs. When
-                  set, a harness run that names neither an inline image nor a runtime
-                  inherits this runtime — the mechanism by which channels, schedules,
-                  ensembles, the API, and the UI select an external runtime without
-                  object-form task authoring.
+                  replaces agent-runner as the primary process for this Agent's ordinary
+                  string-form runs. Those runs are dispatched through harness mode with this
+                  runtime and their original task as the prompt. An explicit object-form
+                  harness task may still select an image or runtime itself.
                 type: string
               skills:
                 description: Skills to mount (from SkillPack CRDs or ConfigMaps).

--- a/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
@@ -2823,6 +2823,15 @@ spec:
                 description: PolicyRef references the SympoziumPolicy that applies
                   to this instance.
                 type: string
+              runtimeRef:
+                description: |-
+                  RuntimeRef references an administrator-approved AgentRuntime that
+                  replaces agent-runner as the primary process for this Agent's runs. When
+                  set, a harness run that names neither an inline image nor a runtime
+                  inherits this runtime — the mechanism by which channels, schedules,
+                  ensembles, the API, and the UI select an external runtime without
+                  object-form task authoring.
+                type: string
               skills:
                 description: Skills to mount (from SkillPack CRDs or ConfigMaps).
                 items:

--- a/charts/sympozium/crds/sympozium.ai_agents.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agents.yaml
@@ -2826,11 +2826,10 @@ spec:
               runtimeRef:
                 description: |-
                   RuntimeRef references an administrator-approved AgentRuntime that
-                  replaces agent-runner as the primary process for this Agent's runs. When
-                  set, a harness run that names neither an inline image nor a runtime
-                  inherits this runtime — the mechanism by which channels, schedules,
-                  ensembles, the API, and the UI select an external runtime without
-                  object-form task authoring.
+                  replaces agent-runner as the primary process for this Agent's ordinary
+                  string-form runs. Those runs are dispatched through harness mode with this
+                  runtime and their original task as the prompt. An explicit object-form
+                  harness task may still select an image or runtime itself.
                 type: string
               skills:
                 description: Skills to mount (from SkillPack CRDs or ConfigMaps).

--- a/charts/sympozium/crds/sympozium.ai_agents.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agents.yaml
@@ -2823,6 +2823,15 @@ spec:
                 description: PolicyRef references the SympoziumPolicy that applies
                   to this instance.
                 type: string
+              runtimeRef:
+                description: |-
+                  RuntimeRef references an administrator-approved AgentRuntime that
+                  replaces agent-runner as the primary process for this Agent's runs. When
+                  set, a harness run that names neither an inline image nor a runtime
+                  inherits this runtime — the mechanism by which channels, schedules,
+                  ensembles, the API, and the UI select an external runtime without
+                  object-form task authoring.
+                type: string
               skills:
                 description: Skills to mount (from SkillPack CRDs or ConfigMaps).
                 items:

--- a/config/crd/bases/sympozium.ai_agents.yaml
+++ b/config/crd/bases/sympozium.ai_agents.yaml
@@ -2826,11 +2826,10 @@ spec:
               runtimeRef:
                 description: |-
                   RuntimeRef references an administrator-approved AgentRuntime that
-                  replaces agent-runner as the primary process for this Agent's runs. When
-                  set, a harness run that names neither an inline image nor a runtime
-                  inherits this runtime — the mechanism by which channels, schedules,
-                  ensembles, the API, and the UI select an external runtime without
-                  object-form task authoring.
+                  replaces agent-runner as the primary process for this Agent's ordinary
+                  string-form runs. Those runs are dispatched through harness mode with this
+                  runtime and their original task as the prompt. An explicit object-form
+                  harness task may still select an image or runtime itself.
                 type: string
               skills:
                 description: Skills to mount (from SkillPack CRDs or ConfigMaps).

--- a/config/crd/bases/sympozium.ai_agents.yaml
+++ b/config/crd/bases/sympozium.ai_agents.yaml
@@ -2823,6 +2823,15 @@ spec:
                 description: PolicyRef references the SympoziumPolicy that applies
                   to this instance.
                 type: string
+              runtimeRef:
+                description: |-
+                  RuntimeRef references an administrator-approved AgentRuntime that
+                  replaces agent-runner as the primary process for this Agent's runs. When
+                  set, a harness run that names neither an inline image nor a runtime
+                  inherits this runtime — the mechanism by which channels, schedules,
+                  ensembles, the API, and the UI select an external runtime without
+                  object-form task authoring.
+                type: string
               skills:
                 description: Skills to mount (from SkillPack CRDs or ConfigMaps).
                 items:

--- a/docs/modes/harness.md
+++ b/docs/modes/harness.md
@@ -403,8 +403,8 @@ other check, so the image allowlist, digest recording, and capability gating app
 resolved values exactly as they do for an inline image. A runtime that does not exist or is
 not `Ready` is rejected at admission.
 
-An Agent can bind a runtime so every run inherits it — including channel, schedule, ensemble,
-API, and UI runs — without authoring `task.parameters.runtime` per run:
+An Agent can bind a default runtime so its ordinary string-form runs inherit it — including
+channel, schedule, API, and UI runs — without authoring an object-form task:
 
 ```yaml
 apiVersion: sympozium.ai/v1alpha1
@@ -416,11 +416,13 @@ spec:
   # ...
 ```
 
-A run on that Agent still sets `task.mode: harness` but omits both `image` and `runtime`;
-the runtime comes from the Agent. An explicit `image` or `runtime` on the run overrides the
-Agent's `runtimeRef`. Agent-level runtime selection is not expressible through an Ensemble
-persona (it is an administrator decision, not a persona concept); set it out of band on the
-Agent.
+The controller converts the string task into harness mode, preserves the original text as the
+adapter prompt, and resolves the runtime from the Agent. An explicit object-form harness task
+with an `image` or `runtime` overrides the Agent default.
+
+Agent-level runtime selection is not expressible through an Ensemble persona because it is an
+administrator decision rather than a persona concept. Set it out of band on the generated
+Agent; Ensemble reconciliation preserves that administrator-owned field.
 
 ## Graceful degradation
 

--- a/docs/modes/harness.md
+++ b/docs/modes/harness.md
@@ -403,9 +403,24 @@ other check, so the image allowlist, digest recording, and capability gating app
 resolved values exactly as they do for an inline image. A runtime that does not exist or is
 not `Ready` is rejected at admission.
 
-Binding a runtime to an Agent — so channels, schedules, ensembles, the API and the UI inherit
-it without authoring `task.parameters.runtime` per run — is the next step on the epic and is
-**not** wired up yet.
+An Agent can bind a runtime so every run inherits it — including channel, schedule, ensemble,
+API, and UI runs — without authoring `task.parameters.runtime` per run:
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: Agent
+metadata:
+  name: my-agent
+spec:
+  runtimeRef: codex-v1
+  # ...
+```
+
+A run on that Agent still sets `task.mode: harness` but omits both `image` and `runtime`;
+the runtime comes from the Agent. An explicit `image` or `runtime` on the run overrides the
+Agent's `runtimeRef`. Agent-level runtime selection is not expressible through an Ensemble
+persona (it is an administrator decision, not a persona concept); set it out of band on the
+Agent.
 
 ## Graceful degradation
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -681,9 +681,13 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 	// instead of a runtime name. When the task names neither an image nor a
 	// runtime, the Agent's runtimeRef is inherited.
 	var runtimeInstance sympoziumv1alpha1.Agent
-	if err := r.Get(ctx, client.ObjectKey{Namespace: agentRun.Namespace, Name: agentRun.Spec.AgentRef}, &runtimeInstance); err == nil {
-		agentRun.Spec.Task = taskmodes.ApplyAgentRuntime(agentRun.Spec.Task, runtimeInstance.Spec.RuntimeRef)
+	if err := r.Get(ctx, client.ObjectKey{Namespace: agentRun.Namespace, Name: agentRun.Spec.AgentRef}, &runtimeInstance); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Agent %q not found while resolving runtime", agentRun.Spec.AgentRef))
+		}
+		return ctrl.Result{}, fmt.Errorf("reading Agent %q while resolving runtime: %w", agentRun.Spec.AgentRef, err)
 	}
+	agentRun.Spec.Task = taskmodes.ApplyAgentRuntime(agentRun.Spec.Task, runtimeInstance.Spec.RuntimeRef)
 	if normalized, err := taskmodes.NormalizeHarnessTask(agentRun.Namespace, agentRun.Spec.Task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
 		var rt sympoziumv1alpha1.AgentRuntime
 		if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &rt); err != nil {

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -678,7 +678,12 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 
 	// Resolve a harness runtime reference into inline image/capabilities so the
 	// policy check, task-mode dispatch, and pod build all see resolved values
-	// instead of a runtime name.
+	// instead of a runtime name. When the task names neither an image nor a
+	// runtime, the Agent's runtimeRef is inherited.
+	var runtimeInstance sympoziumv1alpha1.Agent
+	if err := r.Get(ctx, client.ObjectKey{Namespace: agentRun.Namespace, Name: agentRun.Spec.AgentRef}, &runtimeInstance); err == nil {
+		agentRun.Spec.Task = taskmodes.ApplyAgentRuntime(agentRun.Spec.Task, runtimeInstance.Spec.RuntimeRef)
+	}
 	if normalized, err := taskmodes.NormalizeHarnessTask(agentRun.Namespace, agentRun.Spec.Task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
 		var rt sympoziumv1alpha1.AgentRuntime
 		if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &rt); err != nil {

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -313,10 +313,11 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 		// existing Agents with no change here — the field-by-field form had to be
 		// extended for each one and drifted behind buildAgent (see #264).
 		//
-		// AgentSpec carries no out-of-band state, so nothing is carried over from
-		// the existing object. Fields buildAgent never sets are cleared; they are
-		// listed in agentFieldsNotExpressibleByEnsemble in ensemble_parity_test.go.
+		// Runtime selection is administrator-owned rather than persona-owned, so
+		// retain an out-of-band runtimeRef while converging every Ensemble-owned
+		// field to buildAgent's desired spec.
 		desired := r.buildAgent(pack, persona, instanceName, modelEndpoint)
+		desired.Spec.RuntimeRef = existingInst.Spec.RuntimeRef
 
 		needsUpdate := false
 		specDrifted := !reflect.DeepEqual(existingInst.Spec, desired.Spec)

--- a/internal/controller/ensemble_parity_test.go
+++ b/internal/controller/ensemble_parity_test.go
@@ -46,6 +46,7 @@ var agentFieldsNotExpressibleByEnsemble = map[string]string{
 	"Agents.Default.Thinking":     "no AgentConfigSpec field; per-Agent thinking mode is not an ensemble concept",
 	"Agents.Default.Sandbox":      "no AgentConfigSpec field; ensembles configure agentSandbox instead",
 	"Agents.Default.NodeSelector": "no AgentConfigSpec field; placement is not expressible per persona",
+	"RuntimeRef":                  "runtime selection is an administrator decision, not a persona concept; bind it out of band or add an AgentConfigSpec field",
 	"WebEndpoint":                 "superseded by the web-endpoint skill, which buildDesiredSkills adds from persona.webEndpoint",
 	"ImagePullSecrets":            "no EnsembleSpec field; cluster-level registry credentials are not an ensemble concept",
 }

--- a/internal/controller/ensemble_parity_test.go
+++ b/internal/controller/ensemble_parity_test.go
@@ -46,9 +46,16 @@ var agentFieldsNotExpressibleByEnsemble = map[string]string{
 	"Agents.Default.Thinking":     "no AgentConfigSpec field; per-Agent thinking mode is not an ensemble concept",
 	"Agents.Default.Sandbox":      "no AgentConfigSpec field; ensembles configure agentSandbox instead",
 	"Agents.Default.NodeSelector": "no AgentConfigSpec field; placement is not expressible per persona",
-	"RuntimeRef":                  "runtime selection is an administrator decision, not a persona concept; bind it out of band or add an AgentConfigSpec field",
 	"WebEndpoint":                 "superseded by the web-endpoint skill, which buildDesiredSkills adds from persona.webEndpoint",
 	"ImagePullSecrets":            "no EnsembleSpec field; cluster-level registry credentials are not an ensemble concept",
+}
+
+// agentFieldsPreservedOutOfBand are intentionally not derived from an Ensemble
+// but survive reconciliation because a different owner is authoritative for
+// them. Keep this list small: every entry is an exception to whole-spec
+// convergence and needs explicit reconciliation code plus a preservation test.
+var agentFieldsPreservedOutOfBand = map[string]string{
+	"RuntimeRef": "runtime selection is administrator-owned rather than persona-owned",
 }
 
 // ── the properties ────────────────────────────────────────────────────────────
@@ -67,6 +74,7 @@ func TestAgentUpdateConvergesToCreate(t *testing.T) {
 	// A persisted Agent whose spec is entirely wrong.
 	drifted := wantAgent.DeepCopy()
 	fillStruct(t, reflect.ValueOf(&drifted.Spec).Elem(), 0)
+	wantAgent.Spec.RuntimeRef = drifted.Spec.RuntimeRef
 
 	r := newEnsembleTestReconciler(t, drifted)
 	if _, err := r.reconcileAgentConfig(context.Background(), logr.Discard(), pack, persona, 0, ""); err != nil {
@@ -79,6 +87,23 @@ func TestAgentUpdateConvergesToCreate(t *testing.T) {
 		t.Errorf("update path did not converge at %s\n  buildAgent (create): %s\n  after update:        %s\n\n"+
 			"reconcileAgentConfig assigns the whole spec from buildAgent; a difference here means "+
 			"something is mutating the spec after that assignment.", d.path, d.a, d.b)
+	}
+}
+
+func TestAgentRuntimeRefSurvivesEnsembleReconcile(t *testing.T) {
+	pack, persona := convergenceFixture()
+	instanceName := agentInstanceName(pack, persona)
+	existing := (&EnsembleReconciler{}).buildAgent(pack, persona, instanceName, "")
+	existing.Spec.RuntimeRef = "codex-v1"
+
+	r := newEnsembleTestReconciler(t, existing)
+	if _, err := r.reconcileAgentConfig(context.Background(), logr.Discard(), pack, persona, 0, ""); err != nil {
+		t.Fatalf("reconcileAgentConfig: %v", err)
+	}
+
+	got := getAgent(t, r, instanceName, existing.Namespace)
+	if got.Spec.RuntimeRef != "codex-v1" {
+		t.Fatalf("runtimeRef = %q after Ensemble reconcile, want administrator-owned value preserved", got.Spec.RuntimeRef)
 	}
 }
 
@@ -197,9 +222,16 @@ func TestAgentSpecFieldsAreEnsembleExpressible(t *testing.T) {
 				t.Errorf("agentFieldsNotExpressibleByEnsemble[%q] says %q, but buildAgent does set it — delete the entry",
 					path, reason)
 			}
+			if reason, declared := agentFieldsPreservedOutOfBand[path]; declared {
+				t.Errorf("agentFieldsPreservedOutOfBand[%q] says %q, but buildAgent does set it — delete the entry",
+					path, reason)
+			}
 			continue
 		}
 		if _, declared := agentFieldsNotExpressibleByEnsemble[path]; declared {
+			continue
+		}
+		if _, declared := agentFieldsPreservedOutOfBand[path]; declared {
 			continue
 		}
 		t.Errorf("buildAgent leaves AgentSpec.%s unset.\n"+
@@ -222,12 +254,17 @@ func TestInexpressibleFieldsHaveReasons(t *testing.T) {
 	for _, p := range enumerateFieldPaths(specType, "") {
 		valid[p] = true
 	}
-	for path, reason := range agentFieldsNotExpressibleByEnsemble {
-		if strings.TrimSpace(reason) == "" {
-			t.Errorf("agentFieldsNotExpressibleByEnsemble[%q] has an empty reason", path)
-		}
-		if !valid[path] {
-			t.Errorf("agentFieldsNotExpressibleByEnsemble[%q]: no such AgentSpec field path — delete the entry", path)
+	for listName, fields := range map[string]map[string]string{
+		"agentFieldsNotExpressibleByEnsemble": agentFieldsNotExpressibleByEnsemble,
+		"agentFieldsPreservedOutOfBand":       agentFieldsPreservedOutOfBand,
+	} {
+		for path, reason := range fields {
+			if strings.TrimSpace(reason) == "" {
+				t.Errorf("%s[%q] has an empty reason", listName, path)
+			}
+			if !valid[path] {
+				t.Errorf("%s[%q]: no such AgentSpec field path — delete the entry", listName, path)
+			}
 		}
 	}
 }

--- a/internal/controller/taskmodes/harness.go
+++ b/internal/controller/taskmodes/harness.go
@@ -315,19 +315,29 @@ func HarnessImageDigest(task *sympoziumv1alpha1.TaskSpec) string {
 	return digest
 }
 
-// ApplyAgentRuntime fills in a harness task's runtime reference from the
-// Agent's spec.runtimeRef when the task names neither an inline image nor a
-// runtime. It returns the (possibly unchanged) task. This is what lets a
-// channel, schedule, ensemble, API, or UI run inherit the Agent's runtime
-// without authoring task.parameters.runtime per run.
+// ApplyAgentRuntime applies an Agent's default runtime to a task. String-form
+// tasks are converted to harness mode while preserving their prompt; this is
+// the path used by channels, schedules, the API, the UI, and other ordinary run
+// entrypoints. An object-form harness task inherits the runtime only when it
+// names neither an inline image nor an explicit runtime.
 func ApplyAgentRuntime(task *sympoziumv1alpha1.TaskSpec, agentRuntimeRef string) *sympoziumv1alpha1.TaskSpec {
-	if task == nil || task.IsString() || task.GetMode() != Harness {
+	runtimeRef := strings.TrimSpace(agentRuntimeRef)
+	if task == nil || runtimeRef == "" {
+		return task
+	}
+	if task.IsString() {
+		return &sympoziumv1alpha1.TaskSpec{
+			Mode: Harness,
+			Parameters: map[string]string{
+				harnessParamPrompt:  task.GetPrompt(),
+				harnessParamRuntime: runtimeRef,
+			},
+		}
+	}
+	if task.GetMode() != Harness {
 		return task
 	}
 	if strings.TrimSpace(task.Parameters[harnessParamImage]) != "" || strings.TrimSpace(task.Parameters[harnessParamRuntime]) != "" {
-		return task
-	}
-	if strings.TrimSpace(agentRuntimeRef) == "" {
 		return task
 	}
 
@@ -336,7 +346,7 @@ func ApplyAgentRuntime(task *sympoziumv1alpha1.TaskSpec, agentRuntimeRef string)
 	for k, v := range task.Parameters {
 		params[k] = v
 	}
-	params[harnessParamRuntime] = agentRuntimeRef
+	params[harnessParamRuntime] = runtimeRef
 	cp.Parameters = params
 	return &cp
 }

--- a/internal/controller/taskmodes/harness.go
+++ b/internal/controller/taskmodes/harness.go
@@ -315,6 +315,32 @@ func HarnessImageDigest(task *sympoziumv1alpha1.TaskSpec) string {
 	return digest
 }
 
+// ApplyAgentRuntime fills in a harness task's runtime reference from the
+// Agent's spec.runtimeRef when the task names neither an inline image nor a
+// runtime. It returns the (possibly unchanged) task. This is what lets a
+// channel, schedule, ensemble, API, or UI run inherit the Agent's runtime
+// without authoring task.parameters.runtime per run.
+func ApplyAgentRuntime(task *sympoziumv1alpha1.TaskSpec, agentRuntimeRef string) *sympoziumv1alpha1.TaskSpec {
+	if task == nil || task.IsString() || task.GetMode() != Harness {
+		return task
+	}
+	if strings.TrimSpace(task.Parameters[harnessParamImage]) != "" || strings.TrimSpace(task.Parameters[harnessParamRuntime]) != "" {
+		return task
+	}
+	if strings.TrimSpace(agentRuntimeRef) == "" {
+		return task
+	}
+
+	cp := *task
+	params := make(map[string]string, len(task.Parameters)+1)
+	for k, v := range task.Parameters {
+		params[k] = v
+	}
+	params[harnessParamRuntime] = agentRuntimeRef
+	cp.Parameters = params
+	return &cp
+}
+
 // NormalizeHarnessTask resolves a harness task's runtime reference into its
 // canonical inline form, so the rest of the pipeline (Validate, image policy,
 // OverrideAgentContainer, digest recording) sees only resolved values. When the

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -632,6 +632,45 @@ func TestNormalizeHarnessTask_PassesThroughNonRuntimeTasks(t *testing.T) {
 	}
 }
 
+func TestApplyAgentRuntime_FillsInMissingRuntime(t *testing.T) {
+	task := &sympoziumv1alpha1.TaskSpec{
+		Mode:       Harness,
+		Parameters: map[string]string{harnessParamPrompt: "do it"},
+	}
+	got := ApplyAgentRuntime(task, "codex-v1")
+	if got.Parameters[harnessParamRuntime] != "codex-v1" {
+		t.Fatalf("ApplyAgentRuntime did not inject runtime ref: %v", got.Parameters)
+	}
+	if task.Parameters[harnessParamRuntime] != "" {
+		t.Fatal("ApplyAgentRuntime mutated the input task")
+	}
+}
+
+func TestApplyAgentRuntime_DoesNotOverrideExplicitImageOrRuntime(t *testing.T) {
+	withImage := harnessTask(nil)
+	if got := ApplyAgentRuntime(withImage, "codex-v1"); got.Parameters[harnessParamRuntime] != "" {
+		t.Fatalf("explicit image should not be overridden by Agent runtimeRef: %v", got.Parameters)
+	}
+	withRuntime := &sympoziumv1alpha1.TaskSpec{
+		Mode:       Harness,
+		Parameters: map[string]string{harnessParamPrompt: "do it", harnessParamRuntime: "other"},
+	}
+	if got := ApplyAgentRuntime(withRuntime, "codex-v1"); got.Parameters[harnessParamRuntime] != "other" {
+		t.Fatalf("explicit runtime should not be overridden by Agent runtimeRef: %v", got.Parameters)
+	}
+	// Empty Agent runtimeRef, non-harness task, and nil task are all no-ops.
+	if got := ApplyAgentRuntime(harnessTask(nil), ""); got.Parameters[harnessParamRuntime] != "" {
+		t.Fatal("empty Agent runtimeRef should not inject")
+	}
+	sidecar := &sympoziumv1alpha1.TaskSpec{Mode: SidecarDriven, Tool: "primary"}
+	if got := ApplyAgentRuntime(sidecar, "codex-v1"); got != sidecar {
+		t.Fatal("non-harness task should pass through unchanged")
+	}
+	if got := ApplyAgentRuntime(nil, "codex-v1"); got != nil {
+		t.Fatal("nil task should pass through unchanged")
+	}
+}
+
 // ── Capability gating against an AgentRun ───────────────────────────────────
 
 func harnessRun(task *sympoziumv1alpha1.TaskSpec) *sympoziumv1alpha1.AgentRun {

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -646,6 +646,23 @@ func TestApplyAgentRuntime_FillsInMissingRuntime(t *testing.T) {
 	}
 }
 
+func TestApplyAgentRuntime_ConvertsStringTask(t *testing.T) {
+	task := sympoziumv1alpha1.NewStringTask("do it through the normal entrypoint")
+	got := ApplyAgentRuntime(task, "  codex-v1  ")
+	if got.IsString() || got.GetMode() != Harness {
+		t.Fatalf("ApplyAgentRuntime did not convert string task to harness mode: %+v", got)
+	}
+	if got.Parameters[harnessParamRuntime] != "codex-v1" {
+		t.Errorf("runtime = %q, want trimmed Agent runtimeRef", got.Parameters[harnessParamRuntime])
+	}
+	if got.Parameters[harnessParamPrompt] != "do it through the normal entrypoint" {
+		t.Errorf("prompt = %q, want original string task", got.Parameters[harnessParamPrompt])
+	}
+	if !task.IsString() || task.GetPrompt() != "do it through the normal entrypoint" {
+		t.Fatal("ApplyAgentRuntime mutated the input string task")
+	}
+}
+
 func TestApplyAgentRuntime_DoesNotOverrideExplicitImageOrRuntime(t *testing.T) {
 	withImage := harnessTask(nil)
 	if got := ApplyAgentRuntime(withImage, "codex-v1"); got.Parameters[harnessParamRuntime] != "" {

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -92,9 +92,22 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Allowed("run is being deleted; skipping policy validation")
 	}
 
+	// Look up the owning Agent
+	var instance sympoziumv1alpha1.Agent
+	if err := pe.Client.Get(ctx, types.NamespacedName{
+		Name:      run.Spec.AgentRef,
+		Namespace: run.Namespace,
+	}, &instance); err != nil {
+		return admission.Errored(http.StatusBadRequest,
+			fmt.Errorf("failed to find Agent %s: %w", run.Spec.AgentRef, err))
+	}
+
 	// Resolve a harness runtime reference into inline image/capabilities before
 	// any other check, so image policy, capability, and digest validation all
-	// see the resolved values rather than a runtime name they cannot use.
+	// see the resolved values rather than a runtime name they cannot use. When
+	// the task names neither an image nor a runtime, the Agent's runtimeRef is
+	// inherited.
+	run.Spec.Task = taskmodes.ApplyAgentRuntime(run.Spec.Task, instance.Spec.RuntimeRef)
 	normalized, err := taskmodes.NormalizeHarnessTask(run.Namespace, run.Spec.Task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
 		var rt sympoziumv1alpha1.AgentRuntime
 		if err := pe.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &rt); err != nil {
@@ -106,16 +119,6 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Denied(err.Error())
 	}
 	run.Spec.Task = normalized
-
-	// Look up the owning Agent
-	var instance sympoziumv1alpha1.Agent
-	if err := pe.Client.Get(ctx, types.NamespacedName{
-		Name:      run.Spec.AgentRef,
-		Namespace: run.Namespace,
-	}, &instance); err != nil {
-		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("failed to find Agent %s: %w", run.Spec.AgentRef, err))
-	}
 
 	// Validate user-supplied volumes (AgentRun + resolved SkillPack sidecars).
 	// This catches reserved-name collisions and same-name-different-source

--- a/internal/webhook/task_mode_capabilities_test.go
+++ b/internal/webhook/task_mode_capabilities_test.go
@@ -189,9 +189,10 @@ func TestPolicyEnforcer_RejectsMissingRuntime(t *testing.T) {
 	}
 }
 
-// A harness run that names neither an image nor a runtime inherits the Agent's
-// spec.runtimeRef. This is the path channels/schedules/ensembles/API/UI take to
-// select an external runtime without authoring task.parameters.runtime.
+// An ordinary string-form run inherits the Agent's spec.runtimeRef and is
+// validated as a harness run. This is the shape channels, schedules, the API,
+// and the UI create; testing an object-form harness task here would miss the
+// product entrypoints this inheritance exists to support.
 func TestPolicyEnforcer_InheritsAgentRuntimeRef(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
@@ -219,10 +220,7 @@ func TestPolicyEnforcer_InheritsAgentRuntimeRef(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, policy, runtimeObj).Build()
 	pe := &PolicyEnforcer{Client: cl, Log: logr.Discard(), Decoder: decoderFor(t, scheme)}
 
-	run := capabilityRun(&sympoziumv1alpha1.TaskSpec{
-		Mode:       taskmodes.Harness,
-		Parameters: map[string]string{"prompt": "do it"},
-	})
+	run := capabilityRun(sympoziumv1alpha1.NewStringTask("do it"))
 
 	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))
 	if !resp.Allowed {

--- a/internal/webhook/task_mode_capabilities_test.go
+++ b/internal/webhook/task_mode_capabilities_test.go
@@ -189,6 +189,47 @@ func TestPolicyEnforcer_RejectsMissingRuntime(t *testing.T) {
 	}
 }
 
+// A harness run that names neither an image nor a runtime inherits the Agent's
+// spec.runtimeRef. This is the path channels/schedules/ensembles/API/UI take to
+// select an external runtime without authoring task.parameters.runtime.
+func TestPolicyEnforcer_InheritsAgentRuntimeRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	agent := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentSpec{PolicyRef: "harness-enabled", RuntimeRef: "codex-v1"},
+	}
+	policy := &sympoziumv1alpha1.SympoziumPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: "default"},
+		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+		},
+	}
+	runtimeObj := &sympoziumv1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "codex-v1", Namespace: "default"},
+		Spec: sympoziumv1alpha1.AgentRuntimeSpec{
+			Image: "ghcr.io/acme/codex-adapter@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		Status: sympoziumv1alpha1.AgentRuntimeStatus{
+			Conditions: []metav1.Condition{{Type: sympoziumv1alpha1.AgentRuntimeReadyCondition, Status: metav1.ConditionTrue, Reason: "Validated"}},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, policy, runtimeObj).Build()
+	pe := &PolicyEnforcer{Client: cl, Log: logr.Discard(), Decoder: decoderFor(t, scheme)}
+
+	run := capabilityRun(&sympoziumv1alpha1.TaskSpec{
+		Mode:       taskmodes.Harness,
+		Parameters: map[string]string{"prompt": "do it"},
+	})
+
+	resp := pe.Handle(context.Background(), admissionRequestFor(t, run))
+	if !resp.Allowed {
+		t.Fatalf("expected ALLOW via inherited Agent runtimeRef; denied: %s", resp.Result.Message)
+	}
+}
+
 // An image that declares nothing gets nothing: a run asking for enforcement
 // the image never claimed is denied rather than admitted and degraded.
 func TestPolicyEnforcer_DeniesUnsupportedCapability(t *testing.T) {


### PR DESCRIPTION
## Summary

Completes the "supported product path" half of #349: an Agent can select a default runtime, and ordinary string-form AgentRuns created by channels, schedules, the API, web proxy, MCP proxy, and UI are converted to harness execution automatically.

`Agent.spec.runtimeRef` is administrator-owned configuration. For a string-form run, admission and the controller preserve the original task as the harness prompt, inject the Agent's runtime reference, and resolve it to the approved image and capabilities. An explicit object-form harness task may still select its own image or runtime under the existing policy controls.

`AgentRun` remains the invocation, lifecycle, cancellation, audit, and result object.

## Changes

- Added `Agent.spec.runtimeRef` and regenerated CRD/Helm copies.
- `taskmodes.ApplyAgentRuntime`:
  - converts ordinary string tasks to `mode: harness` while preserving the prompt;
  - fills a missing runtime on object-form harness tasks;
  - leaves explicit object-form image/runtime selections and unrelated task modes unchanged.
- Wired inheritance into admission and controller reconciliation.
- Controller Agent lookup now fails closed instead of silently skipping runtime inheritance.
- Ensemble reconciliation preserves an out-of-band administrator-set `runtimeRef`.
- Added focused tests for:
  - string-task conversion and prompt preservation;
  - object-form inheritance and override behavior;
  - webhook admission using the actual string task shape produced by normal entrypoints;
  - Ensemble runtimeRef preservation.
- Updated harness documentation to distinguish the Agent default from explicit object-form overrides.

## Verification

- `make generate`
- `go test ./...`
- `go test -race ./internal/controller/taskmodes ./internal/webhook ./internal/controller ./api/v1alpha1`
- Live object-form inheritance and negative admission case were verified before the follow-up correction.

## Follow-up

Resolution hardening is tracked in #357. The remaining #349 work includes per-run identity/token isolation, NATS ACLs, signature/attestation, MCP conformance, and BYO examples/conformance suites.
