### PR TITLE
feat(security): isolate Kubernetes identity per AgentRun

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -571,7 +571,7 @@ type LifecycleHooks struct {
 
 	// RBAC defines namespace-scoped Kubernetes RBAC rules to create for
 	// lifecycle hook containers. A Role and RoleBinding are provisioned
-	// in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+	// in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
 	// This allows hooks to interact with Kubernetes resources (e.g., create
 	// or delete ConfigMaps, read Secrets).
 	// +optional

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -381,7 +381,7 @@ spec:
                     description: |-
                       RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                       lifecycle hook containers. A Role and RoleBinding are provisioned
-                      in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                      in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                       This allows hooks to interact with Kubernetes resources (e.g., create
                       or delete ConfigMaps, read Secrets).
                     items:

--- a/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
@@ -343,7 +343,7 @@ spec:
                             description: |-
                               RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                               lifecycle hook containers. A Role and RoleBinding are provisioned
-                              in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                              in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                               This allows hooks to interact with Kubernetes resources (e.g., create
                               or delete ConfigMaps, read Secrets).
                             items:

--- a/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
@@ -393,7 +393,7 @@ spec:
                           description: |-
                             RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                             lifecycle hook containers. A Role and RoleBinding are provisioned
-                            in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                            in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                             This allows hooks to interact with Kubernetes resources (e.g., create
                             or delete ConfigMaps, read Secrets).
                           items:

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -381,7 +381,7 @@ spec:
                     description: |-
                       RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                       lifecycle hook containers. A Role and RoleBinding are provisioned
-                      in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                      in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                       This allows hooks to interact with Kubernetes resources (e.g., create
                       or delete ConfigMaps, read Secrets).
                     items:

--- a/charts/sympozium/crds/sympozium.ai_agents.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agents.yaml
@@ -343,7 +343,7 @@ spec:
                             description: |-
                               RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                               lifecycle hook containers. A Role and RoleBinding are provisioned
-                              in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                              in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                               This allows hooks to interact with Kubernetes resources (e.g., create
                               or delete ConfigMaps, read Secrets).
                             items:

--- a/charts/sympozium/crds/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium/crds/sympozium.ai_ensembles.yaml
@@ -393,7 +393,7 @@ spec:
                           description: |-
                             RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                             lifecycle hook containers. A Role and RoleBinding are provisioned
-                            in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                            in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                             This allows hooks to interact with Kubernetes resources (e.g., create
                             or delete ConfigMaps, read Secrets).
                           items:

--- a/charts/sympozium/templates/rbac.yaml
+++ b/charts/sympozium/templates/rbac.yaml
@@ -17,6 +17,18 @@ metadata:
     {{- include "sympozium.labels" . | nindent 4 }}
     app.kubernetes.io/component: apiserver
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # Annotation template only. AgentRun pods use unique sympozium-run-* accounts
+  # that copy workload-identity annotations from this object.
+  name: sympozium-agent
+  namespace: {{ include "sympozium.namespace" . }}
+  labels:
+    {{- include "sympozium.labels" . | nindent 4 }}
+    app.kubernetes.io/component: identity-template
+automountServiceAccountToken: false
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -284,37 +296,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: sympozium-apiserver
-    namespace: {{ include "sympozium.namespace" . }}
----
-# Canary health-check RBAC — allows the system canary agent to list
-# cluster resources for deterministic health checks.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "sympozium.fullname" . }}-canary
-  labels:
-    {{- include "sympozium.labels" . | nindent 4 }}
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list"]
-  - apiGroups: ["sympozium.ai"]
-    resources: ["sympoziumschedules", "mcpservers"]
-    verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "sympozium.fullname" . }}-canary
-  labels:
-    {{- include "sympozium.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "sympozium.fullname" . }}-canary
-subjects:
-  - kind: ServiceAccount
-    name: sympozium-agent
     namespace: {{ include "sympozium.namespace" . }}
 {{- end }}
 {{- if and .Values.rbac.create .Values.llmfit.daemonset.enabled }}

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -381,7 +381,7 @@ spec:
                     description: |-
                       RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                       lifecycle hook containers. A Role and RoleBinding are provisioned
-                      in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                      in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                       This allows hooks to interact with Kubernetes resources (e.g., create
                       or delete ConfigMaps, read Secrets).
                     items:

--- a/config/crd/bases/sympozium.ai_agents.yaml
+++ b/config/crd/bases/sympozium.ai_agents.yaml
@@ -343,7 +343,7 @@ spec:
                             description: |-
                               RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                               lifecycle hook containers. A Role and RoleBinding are provisioned
-                              in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                              in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                               This allows hooks to interact with Kubernetes resources (e.g., create
                               or delete ConfigMaps, read Secrets).
                             items:

--- a/config/crd/bases/sympozium.ai_ensembles.yaml
+++ b/config/crd/bases/sympozium.ai_ensembles.yaml
@@ -393,7 +393,7 @@ spec:
                           description: |-
                             RBAC defines namespace-scoped Kubernetes RBAC rules to create for
                             lifecycle hook containers. A Role and RoleBinding are provisioned
-                            in the agent namespace, bound to the "sympozium-agent" ServiceAccount.
+                            in the agent namespace, bound only to this AgentRun's unique ServiceAccount.
                             This allows hooks to interact with Kubernetes resources (e.g., create
                             or delete ConfigMaps, read Secrets).
                           items:

--- a/docs/concepts/lifecycle-hooks.md
+++ b/docs/concepts/lifecycle-hooks.md
@@ -89,7 +89,7 @@ All lifecycle hook containers receive these env vars:
 
 ## RBAC for Hooks
 
-By default, lifecycle hook containers run with the `sympozium-agent` ServiceAccount, which has **no Kubernetes permissions**. If your hooks need to interact with the Kubernetes API (e.g., create or delete ConfigMaps), declare the required RBAC rules:
+Every AgentRun gets a unique ServiceAccount with automatic token mounting disabled. Lifecycle hooks receive **no Kubernetes token or permissions** by default. If your hooks need to interact with the Kubernetes API (for example, to create or delete ConfigMaps), declare the required RBAC rules:
 
 ```yaml
 spec:
@@ -109,7 +109,7 @@ spec:
         command: ["kubectl", "delete", "configmap", "run-context"]
 ```
 
-The controller creates a namespace-scoped Role and RoleBinding for the run, bound to `sympozium-agent`. These are garbage-collected when the AgentRun is deleted — no standing permissions.
+The controller creates a namespace-scoped Role and RoleBinding for the run, bound only to that AgentRun's ServiceAccount. It projects a pod-bound, 10-minute token into the declared hook containers, not into the agent, harness, IPC bridge, or unrelated sidecars. The ServiceAccount and namespace-scoped RBAC are garbage-collected when the AgentRun is deleted; cluster-scoped RBAC is removed when the run completes.
 
 ## Examples
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -382,8 +382,9 @@ the sidecar container into the agent pod and creates scoped RBAC resources
 cluster-wide access). The controller uses a scoped `ClusterRole` with explicitly
 enumerated permissions rather than `cluster-admin`, so any new API groups required
 by SkillPack RBAC rules must also be added to the controller's own ClusterRole to
-avoid Kubernetes RBAC escalation prevention. RBAC resources are garbage-collected
-when the AgentRun completes or is deleted.
+avoid Kubernetes RBAC escalation prevention. Cluster-scoped RBAC is removed when
+the AgentRun completes; namespaced RBAC and the run identity are owned by the
+AgentRun and are garbage-collected when it is deleted.
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -398,7 +399,8 @@ when the AgentRun completes or is deleted.
 │   /skills        NATS            full RBAC      │
 │   /ipc                                          │
 │                                                 │
-│  ServiceAccount: sympozium-agent                 │
+│  ServiceAccount: sympozium-run-<run>              │
+│  token mounted only in RBAC sidecars              │
 │  + Role: sympozium-skill-k8s-ops-<run>           │
 │  + ClusterRole: sympozium-skill-k8s-ops-<run>    │
 └─────────────────────────────────────────────────┘
@@ -629,7 +631,8 @@ spec:
         sympozium.ai/agent-run: run-abc123
     spec:
       restartPolicy: Never
-      serviceAccountName: sympozium-agent   # minimal RBAC, no cluster access
+      serviceAccountName: sympozium-run-run-abc123
+      automountServiceAccountToken: false
 
       securityContext:
         runAsNonRoot: true
@@ -1208,7 +1211,8 @@ the IPC bridge flushes them to the database in batches.
 │  • capabilities: drop ALL                                                │
 │  • seccompProfile: RuntimeDefault                                        │
 │  • No host network/PID/IPC namespace sharing                             │
-│  • No service account token auto-mount                                   │
+│  • No service account token auto-mount; short-lived tokens only in       │
+│    RBAC-declaring trusted sidecars/hooks                                  │
 │  • NetworkPolicy: deny all (or restricted egress)                        │
 │  • Resource limits enforced (CPU, memory, pids, ephemeral storage)       │
 │  • Secrets mounted only for authorized providers                         │

--- a/docs/guides/aws-bedrock.md
+++ b/docs/guides/aws-bedrock.md
@@ -85,8 +85,8 @@ eksctl utils associate-iam-oidc-provider \
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
-        "StringEquals": {
-          "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:sub": "system:serviceaccount:sympozium:sympozium-agent"
+        "StringLike": {
+          "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:sub": "system:serviceaccount:sympozium:sympozium-run-*"
         }
       }
     }
@@ -96,12 +96,18 @@ eksctl utils associate-iam-oidc-provider \
 
 3. **Attach Bedrock permissions policy** to the role (same as Option A)
 
-4. **Annotate your service account:**
+4. **Annotate the namespace identity template:**
 ```bash
 kubectl annotate serviceaccount sympozium-agent \
   eks.amazonaws.com/role-arn=arn:aws:iam::<account-id>:role/<bedrock-role-name> \
   -n sympozium
 ```
+
+Each AgentRun uses a unique `sympozium-run-<run>` ServiceAccount. The controller
+copies workload-identity annotations from `sympozium-agent` when it creates that
+identity, while the IAM trust policy above limits federation to run accounts in
+this namespace. The base account is an annotation template and is not selected
+by AgentRun pods.
 
 ### Option C: EC2 Instance Profile / EKS Node Role
 
@@ -246,6 +252,9 @@ eksctl create iamserviceaccount \
   --role-name sympozium-bedrock-role \
   --attach-policy-arn arn:aws:iam::<account>:policy/BedrockAccess \
   --approve
+
+# Update the generated role trust condition from StringEquals on
+# sympozium-agent to StringLike on sympozium-run-* as shown above.
 
 # 2. Create minimal secret (IRSA handles auth)
 kubectl create secret generic bedrock-agent-key -n sympozium \

--- a/docs/guides/serving-mode.md
+++ b/docs/guides/serving-mode.md
@@ -34,7 +34,7 @@ spec:
 ### Reconciliation flow
 
 1. **Pending** — Controller detects `requiresServer: true` on a resolved sidecar and calls `reconcilePendingServer()`:
-   - Ensures the `sympozium-agent` ServiceAccount exists
+   - Creates a unique `sympozium-run-<run>` ServiceAccount for the serving run
    - Creates ephemeral RBAC for the skill
    - Generates an API key Secret (if not provided)
    - Builds and creates a Deployment with the sidecar container

--- a/docs/guides/writing-skills.md
+++ b/docs/guides/writing-skills.md
@@ -284,7 +284,7 @@ If the sidecar needs to talk to the Kubernetes API (e.g. `kubectl get pods`), de
 
 ### Namespace-scoped RBAC (`rbac`)
 
-Creates a **Role** + **RoleBinding** in the AgentRun's namespace, bound to the `sympozium-agent` ServiceAccount:
+Creates a **Role** + **RoleBinding** in the AgentRun's namespace, bound only to that AgentRun's unique ServiceAccount. Automatic token mounting stays disabled; the controller projects a pod-bound, 10-minute token only into the SkillPack sidecar that declared RBAC:
 
 ```yaml
   sidecar:

--- a/docs/modes/harness.md
+++ b/docs/modes/harness.md
@@ -309,6 +309,14 @@ has a direct analogue, and the line falls in the same place:
   `/ipc/output` was produced by an LLM and is treated as adversarial, exactly as for
   `agent-runner`. Validate anything a harness writes before acting on it. The narrowed `/ipc`
   mount is what keeps "adversarial" from meaning "can create sub-agent runs".
+- **The harness has no Kubernetes identity.** Every AgentRun gets a unique
+  ServiceAccount, but automatic token mounting is disabled. A pod-bound token is
+  projected only into trusted SkillPack sidecars that explicitly declare RBAC;
+  it is not mounted into the harness or IPC bridge. Concurrent runs therefore do
+  not union their Kubernetes permissions.
+- **Pod-wide host privileges are incompatible.** Harness admission rejects
+  lifecycle RBAC and SkillPacks with host access, host networking, host PID, or
+  privileged execution until those paths have a separately mediated boundary.
 
 The result payload is assembled with `jq --arg`, so harness output is encoded as a JSON
 string and cannot forge a result structure. It cannot forge the marker either: an agent that
@@ -435,6 +443,7 @@ Agent; Ensemble reconciliation preserves that administrator-owned field.
 | Explicit opt-in but no image allowlist | Admitted with no image restriction; use only for controlled experimentation. |
 | A capability is requested but not declared | **Denied at admission**, naming the mode and the capability. |
 | `backend: celln` | **Denied at admission**: celln never builds the container harness mode replaces. |
+| Lifecycle RBAC or a host-access/privileged SkillPack | **Denied at admission and by the controller**; these surfaces are not isolated from an external primary container. |
 | Image declares a capability it does not honour | Admitted and run. The field is silently dropped — this is the one failure the descriptor cannot catch, and why a claim is a promise. |
 | Image ignores the result contract | Run fails with no result rather than hanging: no marker, no `/ipc/output/result.json`, and the container exit drives the phase. |
 | Harness writes to `/ipc/spawn`, `/ipc/tools`, … | Not possible: those paths are not in its mount namespace. A write fails with "no such file or directory". |

--- a/docs/sidecars/writing-orchestrator-sidecars.md
+++ b/docs/sidecars/writing-orchestrator-sidecars.md
@@ -1,7 +1,7 @@
 # Writing Orchestrator Sidecars
 
 !!! warning "Trust model — read this before authoring or installing one"
-    An orchestrator sidecar **fully controls how the AgentRun executes**. It owns the workflow loop, decides when to call the LLM, decides what to persist, and writes the run-completion signal. Because it runs with the AgentRun's identity and credentials, a malicious or buggy orchestrator can:
+    An orchestrator sidecar **fully controls how the AgentRun executes**. It owns the workflow loop, decides when to call the LLM, decides what to persist, and writes the run-completion signal. If it declares Kubernetes RBAC, it receives the AgentRun's unique, short-lived projected identity; otherwise no Kubernetes token is mounted. A malicious or buggy orchestrator with declared credentials can:
 
     - Issue arbitrary LLM calls billed to the AgentRun.
     - Read, exfiltrate, or tamper with anything the sidecar has access to (secrets, mounted volumes, network).

--- a/docs/sympozium-vs-kagent.md
+++ b/docs/sympozium-vs-kagent.md
@@ -45,7 +45,7 @@ This is the most fundamental difference between the two projects.
 
 ### Tool Isolation
 
-**Sympozium** injects every skill as a **dedicated sidecar container** in the agent pod. Each sidecar gets its own ServiceAccount with least-privilege RBAC that is created at run start and garbage-collected at run end. Skills communicate with the agent container over a shared `/workspace` volume and gRPC. A kubectl skill has cluster access; the agent container itself does not.
+**Sympozium** injects every skill as a **dedicated sidecar container** in the agent pod. Each AgentRun gets a unique ServiceAccount; least-privilege RBAC and a short-lived projected token are exposed only to sidecars that declare Kubernetes access. Skills communicate with the agent container over shared workspace/IPC surfaces. A kubectl skill can have cluster access; the agent or external harness container does not receive its Kubernetes credential.
 
 **kagent** loads tools **in-process** within the engine via MCP clients or built-in function calls. Tool execution shares the same process, memory space, and Kubernetes credentials as the agent itself.
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -91,6 +92,12 @@ var (
 
 const agentRunFinalizer = "sympozium.ai/agentrun-finalizer"
 const systemNamespace = "sympozium-system"
+
+const (
+	legacyAgentServiceAccountName = "sympozium-agent"
+	runAPIAccessVolumeName        = "sympozium-run-api-access"
+	runAPIAccessMountPath         = "/var/run/secrets/kubernetes.io/serviceaccount"
+)
 
 // tokenBudgetCountedAnnotation marks an AgentRun whose token usage has already
 // been aggregated into its ensemble's budget, so repeated reconciles of the
@@ -481,8 +488,10 @@ func (r *AgentRunReconciler) prepareRunPrerequisites(
 ) (runPrerequisites, error) {
 	var out runPrerequisites
 
-	// Ensure the sympozium-agent ServiceAccount exists in the target namespace.
-	if err := r.ensureAgentServiceAccount(ctx, agentRun.Namespace); err != nil {
+	// Give every AgentRun its own Kubernetes identity. The namespace-level
+	// sympozium-agent account is retained only as an annotation template for
+	// workload-identity integrations; no run pod executes as that shared account.
+	if err := r.ensureAgentServiceAccount(ctx, agentRun); err != nil {
 		return out, fmt.Errorf("ensuring agent service account: %w", err)
 	}
 
@@ -546,6 +555,9 @@ func (r *AgentRunReconciler) prepareTaskPrerequisites(
 			log.V(1).Info("Skipping server-only sidecar in task mode", "skillPack", sc.skillPackName)
 		}
 	}
+	if err := validateHarnessIsolation(agentRun, sidecars); err != nil {
+		return nil, &ctrl.Result{}, r.failRun(ctx, agentRun, err.Error())
+	}
 
 	// Write the native sidecar-tools manifest as a read-only ConfigMap when any
 	// attached sidecar declares tools. The definitions come from the SkillPack CRD
@@ -606,6 +618,10 @@ func (r *AgentRunReconciler) prepareTaskPrerequisites(
 	//   - Clock skew between cluster nodes (`date` on each node vs NTP)
 	//   - Controller ClusterRole missing RBAC delegation permissions
 	//     (re-run `helm upgrade` to sync the latest chart RBAC)
+	if err := r.ensureCanaryRBAC(ctx, agentRun); err != nil {
+		return nil, &ctrl.Result{}, r.failRun(ctx, agentRun,
+			fmt.Sprintf("failed to create isolated canary RBAC: %v", err))
+	}
 	if err := r.ensureSkillRBAC(ctx, log, agentRun, sidecars); err != nil {
 		return nil, &ctrl.Result{}, r.failRun(ctx, agentRun,
 			fmt.Sprintf("failed to create skill RBAC — the agent would run without Kubernetes permissions. "+
@@ -1893,8 +1909,8 @@ func (r *AgentRunReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 func (r *AgentRunReconciler) reconcilePendingServer(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun, sidecars []resolvedSidecar) (ctrl.Result, error) {
 	log.Info("Reconciling pending server-mode AgentRun")
 
-	// Ensure ServiceAccount exists.
-	if err := r.ensureAgentServiceAccount(ctx, agentRun.Namespace); err != nil {
+	// Ensure this server-mode run has the same isolated identity as task runs.
+	if err := r.ensureAgentServiceAccount(ctx, agentRun); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring agent service account: %w", err)
 	}
 
@@ -2010,10 +2026,11 @@ func (r *AgentRunReconciler) reconcilePendingServer(ctx context.Context, log log
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyAlways,
-					ServiceAccountName: "sympozium-agent",
-					ImagePullSecrets:   agentRun.Spec.ImagePullSecrets,
-					NodeSelector:       agentRun.Spec.Model.NodeSelector,
+					RestartPolicy:                corev1.RestartPolicyAlways,
+					ServiceAccountName:           agentRunServiceAccountName(agentRun),
+					AutomountServiceAccountToken: boolPtr(false),
+					ImagePullSecrets:             agentRun.Spec.ImagePullSecrets,
+					NodeSelector:                 agentRun.Spec.Model.NodeSelector,
 					Containers: []corev1.Container{
 						{
 							Name:            "web-proxy",
@@ -2061,6 +2078,10 @@ func (r *AgentRunReconciler) reconcilePendingServer(ctx context.Context, log log
 				},
 			},
 		},
+	}
+	if len(serverSidecar.sidecar.RBAC) > 0 || len(serverSidecar.sidecar.ClusterRBAC) > 0 {
+		deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, runAPIAccessVolume())
+		mountRunAPIAccess(&deploy.Spec.Template.Spec.Containers[0])
 	}
 
 	if err := controllerutil.SetControllerReference(agentRun, deploy, r.Scheme); err != nil {
@@ -2404,32 +2425,85 @@ func (r *AgentRunReconciler) validatePolicy(ctx context.Context, agentRun *sympo
 	return nil
 }
 
-// ensureAgentServiceAccount creates the sympozium-agent ServiceAccount in the
-// given namespace if it does not already exist. This is needed because agent
-// Jobs reference this SA and run in the user's namespace, not sympozium-system.
-func (r *AgentRunReconciler) ensureAgentServiceAccount(ctx context.Context, namespace string) error {
+// agentRunServiceAccountName returns the identity used only by this AgentRun.
+// AgentRun names already satisfy Kubernetes DNS-subdomain requirements.
+func agentRunServiceAccountName(agentRun *sympoziumv1alpha1.AgentRun) string {
+	const maxDNSSubdomainLength = 253
+	name := "sympozium-run-" + agentRun.Name
+	if len(name) <= maxDNSSubdomainLength {
+		return name
+	}
+	sum := sha256.Sum256([]byte(agentRun.Name))
+	suffix := fmt.Sprintf("-%x", sum[:8])
+	return strings.TrimRight(name[:maxDNSSubdomainLength-len(suffix)], "-") + suffix
+}
+
+// ensureAgentServiceAccount creates a unique ServiceAccount owned by the run.
+// If the legacy namespace-level account exists, its annotations are copied so
+// existing cloud workload-identity configuration continues to apply. The
+// shared account itself is never selected by an AgentRun pod or RoleBinding.
+func (r *AgentRunReconciler) ensureAgentServiceAccount(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun) error {
+	name := agentRunServiceAccountName(agentRun)
 	sa := &corev1.ServiceAccount{}
-	err := r.Get(ctx, client.ObjectKey{Name: "sympozium-agent", Namespace: namespace}, sa)
+	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: agentRun.Namespace}, sa)
 	if err == nil {
-		return nil // already exists
+		return nil
 	}
 	if !errors.IsNotFound(err) {
-		return fmt.Errorf("checking for agent service account: %w", err)
+		return fmt.Errorf("checking for run service account: %w", err)
 	}
+
+	annotations := map[string]string{}
+	template := &corev1.ServiceAccount{}
+	if err := r.Get(ctx, client.ObjectKey{Name: legacyAgentServiceAccountName, Namespace: agentRun.Namespace}, template); errors.IsNotFound(err) {
+		automount := false
+		template = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      legacyAgentServiceAccountName,
+				Namespace: agentRun.Namespace,
+				Labels: map[string]string{
+					"sympozium.ai/component":       "identity-template",
+					"app.kubernetes.io/managed-by": "sympozium-controller",
+				},
+			},
+			AutomountServiceAccountToken: &automount,
+		}
+		if err := r.Create(ctx, template); err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating service account annotation template: %w", err)
+		}
+		if err := r.Get(ctx, client.ObjectKey{Name: legacyAgentServiceAccountName, Namespace: agentRun.Namespace}, template); err != nil {
+			return fmt.Errorf("reading service account annotation template: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("checking service account annotation template: %w", err)
+	}
+	if template != nil {
+		for key, value := range template.Annotations {
+			annotations[key] = value
+		}
+	}
+
+	automount := false
 	sa = &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sympozium-agent",
-			Namespace: namespace,
+			Name:        name,
+			Namespace:   agentRun.Namespace,
+			Annotations: annotations,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "sympozium",
+				"sympozium.ai/agent-run":       agentRun.Name,
+				"app.kubernetes.io/managed-by": "sympozium-controller",
 			},
 		},
+		AutomountServiceAccountToken: &automount,
+	}
+	if err := controllerutil.SetControllerReference(agentRun, sa, r.Scheme); err != nil {
+		return fmt.Errorf("setting run service account owner: %w", err)
 	}
 	if err := r.Create(ctx, sa); err != nil {
 		if errors.IsAlreadyExists(err) {
 			return nil
 		}
-		return fmt.Errorf("creating agent service account: %w", err)
+		return fmt.Errorf("creating run service account: %w", err)
 	}
 	return nil
 }
@@ -2503,13 +2577,14 @@ func (r *AgentRunReconciler) buildAgentPodTemplate(
 			Labels: agentPodLabels(agentRun),
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:      corev1.RestartPolicyNever,
-			ServiceAccountName: "sympozium-agent",
-			ImagePullSecrets:   agentRun.Spec.ImagePullSecrets,
-			HostNetwork:        hostNetwork,
-			HostPID:            hostPID,
-			DNSPolicy:          dnsPolicy,
-			NodeSelector:       agentRun.Spec.Model.NodeSelector,
+			RestartPolicy:                corev1.RestartPolicyNever,
+			ServiceAccountName:           agentRunServiceAccountName(agentRun),
+			AutomountServiceAccountToken: boolPtr(false),
+			ImagePullSecrets:             agentRun.Spec.ImagePullSecrets,
+			HostNetwork:                  hostNetwork,
+			HostPID:                      hostPID,
+			DNSPolicy:                    dnsPolicy,
+			NodeSelector:                 agentRun.Spec.Model.NodeSelector,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot:   &runAsNonRoot,
 				RunAsUser:      &runAsUser,
@@ -2525,6 +2600,7 @@ func (r *AgentRunReconciler) buildAgentPodTemplate(
 	// Shared pod mutators (shared memory, relationship context, subagents, …),
 	// registered in agentrun_pod_mutators.go.
 	r.applyPodMutators(ctx, agentRun, &tmpl.Spec)
+	configureRunAPIAccess(agentRun, sidecars, &tmpl.Spec)
 
 	return tmpl, nil
 }
@@ -3751,7 +3827,6 @@ func (r *AgentRunReconciler) buildVolumes(agentRun *sympoziumv1alpha1.AgentRun, 
 			},
 		},
 	}
-
 	// Build skills projected volume from skill references
 	var sources []corev1.VolumeProjection
 	for _, skill := range agentRun.Spec.Skills {
@@ -3965,14 +4040,15 @@ func (r *AgentRunReconciler) buildVolumes(agentRun *sympoziumv1alpha1.AgentRun, 
 // on every agent pod. User-supplied volumes/mounts with these names are
 // silently skipped to prevent accidental clobbering of core functionality.
 var reservedVolumeNames = map[string]struct{}{
-	"workspace":     {},
-	"ipc":           {},
-	"skills":        {},
-	"tmp":           {},
-	"memory":        {},
-	"mcp-config":    {},
-	"sidecar-tools": {},
-	"harness-home":  {},
+	"workspace":            {},
+	"ipc":                  {},
+	"skills":               {},
+	"tmp":                  {},
+	"memory":               {},
+	"mcp-config":           {},
+	"sidecar-tools":        {},
+	"harness-home":         {},
+	runAPIAccessVolumeName: {},
 }
 
 func isReservedVolumeName(name string) bool {
@@ -4029,8 +4105,96 @@ func hostAccessVolumeName(skillPackName string, index int) string {
 	return name
 }
 
+// runAPIAccessVolume reproduces the bounded Kubernetes API credential volume
+// normally injected by the service-account admission plugin, but keeps it
+// under controller control so it can be mounted only into declared trusted
+// sidecars. The token is pod-bound and uses Kubernetes' minimum commonly
+// supported lifetime (10 minutes).
+func runAPIAccessVolume() corev1.Volume {
+	expirationSeconds := int64(600)
+	optional := false
+	return corev1.Volume{
+		Name: runAPIAccessVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				DefaultMode: int32Ptr(0o444),
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Path:              "token",
+							ExpirationSeconds: &expirationSeconds,
+						},
+					},
+					{
+						ConfigMap: &corev1.ConfigMapProjection{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "kube-root-ca.crt"},
+							Items:                []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+							Optional:             &optional,
+						},
+					},
+					{
+						DownwardAPI: &corev1.DownwardAPIProjection{
+							Items: []corev1.DownwardAPIVolumeFile{{
+								Path:     "namespace",
+								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func mountRunAPIAccess(container *corev1.Container) {
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      runAPIAccessVolumeName,
+		MountPath: runAPIAccessMountPath,
+		ReadOnly:  true,
+	})
+}
+
+// configureRunAPIAccess leaves automatic token mounting disabled for every
+// container, then explicitly projects a short-lived token only into SkillPack
+// sidecars and lifecycle hooks that declared Kubernetes RBAC. In particular,
+// the primary agent/harness and ipc-bridge never receive Kubernetes credentials.
+func configureRunAPIAccess(agentRun *sympoziumv1alpha1.AgentRun, sidecars []resolvedSidecar, podSpec *corev1.PodSpec) {
+	trustedContainers := map[string]struct{}{}
+	if agentRun.Spec.CanaryMode {
+		trustedContainers["agent"] = struct{}{}
+	}
+	for _, sidecar := range sidecars {
+		if len(sidecar.sidecar.RBAC) > 0 || len(sidecar.sidecar.ClusterRBAC) > 0 {
+			trustedContainers["skill-"+sidecar.skillPackName] = struct{}{}
+		}
+	}
+	trustedInitContainers := map[string]struct{}{}
+	if agentRun.Spec.Lifecycle != nil && len(agentRun.Spec.Lifecycle.RBAC) > 0 {
+		for _, hook := range agentRun.Spec.Lifecycle.PreRun {
+			trustedInitContainers["pre-"+hook.Name] = struct{}{}
+		}
+	}
+
+	if len(trustedContainers) == 0 && len(trustedInitContainers) == 0 {
+		return
+	}
+	podSpec.Volumes = append(podSpec.Volumes, runAPIAccessVolume())
+	for i := range podSpec.Containers {
+		if _, ok := trustedContainers[podSpec.Containers[i].Name]; ok {
+			mountRunAPIAccess(&podSpec.Containers[i])
+		}
+	}
+	for i := range podSpec.InitContainers {
+		if _, ok := trustedInitContainers[podSpec.InitContainers[i].Name]; ok {
+			mountRunAPIAccess(&podSpec.InitContainers[i])
+		}
+	}
+}
+
 // boolPtr returns a pointer to a bool.
 func boolPtr(b bool) *bool { return &b }
+
+func int32Ptr(i int32) *int32 { return &i }
 
 // agentRunHasMemorySkill returns true if the AgentRun references the "memory" SkillPack.
 func agentRunHasMemorySkill(agentRun *sympoziumv1alpha1.AgentRun) bool {
@@ -4697,7 +4861,7 @@ func (r *AgentRunReconciler) ensureSkillRBAC(ctx context.Context, log logr.Logge
 			if err := controllerutil.SetControllerReference(agentRun, role, r.Scheme); err != nil {
 				log.Error(err, "Failed to set owner on Role")
 			}
-			if err := r.Create(ctx, role); err != nil && !errors.IsAlreadyExists(err) {
+			if err := r.reconcileRole(ctx, role); err != nil {
 				return fmt.Errorf("creating skill Role %s: %w", roleName, err)
 			}
 
@@ -4719,7 +4883,7 @@ func (r *AgentRunReconciler) ensureSkillRBAC(ctx context.Context, log logr.Logge
 				Subjects: []rbacv1.Subject{
 					{
 						Kind:      "ServiceAccount",
-						Name:      "sympozium-agent",
+						Name:      agentRunServiceAccountName(agentRun),
 						Namespace: agentRun.Namespace,
 					},
 				},
@@ -4727,7 +4891,7 @@ func (r *AgentRunReconciler) ensureSkillRBAC(ctx context.Context, log logr.Logge
 			if err := controllerutil.SetControllerReference(agentRun, rb, r.Scheme); err != nil {
 				log.Error(err, "Failed to set owner on RoleBinding")
 			}
-			if err := r.Create(ctx, rb); err != nil && !errors.IsAlreadyExists(err) {
+			if err := r.reconcileRoleBinding(ctx, rb); err != nil {
 				return fmt.Errorf("creating skill RoleBinding %s: %w", roleName, err)
 			}
 			log.Info("Created skill RBAC (namespaced)", "role", roleName, "skill", sc.skillPackName)
@@ -4756,7 +4920,7 @@ func (r *AgentRunReconciler) ensureSkillRBAC(ctx context.Context, log logr.Logge
 				},
 				Rules: rules,
 			}
-			if err := r.Create(ctx, cr); err != nil && !errors.IsAlreadyExists(err) {
+			if err := r.reconcileClusterRole(ctx, cr); err != nil {
 				return fmt.Errorf("creating skill ClusterRole %s: %w", crName, err)
 			}
 
@@ -4777,12 +4941,12 @@ func (r *AgentRunReconciler) ensureSkillRBAC(ctx context.Context, log logr.Logge
 				Subjects: []rbacv1.Subject{
 					{
 						Kind:      "ServiceAccount",
-						Name:      "sympozium-agent",
+						Name:      agentRunServiceAccountName(agentRun),
 						Namespace: agentRun.Namespace,
 					},
 				},
 			}
-			if err := r.Create(ctx, crb); err != nil && !errors.IsAlreadyExists(err) {
+			if err := r.reconcileClusterRoleBinding(ctx, crb); err != nil {
 				return fmt.Errorf("creating skill ClusterRoleBinding %s: %w", crName, err)
 			}
 			log.Info("Created skill RBAC (cluster)", "clusterRole", crName, "skill", sc.skillPackName)
@@ -4791,10 +4955,72 @@ func (r *AgentRunReconciler) ensureSkillRBAC(ctx context.Context, log logr.Logge
 	return nil
 }
 
+// validateHarnessIsolation rejects pod-level privilege combinations that an
+// external primary container would inherit or could reach through shared
+// volumes. These combinations remain unavailable until they have a mediated
+// boundary of their own.
+func validateHarnessIsolation(agentRun *sympoziumv1alpha1.AgentRun, sidecars []resolvedSidecar) error {
+	if taskmodes.HarnessImage(agentRun.Spec.Task) == "" {
+		return nil
+	}
+	if agentRun.Spec.Lifecycle != nil && len(agentRun.Spec.Lifecycle.RBAC) > 0 {
+		return fmt.Errorf("task.mode %q cannot be combined with lifecycle RBAC because hooks share run storage with the external runtime", taskmodes.Harness)
+	}
+	for _, sidecar := range sidecars {
+		if sidecar.sidecar.HostAccess != nil && sidecar.sidecar.HostAccess.Enabled {
+			return fmt.Errorf("task.mode %q cannot be combined with SkillPack %q host access, host networking, host PID, or privileged execution", taskmodes.Harness, sidecar.skillPackName)
+		}
+	}
+	return nil
+}
+
+// ensureCanaryRBAC grants the trusted built-in canary runner its fixed health
+// check permissions through the same per-run identity boundary as SkillPacks.
+// Harness mode rejects canaryMode, so this token can never land in an external
+// runtime container.
+func (r *AgentRunReconciler) ensureCanaryRBAC(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun) error {
+	if !agentRun.Spec.CanaryMode {
+		return nil
+	}
+
+	name := "sympozium-canary-" + agentRun.Name
+	labels := map[string]string{
+		"sympozium.ai/agent-run":  agentRun.Name,
+		"sympozium.ai/component":  "canary",
+		"sympozium.ai/managed-by": "sympozium",
+	}
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"nodes"}, Verbs: []string{"get", "list"}},
+			{APIGroups: []string{"sympozium.ai"}, Resources: []string{"sympoziumschedules", "mcpservers"}, Verbs: []string{"get", "list"}},
+		},
+	}
+	if err := r.reconcileClusterRole(ctx, role); err != nil {
+		return fmt.Errorf("creating canary ClusterRole %s: %w", name, err)
+	}
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      agentRunServiceAccountName(agentRun),
+			Namespace: agentRun.Namespace,
+		}},
+	}
+	if err := r.reconcileClusterRoleBinding(ctx, binding); err != nil {
+		return fmt.Errorf("creating canary ClusterRoleBinding %s: %w", name, err)
+	}
+	return nil
+}
+
 // ensureLifecycleRBAC creates namespace-scoped Role and RoleBinding for lifecycle
-// hook containers. This grants the "sympozium-agent" ServiceAccount the permissions
-// specified in lifecycle.rbac, so hook containers can interact with Kubernetes
-// resources (e.g., create/delete ConfigMaps).
+// hook containers. This grants only the current AgentRun's ServiceAccount the
+// requested permissions, preventing permission union across concurrent runs.
 func (r *AgentRunReconciler) ensureLifecycleRBAC(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) error {
 	if agentRun.Spec.Lifecycle == nil || len(agentRun.Spec.Lifecycle.RBAC) == 0 {
 		return nil
@@ -4825,7 +5051,7 @@ func (r *AgentRunReconciler) ensureLifecycleRBAC(ctx context.Context, log logr.L
 	if err := controllerutil.SetControllerReference(agentRun, role, r.Scheme); err != nil {
 		log.Error(err, "Failed to set owner on lifecycle Role")
 	}
-	if err := r.Create(ctx, role); err != nil && !errors.IsAlreadyExists(err) {
+	if err := r.reconcileRole(ctx, role); err != nil {
 		return fmt.Errorf("creating lifecycle Role %s: %w", roleName, err)
 	}
 
@@ -4847,7 +5073,7 @@ func (r *AgentRunReconciler) ensureLifecycleRBAC(ctx context.Context, log logr.L
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "sympozium-agent",
+				Name:      agentRunServiceAccountName(agentRun),
 				Namespace: agentRun.Namespace,
 			},
 		},
@@ -4855,12 +5081,76 @@ func (r *AgentRunReconciler) ensureLifecycleRBAC(ctx context.Context, log logr.L
 	if err := controllerutil.SetControllerReference(agentRun, rb, r.Scheme); err != nil {
 		log.Error(err, "Failed to set owner on lifecycle RoleBinding")
 	}
-	if err := r.Create(ctx, rb); err != nil && !errors.IsAlreadyExists(err) {
+	if err := r.reconcileRoleBinding(ctx, rb); err != nil {
 		return fmt.Errorf("creating lifecycle RoleBinding %s: %w", roleName, err)
 	}
 
 	log.Info("Created lifecycle RBAC", "role", roleName)
 	return nil
+}
+
+// The RBAC objects are deterministic and may already exist when a controller
+// restarts midway through a run. Reconcile mutable fields rather than treating
+// AlreadyExists as success: otherwise a RoleBinding created by an older
+// controller can keep pointing at the shared legacy ServiceAccount.
+func (r *AgentRunReconciler) reconcileRole(ctx context.Context, desired *rbacv1.Role) error {
+	existing := &rbacv1.Role{}
+	key := client.ObjectKeyFromObject(desired)
+	if err := r.Get(ctx, key, existing); errors.IsNotFound(err) {
+		return r.Create(ctx, desired)
+	} else if err != nil {
+		return err
+	}
+	existing.Labels = desired.Labels
+	existing.OwnerReferences = desired.OwnerReferences
+	existing.Rules = desired.Rules
+	return r.Update(ctx, existing)
+}
+
+func (r *AgentRunReconciler) reconcileRoleBinding(ctx context.Context, desired *rbacv1.RoleBinding) error {
+	existing := &rbacv1.RoleBinding{}
+	key := client.ObjectKeyFromObject(desired)
+	if err := r.Get(ctx, key, existing); errors.IsNotFound(err) {
+		return r.Create(ctx, desired)
+	} else if err != nil {
+		return err
+	}
+	if existing.RoleRef != desired.RoleRef {
+		return fmt.Errorf("RoleBinding %s/%s has immutable roleRef %#v, want %#v", existing.Namespace, existing.Name, existing.RoleRef, desired.RoleRef)
+	}
+	existing.Labels = desired.Labels
+	existing.OwnerReferences = desired.OwnerReferences
+	existing.Subjects = desired.Subjects
+	return r.Update(ctx, existing)
+}
+
+func (r *AgentRunReconciler) reconcileClusterRole(ctx context.Context, desired *rbacv1.ClusterRole) error {
+	existing := &rbacv1.ClusterRole{}
+	key := client.ObjectKeyFromObject(desired)
+	if err := r.Get(ctx, key, existing); errors.IsNotFound(err) {
+		return r.Create(ctx, desired)
+	} else if err != nil {
+		return err
+	}
+	existing.Labels = desired.Labels
+	existing.Rules = desired.Rules
+	return r.Update(ctx, existing)
+}
+
+func (r *AgentRunReconciler) reconcileClusterRoleBinding(ctx context.Context, desired *rbacv1.ClusterRoleBinding) error {
+	existing := &rbacv1.ClusterRoleBinding{}
+	key := client.ObjectKeyFromObject(desired)
+	if err := r.Get(ctx, key, existing); errors.IsNotFound(err) {
+		return r.Create(ctx, desired)
+	} else if err != nil {
+		return err
+	}
+	if existing.RoleRef != desired.RoleRef {
+		return fmt.Errorf("ClusterRoleBinding %s has immutable roleRef %#v, want %#v", existing.Name, existing.RoleRef, desired.RoleRef)
+	}
+	existing.Labels = desired.Labels
+	existing.Subjects = desired.Subjects
+	return r.Update(ctx, existing)
 }
 
 // cleanupSkillRBAC removes cluster-scoped RBAC resources created for an AgentRun.
@@ -5411,6 +5701,12 @@ func (r *AgentRunReconciler) buildPostRunJob(
 			},
 		},
 	}
+	if len(agentRun.Spec.Lifecycle.RBAC) > 0 {
+		volumes = append(volumes, runAPIAccessVolume())
+		for i := range initContainers {
+			mountRunAPIAccess(&initContainers[i])
+		}
+	}
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -5427,9 +5723,10 @@ func (r *AgentRunReconciler) buildPostRunJob(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: "sympozium-agent",
-					ImagePullSecrets:   agentRun.Spec.ImagePullSecrets,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					ServiceAccountName:           agentRunServiceAccountName(agentRun),
+					AutomountServiceAccountToken: boolPtr(false),
+					ImagePullSecrets:             agentRun.Spec.ImagePullSecrets,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &runAsNonRoot,
 						RunAsUser:    &runAsUser,

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -109,8 +109,11 @@ func TestBuildJob_ServiceAccount(t *testing.T) {
 	r := &AgentRunReconciler{}
 	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, nil, nil, nil)
 
-	if job.Spec.Template.Spec.ServiceAccountName != "sympozium-agent" {
-		t.Errorf("SA = %q, want sympozium-agent", job.Spec.Template.Spec.ServiceAccountName)
+	if job.Spec.Template.Spec.ServiceAccountName != "sympozium-run-test-run" {
+		t.Errorf("SA = %q, want sympozium-run-test-run", job.Spec.Template.Spec.ServiceAccountName)
+	}
+	if job.Spec.Template.Spec.AutomountServiceAccountToken == nil || *job.Spec.Template.Spec.AutomountServiceAccountToken {
+		t.Error("agent pod must disable automatic service-account token mounting")
 	}
 }
 
@@ -1780,8 +1783,11 @@ func TestBuildPostRunJob_ServiceAccount(t *testing.T) {
 
 	job := r.buildPostRunJob(run, 0, "done")
 
-	if job.Spec.Template.Spec.ServiceAccountName != "sympozium-agent" {
-		t.Errorf("postRun Job ServiceAccountName = %q, want sympozium-agent", job.Spec.Template.Spec.ServiceAccountName)
+	if job.Spec.Template.Spec.ServiceAccountName != "sympozium-run-test-run" {
+		t.Errorf("postRun Job ServiceAccountName = %q, want sympozium-run-test-run", job.Spec.Template.Spec.ServiceAccountName)
+	}
+	if job.Spec.Template.Spec.AutomountServiceAccountToken == nil || *job.Spec.Template.Spec.AutomountServiceAccountToken {
+		t.Error("postRun pod must disable automatic service-account token mounting")
 	}
 }
 

--- a/internal/controller/agentrun_identity_test.go
+++ b/internal/controller/agentrun_identity_test.go
@@ -1,0 +1,239 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestHarnessReceivesNoKubernetesToken(t *testing.T) {
+	r := &AgentRunReconciler{}
+	job, err := r.buildJob(context.Background(), harnessModeRun(nil), false, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("build harness job: %v", err)
+	}
+
+	spec := job.Spec.Template.Spec
+	if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+		t.Fatal("harness pod must set automountServiceAccountToken=false")
+	}
+	if hasVolume(spec.Volumes, runAPIAccessVolumeName) {
+		t.Fatal("harness-only pod must not contain a projected Kubernetes API token")
+	}
+	for _, container := range spec.Containers {
+		if hasMount(container.VolumeMounts, runAPIAccessVolumeName) {
+			t.Errorf("container %q unexpectedly receives Kubernetes credentials", container.Name)
+		}
+	}
+}
+
+func TestHarnessRejectsUnisolatedPrivilegeCombinations(t *testing.T) {
+	t.Run("lifecycle RBAC", func(t *testing.T) {
+		run := harnessModeRun(nil)
+		run.Spec.Lifecycle = &sympoziumv1alpha1.LifecycleHooks{RBAC: []sympoziumv1alpha1.RBACRule{{
+			APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get"},
+		}}}
+		if err := validateHarnessIsolation(run, nil); err == nil {
+			t.Fatal("expected harness plus lifecycle RBAC to be rejected")
+		}
+	})
+
+	t.Run("host access SkillPack", func(t *testing.T) {
+		run := harnessModeRun(nil)
+		sidecars := []resolvedSidecar{{
+			skillPackName: "node-admin",
+			sidecar: sympoziumv1alpha1.SkillSidecar{HostAccess: &sympoziumv1alpha1.HostAccessSpec{
+				Enabled: true, HostPID: true,
+			}},
+		}}
+		if err := validateHarnessIsolation(run, sidecars); err == nil {
+			t.Fatal("expected harness plus host-access SkillPack to be rejected")
+		}
+	})
+}
+
+func TestRunAPIAccessMountedOnlyIntoRBACSidecars(t *testing.T) {
+	r := &AgentRunReconciler{}
+	run := newTestRun()
+	sidecars := []resolvedSidecar{
+		{
+			skillPackName: "k8s-reader",
+			sidecar: sympoziumv1alpha1.SkillSidecar{
+				Image: "reader:latest",
+				RBAC: []sympoziumv1alpha1.RBACRule{{
+					APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"},
+				}},
+			},
+		},
+		{
+			skillPackName: "calculator",
+			sidecar:       sympoziumv1alpha1.SkillSidecar{Image: "calculator:latest"},
+		},
+	}
+
+	job, err := r.buildJob(context.Background(), run, false, nil, sidecars, nil, nil)
+	if err != nil {
+		t.Fatalf("build job: %v", err)
+	}
+	spec := job.Spec.Template.Spec
+	if !hasVolume(spec.Volumes, runAPIAccessVolumeName) {
+		t.Fatal("RBAC sidecar requires a projected Kubernetes API token volume")
+	}
+
+	for _, name := range []string{"agent", "ipc-bridge", "skill-calculator"} {
+		container := containerByName(spec.Containers, name)
+		if container == nil {
+			t.Fatalf("missing container %q", name)
+		}
+		if hasMount(container.VolumeMounts, runAPIAccessVolumeName) {
+			t.Errorf("untrusted container %q receives Kubernetes credentials", name)
+		}
+	}
+	reader := containerByName(spec.Containers, "skill-k8s-reader")
+	if reader == nil || !hasMount(reader.VolumeMounts, runAPIAccessVolumeName) {
+		t.Fatal("RBAC-declaring SkillPack sidecar does not receive its projected token")
+	}
+
+	for _, volume := range spec.Volumes {
+		if volume.Name != runAPIAccessVolumeName {
+			continue
+		}
+		projection := volume.Projected.Sources[0].ServiceAccountToken
+		if projection == nil || projection.ExpirationSeconds == nil || *projection.ExpirationSeconds != 600 {
+			t.Fatalf("token projection expiration = %#v, want 600 seconds", projection)
+		}
+	}
+}
+
+func TestLifecycleTokenProjectionExcludesAgentAndDoneContainers(t *testing.T) {
+	r := &AgentRunReconciler{}
+	rules := []sympoziumv1alpha1.RBACRule{{
+		APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get"},
+	}}
+	run := newTestRunWithLifecycle(
+		[]sympoziumv1alpha1.LifecycleHookContainer{{Name: "prepare", Image: "kubectl:latest"}},
+		[]sympoziumv1alpha1.LifecycleHookContainer{{Name: "finish", Image: "kubectl:latest"}},
+		rules,
+	)
+
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("build main job: %v", err)
+	}
+	if !hasMount(job.Spec.Template.Spec.InitContainers[0].VolumeMounts, runAPIAccessVolumeName) {
+		t.Fatal("preRun RBAC hook lacks projected token")
+	}
+	if hasMount(job.Spec.Template.Spec.Containers[0].VolumeMounts, runAPIAccessVolumeName) {
+		t.Fatal("primary agent received lifecycle hook credentials")
+	}
+
+	post := r.buildPostRunJob(run, 0, "done")
+	if !hasMount(post.Spec.Template.Spec.InitContainers[0].VolumeMounts, runAPIAccessVolumeName) {
+		t.Fatal("postRun RBAC hook lacks projected token")
+	}
+	if hasMount(post.Spec.Template.Spec.Containers[0].VolumeMounts, runAPIAccessVolumeName) {
+		t.Fatal("postRun sentinel container received lifecycle credentials")
+	}
+}
+
+func TestCanaryUsesItsOwnIdentityAndFixedRBAC(t *testing.T) {
+	run := newTestRun()
+	run.Name = "canary-run"
+	run.UID = types.UID("canary-uid")
+	run.Spec.CanaryMode = true
+	r := newAgentRunTestReconciler(t, run)
+
+	if err := r.ensureAgentServiceAccount(context.Background(), run); err != nil {
+		t.Fatalf("ensure service account: %v", err)
+	}
+	if err := r.ensureCanaryRBAC(context.Background(), run); err != nil {
+		t.Fatalf("ensure canary RBAC: %v", err)
+	}
+
+	var binding rbacv1.ClusterRoleBinding
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "sympozium-canary-canary-run"}, &binding); err != nil {
+		t.Fatalf("get canary ClusterRoleBinding: %v", err)
+	}
+	if len(binding.Subjects) != 1 || binding.Subjects[0].Name != "sympozium-run-canary-run" {
+		t.Fatalf("canary binding subjects = %#v", binding.Subjects)
+	}
+
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("build canary job: %v", err)
+	}
+	agent := containerByName(job.Spec.Template.Spec.Containers, "agent")
+	bridge := containerByName(job.Spec.Template.Spec.Containers, "ipc-bridge")
+	if agent == nil || !hasMount(agent.VolumeMounts, runAPIAccessVolumeName) {
+		t.Fatal("trusted canary runner lacks projected Kubernetes token")
+	}
+	if bridge == nil || hasMount(bridge.VolumeMounts, runAPIAccessVolumeName) {
+		t.Fatal("ipc-bridge received canary Kubernetes credentials")
+	}
+}
+
+func TestRunServiceAccountsAndBindingsAreIsolated(t *testing.T) {
+	runA := newTestRun()
+	runA.Name = "run-a"
+	runA.UID = types.UID("uid-a")
+	runA.Spec.Lifecycle = &sympoziumv1alpha1.LifecycleHooks{RBAC: []sympoziumv1alpha1.RBACRule{{
+		APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get"},
+	}}}
+	runB := runA.DeepCopy()
+	runB.Name = "run-b"
+	runB.UID = types.UID("uid-b")
+
+	template := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: legacyAgentServiceAccountName, Namespace: "default",
+		Annotations: map[string]string{"eks.amazonaws.com/role-arn": "arn:example"},
+	}}
+	staleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "sympozium-lifecycle-run-a", Namespace: "default"},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "sympozium-lifecycle-run-a",
+		},
+		Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: legacyAgentServiceAccountName, Namespace: "default"}},
+	}
+	r := newAgentRunTestReconciler(t, runA, runB, template, staleBinding)
+	for _, run := range []*sympoziumv1alpha1.AgentRun{runA, runB} {
+		if err := r.ensureAgentServiceAccount(context.Background(), run); err != nil {
+			t.Fatalf("ensure service account for %s: %v", run.Name, err)
+		}
+		if err := r.ensureLifecycleRBAC(context.Background(), logr.Discard(), run); err != nil {
+			t.Fatalf("ensure lifecycle RBAC for %s: %v", run.Name, err)
+		}
+	}
+
+	for _, run := range []*sympoziumv1alpha1.AgentRun{runA, runB} {
+		wantSA := agentRunServiceAccountName(run)
+		var sa corev1.ServiceAccount
+		if err := r.Get(context.Background(), types.NamespacedName{Name: wantSA, Namespace: run.Namespace}, &sa); err != nil {
+			t.Fatalf("get service account %s: %v", wantSA, err)
+		}
+		if sa.AutomountServiceAccountToken == nil || *sa.AutomountServiceAccountToken {
+			t.Errorf("service account %s does not disable automount", wantSA)
+		}
+		if sa.Annotations["eks.amazonaws.com/role-arn"] != "arn:example" {
+			t.Errorf("service account %s did not inherit workload-identity annotation", wantSA)
+		}
+		if len(sa.OwnerReferences) != 1 || sa.OwnerReferences[0].UID != run.UID {
+			t.Errorf("service account %s owner = %#v, want AgentRun %s", wantSA, sa.OwnerReferences, run.Name)
+		}
+
+		var binding rbacv1.RoleBinding
+		bindingName := "sympozium-lifecycle-" + run.Name
+		if err := r.Get(context.Background(), types.NamespacedName{Name: bindingName, Namespace: run.Namespace}, &binding); err != nil {
+			t.Fatalf("get RoleBinding %s: %v", bindingName, err)
+		}
+		if len(binding.Subjects) != 1 || binding.Subjects[0].Name != wantSA {
+			t.Errorf("RoleBinding %s subjects = %#v, want only %s", bindingName, binding.Subjects, wantSA)
+		}
+	}
+}

--- a/internal/controller/taskmodes/capabilities.go
+++ b/internal/controller/taskmodes/capabilities.go
@@ -250,6 +250,9 @@ func ValidateRunCompatibility(run *sympoziumv1alpha1.AgentRun) error {
 	if run.Spec.CanaryMode {
 		unsupported = append(unsupported, "canaryMode")
 	}
+	if run.Spec.AgentSandbox != nil && run.Spec.AgentSandbox.WarmPoolRef != "" {
+		unsupported = append(unsupported, "agentSandbox.warmPoolRef")
+	}
 	if len(unsupported) > 0 {
 		return fmt.Errorf("task.mode %q does not support AgentRun controls %v because they are implemented by agent-runner", Harness, unsupported)
 	}

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -447,6 +447,9 @@ func TestValidateRunCompatibility_RejectsAgentRunnerOnlyControls(t *testing.T) {
 		{name: "server", mutate: func(r *sympoziumv1alpha1.AgentRun) { r.Spec.Mode = "server" }, want: "mode=server"},
 		{name: "dry-run", mutate: func(r *sympoziumv1alpha1.AgentRun) { r.Spec.DryRun = true }, want: "dryRun"},
 		{name: "canary", mutate: func(r *sympoziumv1alpha1.AgentRun) { r.Spec.CanaryMode = true }, want: "canaryMode"},
+		{name: "warm pool", mutate: func(r *sympoziumv1alpha1.AgentRun) {
+			r.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxSpec{Enabled: true, WarmPoolRef: "wp-test"}
+		}, want: "agentSandbox.warmPoolRef"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			run := &sympoziumv1alpha1.AgentRun{Spec: sympoziumv1alpha1.AgentRunSpec{Task: harnessTask(nil)}}

--- a/internal/webhook/harness_isolation_test.go
+++ b/internal/webhook/harness_isolation_test.go
@@ -1,0 +1,41 @@
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestHarnessIsolationRejectsLifecycleRBAC(t *testing.T) {
+	run := capabilityRun(harnessTaskSpec(nil))
+	run.Spec.Lifecycle = &sympoziumv1alpha1.LifecycleHooks{RBAC: []sympoziumv1alpha1.RBACRule{{
+		APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get"},
+	}}}
+	err := (&PolicyEnforcer{}).validateHarnessIsolation(context.Background(), run)
+	if err == nil || !strings.Contains(err.Error(), "lifecycle RBAC") {
+		t.Fatalf("error = %v, want lifecycle RBAC rejection", err)
+	}
+}
+
+func TestHarnessIsolationRejectsHostAccessSkillPack(t *testing.T) {
+	pack := &sympoziumv1alpha1.SkillPack{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-admin", Namespace: "default"},
+		Spec: sympoziumv1alpha1.SkillPackSpec{Sidecar: &sympoziumv1alpha1.SkillSidecar{
+			Image: "node-admin:latest",
+			HostAccess: &sympoziumv1alpha1.HostAccessSpec{
+				Enabled: true, HostNetwork: true,
+			},
+		}},
+	}
+	pe := enforcerWithSkillPack(t, pack)
+	run := capabilityRun(harnessTaskSpec(nil))
+	run.Spec.Skills = []sympoziumv1alpha1.SkillRef{{SkillPackRef: "node-admin"}}
+	err := pe.validateHarnessIsolation(context.Background(), run)
+	if err == nil || !strings.Contains(err.Error(), "host access") {
+		t.Fatalf("error = %v, want host-access rejection", err)
+	}
+}

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -28,14 +28,15 @@ const systemNamespace = "sympozium-system"
 
 // reservedVolumeNames mirrors the controller-side reservedVolumeNames helper.
 var reservedVolumeNames = map[string]struct{}{
-	"workspace":     {},
-	"ipc":           {},
-	"skills":        {},
-	"tmp":           {},
-	"memory":        {},
-	"mcp-config":    {},
-	"sidecar-tools": {},
-	"harness-home":  {},
+	"workspace":                {},
+	"ipc":                      {},
+	"skills":                   {},
+	"tmp":                      {},
+	"memory":                   {},
+	"mcp-config":               {},
+	"sidecar-tools":            {},
+	"harness-home":             {},
+	"sympozium-run-api-access": {},
 }
 
 // builtinToolNames are the tool names Sympozium may register for the agent
@@ -146,6 +147,9 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Denied(err.Error())
 	}
 	if err := taskmodes.ValidateRunCompatibility(run); err != nil {
+		return admission.Denied(err.Error())
+	}
+	if err := pe.validateHarnessIsolation(ctx, run); err != nil {
 		return admission.Denied(err.Error())
 	}
 
@@ -293,7 +297,7 @@ func (pe *PolicyEnforcer) validateVolumes(ctx context.Context, run *sympoziumv1a
 
 	for _, v := range run.Spec.Volumes {
 		if _, reserved := reservedVolumeNames[v.Name]; reserved {
-			return fmt.Errorf("AgentRun.spec.volumes[%q]: name is reserved by Sympozium (reserved: workspace, ipc, skills, tmp, memory, mcp-config)", v.Name)
+			return fmt.Errorf("AgentRun.spec.volumes[%q]: name is reserved by Sympozium (including workspace, ipc, skills, tmp, memory, mcp-config, and sympozium-run-api-access)", v.Name)
 		}
 		declarations[v.Name] = append(declarations[v.Name], volumeOrigin{
 			source: "AgentRun.spec.volumes",
@@ -320,7 +324,7 @@ func (pe *PolicyEnforcer) validateVolumes(ctx context.Context, run *sympoziumv1a
 		}
 		for _, v := range sp.Spec.Sidecar.Volumes {
 			if _, reserved := reservedVolumeNames[v.Name]; reserved {
-				return fmt.Errorf("SkillPack %q sidecar volume %q: name is reserved by Sympozium (reserved: workspace, ipc, skills, tmp, memory, mcp-config)", spName, v.Name)
+				return fmt.Errorf("SkillPack %q sidecar volume %q: name is reserved by Sympozium (including workspace, ipc, skills, tmp, memory, mcp-config, and sympozium-run-api-access)", spName, v.Name)
 			}
 			declarations[v.Name] = append(declarations[v.Name], volumeOrigin{
 				source: fmt.Sprintf("SkillPack/%s.spec.sidecar.volumes", spName),
@@ -484,6 +488,34 @@ func toolParameterSchema(raw []byte) (map[string]json.RawMessage, map[string]str
 // controller with the supported-mode list.
 func (pe *PolicyEnforcer) validateTaskModeCapabilities(run *sympoziumv1alpha1.AgentRun) error {
 	return taskmodes.ValidateCapabilities(run)
+}
+
+// validateHarnessIsolation rejects privilege sources that would apply at pod
+// scope or can communicate through storage shared with an external runtime.
+// The controller repeats this check for clusters that run without admission.
+func (pe *PolicyEnforcer) validateHarnessIsolation(ctx context.Context, run *sympoziumv1alpha1.AgentRun) error {
+	if taskmodes.HarnessImage(run.Spec.Task) == "" {
+		return nil
+	}
+	if run.Spec.Lifecycle != nil && len(run.Spec.Lifecycle.RBAC) > 0 {
+		return fmt.Errorf("task.mode %q cannot be combined with lifecycle RBAC because hooks share run storage with the external runtime", taskmodes.Harness)
+	}
+	for _, ref := range run.Spec.Skills {
+		if ref.SkillPackRef == "" {
+			continue
+		}
+		name := strings.TrimPrefix(ref.SkillPackRef, "skillpack-")
+		pack := &sympoziumv1alpha1.SkillPack{}
+		if err := pe.Client.Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: name}, pack); err != nil {
+			if err := pe.Client.Get(ctx, types.NamespacedName{Namespace: systemNamespace, Name: name}, pack); err != nil {
+				continue
+			}
+		}
+		if pack.Spec.Sidecar != nil && pack.Spec.Sidecar.HostAccess != nil && pack.Spec.Sidecar.HostAccess.Enabled {
+			return fmt.Errorf("task.mode %q cannot be combined with SkillPack %q host access, host networking, host PID, or privileged execution", taskmodes.Harness, name)
+		}
+	}
+	return nil
 }
 
 // validateTaskModeBackend rejects a task mode that replaces the agent


### PR DESCRIPTION
## Summary

Adds the per-run Kubernetes identity and token boundary required by #349.

This is stacked on #356 so runtime inheritance remains independently reviewable. Once #356 merges, this PR can be retargeted to `main`.

## Security boundary

- Creates a unique, AgentRun-owned `sympozium-run-<run>` ServiceAccount for task, server, post-run, and Agent Sandbox execution paths.
- Sets `automountServiceAccountToken: false` on the ServiceAccount and every rendered pod.
- Projects a pod-bound, 10-minute token only into:
  - SkillPack sidecars that declare namespaced or cluster RBAC;
  - lifecycle hook containers that declare lifecycle RBAC;
  - the trusted built-in canary runner.
- Never mounts Kubernetes credentials into an external harness, ordinary agent, IPC bridge, unrelated sidecar, or post-run sentinel.
- Rebinds namespaced and cluster-scoped run RBAC to the unique identity, eliminating permission union across concurrent runs.
- Reconciles pre-existing RBAC objects so a stale binding to the legacy shared ServiceAccount is actively repaired after upgrade.
- Replaces the chart's shared canary binding with per-run canary RBAC and cleanup.
- Rejects harness + lifecycle RBAC and harness + host-access/host-network/host-PID/privileged SkillPack combinations at admission and in the controller.
- Rejects harness execution through Agent Sandbox warm pools, whose pre-created pod template cannot carry the run-specific primary container/identity.

The legacy `sympozium-agent` ServiceAccount remains only as an annotation template for IRSA/workload-identity integrations. No AgentRun pod or RoleBinding selects it.

## Compatibility

- AgentRuns remain the execution and lifecycle resource.
- Existing workload-identity annotations on `sympozium-agent` are copied to each run identity; AWS documentation now requires a namespace-scoped `sympozium-run-*` trust condition.
- Job and Agent Sandbox non-warm-pool backends share the same identity-bearing pod template.
- Server-mode and post-run workloads use the same run identity.

## Verification

- `make generate`
- `make test` (full race suite)
- `make vet`
- `make build`
- `helm lint charts/sympozium`
- Focused security regressions cover credential mount exclusion, 10-minute token projection, concurrent-run binding isolation, stale binding repair, canary isolation, and harness privilege-combination denial.

Live cluster verification will be added after deploying this commit.
