### PR TITLE
feat(security): restrict harness NATS access

### DIFF
--- a/charts/sympozium/templates/_helpers.tpl
+++ b/charts/sympozium/templates/_helpers.tpl
@@ -118,6 +118,15 @@ NATS URL — internal or external.
 {{- end }}
 {{- end }}
 
+{{/* Name of credentials Secret for bundled NATS. */}}
+{{- define "sympozium.natsAuthSecret" -}}
+{{- if .Values.nats.auth.existingSecret }}
+{{- .Values.nats.auth.existingSecret }}
+{{- else }}
+{{- printf "%s-nats-auth" (include "sympozium.fullname" .) }}
+{{- end }}
+{{- end }}
+
 {{/*
 Namespace helper.
 */}}

--- a/charts/sympozium/templates/apiserver-deployment.yaml
+++ b/charts/sympozium/templates/apiserver-deployment.yaml
@@ -32,6 +32,15 @@ spec:
             - --serve-ui
           {{- end }}
           env:
+          {{- if and .Values.nats.enabled .Values.nats.auth.enabled }}
+            - name: NATS_USERNAME
+              value: sympozium-control
+            - name: NATS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sympozium.natsAuthSecret" . }}
+                  key: control-password
+          {{- end }}
           {{- if .Values.apiserver.webUI.token }}
             - name: SYMPOZIUM_UI_TOKEN
               value: {{ .Values.apiserver.webUI.token | quote }}

--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -34,6 +34,22 @@ spec:
           env:
             - name: NATS_URL
               value: {{ include "sympozium.natsUrl" . }}
+            {{- if and .Values.nats.enabled .Values.nats.auth.enabled }}
+            - name: NATS_USERNAME
+              value: sympozium-control
+            - name: NATS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sympozium.natsAuthSecret" . }}
+                  key: control-password
+            - name: NATS_BRIDGE_USERNAME
+              value: sympozium-bridge
+            - name: NATS_BRIDGE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sympozium.natsAuthSecret" . }}
+                  key: bridge-password
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/sympozium/templates/llmfit-daemonset.yaml
+++ b/charts/sympozium/templates/llmfit-daemonset.yaml
@@ -54,6 +54,15 @@ spec:
                   fieldPath: spec.nodeName
             - name: NATS_URL
               value: {{ include "sympozium.natsUrl" . }}
+            {{- if and .Values.nats.enabled .Values.nats.auth.enabled }}
+            - name: NATS_USERNAME
+              value: sympozium-control
+            - name: NATS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sympozium.natsAuthSecret" . }}
+                  key: control-password
+            {{- end }}
             - name: LLMFIT_EVENT_INTERVAL
               value: {{ .Values.llmfit.daemonset.eventInterval | quote }}
             - name: LLMFIT_HOST_PROC

--- a/charts/sympozium/templates/nats-auth-secret.yaml
+++ b/charts/sympozium/templates/nats-auth-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.nats.enabled .Values.nats.auth.enabled (not .Values.nats.auth.existingSecret) }}
+{{- $existing := lookup "v1" "Secret" (include "sympozium.namespace" .) (include "sympozium.natsAuthSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sympozium.natsAuthSecret" . }}
+  namespace: {{ include "sympozium.namespace" . }}
+  labels:
+    {{- include "sympozium.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nats
+type: Opaque
+data:
+  control-password: {{ if $existing }}{{ index $existing.data "control-password" }}{{ else }}{{ randAlphaNum 40 | b64enc }}{{ end }}
+  bridge-password: {{ if $existing }}{{ index $existing.data "bridge-password" }}{{ else }}{{ randAlphaNum 40 | b64enc }}{{ end }}
+{{- end }}

--- a/charts/sympozium/templates/nats-config.yaml
+++ b/charts/sympozium/templates/nats-config.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.nats.enabled .Values.nats.auth.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-config
+  namespace: {{ include "sympozium.namespace" . }}
+  labels:
+    {{- include "sympozium.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nats
+data:
+  nats.conf: |
+    jetstream { store_dir: "/data" }
+    http_port: 8222
+    authorization {
+      users = [
+        {user: "sympozium-control", password: $NATS_CONTROL_PASSWORD, permissions: {publish: ">", subscribe: ">"}},
+        {user: "sympozium-bridge", password: $NATS_BRIDGE_PASSWORD, permissions: {
+          publish: ["sympozium.agent.run.completed", "sympozium.agent.run.failed", "sympozium.agent.status.update", "sympozium.agent.stream.chunk", "sympozium.agent.spawn.request", "sympozium.agent.subagent.request", "sympozium.tool.exec.request", "sympozium.channel.message.send", "sympozium.schedule.upsert", "sympozium.agent.prompt.request.*", "sympozium.agent.prompt.result.*", "sympozium.agent.context.clear.*"],
+          subscribe: ["sympozium.agent.followup.*", "sympozium.tool.exec.result.*", "sympozium.agent.delegate.result.*", "sympozium.agent.subagent.result.*"]
+        }}
+      ]
+    }
+{{- end }}

--- a/charts/sympozium/templates/nats-deployment.yaml
+++ b/charts/sympozium/templates/nats-deployment.yaml
@@ -29,10 +29,28 @@ spec:
           image: "{{ .Values.nats.image.repository }}:{{ .Values.nats.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            {{- if .Values.nats.auth.enabled }}
+            - -c
+            - /etc/nats/nats.conf
+            {{- else }}
             - --jetstream
             - --store_dir=/data
             - -m
             - "8222"
+            {{- end }}
+          {{- if .Values.nats.auth.enabled }}
+          env:
+            - name: NATS_CONTROL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sympozium.natsAuthSecret" . }}
+                  key: control-password
+            - name: NATS_BRIDGE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sympozium.natsAuthSecret" . }}
+                  key: bridge-password
+          {{- end }}
           ports:
             - containerPort: 4222
               name: client
@@ -62,6 +80,11 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            {{- if .Values.nats.auth.enabled }}
+            - name: config
+              mountPath: /etc/nats
+              readOnly: true
+            {{- end }}
       volumes:
         - name: data
           {{- if .Values.nats.persistence.enabled }}
@@ -70,6 +93,20 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.nats.auth.enabled }}
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: nats-config
+              - secret:
+                  name: {{ include "sympozium.natsAuthSecret" . }}
+                  items:
+                    - key: control-password
+                      path: control-password
+                    - key: bridge-password
+                      path: bridge-password
+        {{- end }}
       {{- with .Values.nats.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -93,6 +93,15 @@ nats:
       memory: 64Mi
   # -- External NATS URL (used when nats.enabled=false)
   externalUrl: ""
+  auth:
+    # -- Require credentials for the bundled NATS server. The bridge account is
+    # restricted to mediated IPC subjects; all other Sympozium components use
+    # the control-plane account. External NATS operators must provide an
+    # equivalent subject policy themselves.
+    enabled: true
+    # -- Existing Secret containing `control-password` and `bridge-password`.
+    # Leave empty for Helm to create and retain a random secret.
+    existingSecret: ""
   persistence:
     enabled: false
     size: 1Gi

--- a/cmd/ipc-bridge/main.go
+++ b/cmd/ipc-bridge/main.go
@@ -40,7 +40,10 @@ func main() {
 	log := zap.New(zap.UseDevMode(false)).WithName("ipc-bridge")
 
 	// Connect to event bus
-	bus, err := eventbus.NewNATSEventBus(eventBusURL)
+	// The bridge deliberately uses only core NATS. Its credential is allowed to
+	// relay the small, explicit IPC subject set but cannot manage JetStream or
+	// publish directly to arbitrary control-plane subjects.
+	bus, err := eventbus.NewCoreNATSEventBus(eventBusURL)
 	if err != nil {
 		log.Error(err, "failed to connect to event bus")
 		os.Exit(1)

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -97,6 +97,7 @@ const (
 	legacyAgentServiceAccountName = "sympozium-agent"
 	runAPIAccessVolumeName        = "sympozium-run-api-access"
 	runAPIAccessMountPath         = "/var/run/secrets/kubernetes.io/serviceaccount"
+	runNATSBridgeSecretPrefix     = "sympozium-run-nats-"
 )
 
 // tokenBudgetCountedAnnotation marks an AgentRun whose token usage has already
@@ -493,6 +494,9 @@ func (r *AgentRunReconciler) prepareRunPrerequisites(
 	// workload-identity integrations; no run pod executes as that shared account.
 	if err := r.ensureAgentServiceAccount(ctx, agentRun); err != nil {
 		return out, fmt.Errorf("ensuring agent service account: %w", err)
+	}
+	if err := r.ensureNATSBridgeCredentials(ctx, agentRun); err != nil {
+		return out, fmt.Errorf("ensuring IPC bridge NATS credentials: %w", err)
 	}
 
 	// Create the input ConfigMap with the task.
@@ -2438,6 +2442,56 @@ func agentRunServiceAccountName(agentRun *sympoziumv1alpha1.AgentRun) string {
 	return strings.TrimRight(name[:maxDNSSubdomainLength-len(suffix)], "-") + suffix
 }
 
+func agentRunNATSBridgeSecretName(agentRun *sympoziumv1alpha1.AgentRun) string {
+	return runNATSBridgeSecretPrefix + agentRun.Name
+}
+
+func natsBridgeCredentialEnv(agentRun *sympoziumv1alpha1.AgentRun) []corev1.EnvVar {
+	secret := agentRunNATSBridgeSecretName(agentRun)
+	return []corev1.EnvVar{
+		{Name: "NATS_USERNAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secret}, Key: "username",
+		}}},
+		{Name: "NATS_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secret}, Key: "password",
+		}}},
+	}
+}
+
+// ensureNATSBridgeCredentials copies the restricted bridge credential into a
+// run-owned Secret. The credential is mounted only by ipc-bridge, never by the
+// adapter/harness container. Empty controller environment keeps external,
+// unauthenticated NATS installations backward compatible.
+func (r *AgentRunReconciler) ensureNATSBridgeCredentials(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun) error {
+	username, password := os.Getenv("NATS_BRIDGE_USERNAME"), os.Getenv("NATS_BRIDGE_PASSWORD")
+	if username == "" || password == "" {
+		return nil
+	}
+	name := agentRunNATSBridgeSecretName(agentRun)
+	existing := &corev1.Secret{}
+	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: agentRun.Namespace}, existing)
+	if err == nil {
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("checking bridge credential secret: %w", err)
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: agentRun.Namespace, Labels: map[string]string{
+			"sympozium.ai/agent-run": agentRun.Name,
+		}},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"username": []byte(username), "password": []byte(password)},
+	}
+	if err := controllerutil.SetControllerReference(agentRun, secret, r.Scheme); err != nil {
+		return fmt.Errorf("setting bridge credential owner: %w", err)
+	}
+	if err := r.Create(ctx, secret); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating bridge credential secret: %w", err)
+	}
+	return nil
+}
+
 // ensureAgentServiceAccount creates a unique ServiceAccount owned by the run.
 // If the legacy namespace-level account exists, its annotations are copied so
 // existing cloud workload-identity configuration continues to apply. The
@@ -2784,6 +2838,9 @@ func (r *AgentRunReconciler) buildContainers(
 					{Name: "INSTANCE_NAME", Value: agentRun.Spec.AgentRef},
 					{Name: "AGENT_NAMESPACE", Value: agentRun.Namespace},
 					{Name: "EVENT_BUS_URL", Value: "nats://nats.sympozium-system.svc:4222"},
+				}
+				if os.Getenv("NATS_BRIDGE_USERNAME") != "" && os.Getenv("NATS_BRIDGE_PASSWORD") != "" {
+					env = append(env, natsBridgeCredentialEnv(agentRun)...)
 				}
 				// The bridge validates agent-written channel-message attribution
 				// against this identity (see sanitizeOutboundMessage). Stamped at

--- a/internal/controller/agentrun_identity_test.go
+++ b/internal/controller/agentrun_identity_test.go
@@ -13,6 +13,54 @@ import (
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 )
 
+func TestNATSBridgeCredentialsAreRunOwnedAndBridgeOnly(t *testing.T) {
+	t.Setenv("NATS_BRIDGE_USERNAME", "sympozium-bridge")
+	t.Setenv("NATS_BRIDGE_PASSWORD", "not-a-real-password")
+	run := newTestRun()
+	run.Name = "bridge-creds"
+	r := newAgentRunTestReconciler(t, run)
+	if err := r.ensureNATSBridgeCredentials(context.Background(), run); err != nil {
+		t.Fatalf("ensure NATS bridge credentials: %v", err)
+	}
+	var secret corev1.Secret
+	if err := r.Get(context.Background(), types.NamespacedName{Name: agentRunNATSBridgeSecretName(run), Namespace: run.Namespace}, &secret); err != nil {
+		t.Fatalf("get bridge credential secret: %v", err)
+	}
+	if string(secret.Data["username"]) != "sympozium-bridge" || string(secret.Data["password"]) != "not-a-real-password" {
+		t.Fatalf("bridge secret data = %#v", secret.Data)
+	}
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].UID != run.UID {
+		t.Fatalf("bridge secret owner = %#v, want AgentRun", secret.OwnerReferences)
+	}
+
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("build job: %v", err)
+	}
+	bridge := containerByName(job.Spec.Template.Spec.Containers, "ipc-bridge")
+	agent := containerByName(job.Spec.Template.Spec.Containers, "agent")
+	if bridge == nil || agent == nil {
+		t.Fatal("job lacks agent or IPC bridge")
+	}
+	for _, name := range []string{"NATS_USERNAME", "NATS_PASSWORD"} {
+		if !hasEnv(bridge.Env, name) {
+			t.Errorf("bridge lacks %s", name)
+		}
+		if hasEnv(agent.Env, name) {
+			t.Errorf("harness/agent unexpectedly receives %s", name)
+		}
+	}
+}
+
+func hasEnv(env []corev1.EnvVar, name string) bool {
+	for _, item := range env {
+		if item.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func TestHarnessReceivesNoKubernetesToken(t *testing.T) {
 	r := &AgentRunReconciler{}
 	job, err := r.buildJob(context.Background(), harnessModeRun(nil), false, nil, nil, nil, nil)

--- a/internal/controller/density_subscriber.go
+++ b/internal/controller/density_subscriber.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"time"
 
@@ -66,10 +67,10 @@ type llmfitInstalledData struct {
 func (fs *DensitySubscriber) Start(ctx context.Context) error {
 	fs.Log.Info("Connecting to NATS for llmfit density events", "url", fs.NATSUrl)
 
-	nc, err := nats.Connect(fs.NATSUrl,
+	opts := []nats.Option{
 		nats.RetryOnFailedConnect(true),
 		nats.MaxReconnects(-1), // Reconnect indefinitely.
-		nats.ReconnectWait(2*time.Second),
+		nats.ReconnectWait(2 * time.Second),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
 			if err != nil {
 				fs.Log.Info("NATS disconnected", "error", err)
@@ -78,7 +79,11 @@ func (fs *DensitySubscriber) Start(ctx context.Context) error {
 		nats.ReconnectHandler(func(_ *nats.Conn) {
 			fs.Log.Info("NATS reconnected")
 		}),
-	)
+	}
+	if user, password := os.Getenv("NATS_USERNAME"), os.Getenv("NATS_PASSWORD"); user != "" || password != "" {
+		opts = append(opts, nats.UserInfo(user, password))
+	}
+	nc, err := nats.Connect(fs.NATSUrl, opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/eventbus/core_nats.go
+++ b/internal/eventbus/core_nats.go
@@ -1,0 +1,98 @@
+package eventbus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// CoreNATSEventBus is an EventBus backed by core NATS rather than the
+// JetStream management API. It exists for intentionally constrained clients
+// such as the IPC bridge: publishing to a subject is still captured by the
+// sympozium JetStream stream, but the client never needs permission to create
+// streams or consumers.
+type CoreNATSEventBus struct {
+	conn *nats.Conn
+}
+
+// NewCoreNATSEventBus creates a core-NATS client. NATS_USERNAME and
+// NATS_PASSWORD are optional so existing unauthenticated external NATS
+// installations remain supported during migration.
+func NewCoreNATSEventBus(url string) (*CoreNATSEventBus, error) {
+	nc, err := connect(url)
+	if err != nil {
+		return nil, err
+	}
+	return &CoreNATSEventBus{conn: nc}, nil
+}
+
+func (n *CoreNATSEventBus) Publish(ctx context.Context, topic string, event *Event) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshalling event: %w", err)
+	}
+	msg := &nats.Msg{Subject: topicToSubject(topic), Data: data, Header: nats.Header{}}
+	InjectTraceContext(ctx, msg.Header)
+	if err := n.conn.PublishMsg(msg); err != nil {
+		return fmt.Errorf("publishing to %s: %w", msg.Subject, err)
+	}
+	// Unlike JetStream Publish, core NATS publish is asynchronous. Flush before
+	// returning because the bridge may terminate immediately after writing a
+	// terminal result and must not lose that result during connection close.
+	if err := n.conn.FlushWithContext(ctx); err != nil {
+		return fmt.Errorf("flushing publish to %s: %w", msg.Subject, err)
+	}
+	return nil
+}
+
+func (n *CoreNATSEventBus) Subscribe(ctx context.Context, topic string) (<-chan *Event, error) {
+	ch := make(chan *Event, 64)
+	sub, err := n.conn.Subscribe(topicToSubject(topic), func(msg *nats.Msg) {
+		var event Event
+		if err := json.Unmarshal(msg.Data, &event); err != nil {
+			return
+		}
+		event.Ctx = ExtractTraceContext(ctx, msg.Header)
+		select {
+		case ch <- &event:
+		case <-ctx.Done():
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("subscribing to %s: %w", topicToSubject(topic), err)
+	}
+	go func() {
+		<-ctx.Done()
+		sub.Unsubscribe()
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func (n *CoreNATSEventBus) Close() error { n.conn.Close(); return nil }
+
+// connect applies optional username/password credentials and the reconnect
+// behaviour shared by both trusted JetStream clients and constrained bridges.
+func connect(url string) (*nats.Conn, error) {
+	nc, err := nats.Connect(url, connectOptions()...)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to NATS: %w", err)
+	}
+	return nc, nil
+}
+
+func connectOptions() []nats.Option {
+	opts := []nats.Option{
+		nats.RetryOnFailedConnect(true),
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2 * time.Second),
+	}
+	if user, password := os.Getenv("NATS_USERNAME"), os.Getenv("NATS_PASSWORD"); user != "" || password != "" {
+		opts = append(opts, nats.UserInfo(user, password))
+	}
+	return opts
+}

--- a/internal/eventbus/nats.go
+++ b/internal/eventbus/nats.go
@@ -35,27 +35,21 @@ func NewNATSEventBus(url string) (*NATSEventBus, error) {
 	// limit means a NATS pod recreation that takes longer than
 	// limit*ReconnectWait permanently kills the connection, silently breaking
 	// every subscription until the process restarts.
-	nc, err := nats.Connect(url,
-		nats.RetryOnFailedConnect(true),
-		nats.MaxReconnects(-1),
-		nats.ReconnectWait(2*time.Second),
+	opts := append(connectOptions(),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
 			log.Printf("eventbus: disconnected from NATS: %v", err)
 		}),
 		nats.ReconnectHandler(func(c *nats.Conn) {
 			log.Printf("eventbus: reconnected to NATS at %s", c.ConnectedUrl())
-			// NATS may have been recreated with no stream; recreate it so
-			// publishes succeed and consumers can be re-established.
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			if _, err := n.ensureStream(ctx); err != nil {
 				log.Printf("eventbus: failed to ensure stream after reconnect: %v", err)
 			}
 		}),
-		nats.ClosedHandler(func(_ *nats.Conn) {
-			log.Printf("eventbus: NATS connection closed")
-		}),
+		nats.ClosedHandler(func(_ *nats.Conn) { log.Printf("eventbus: NATS connection closed") }),
 	)
+	nc, err := nats.Connect(url, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to NATS: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes the harness NATS-bypass gap from #349:

- enables authentication for the bundled NATS deployment, with a preserved/generated Helm Secret;
- grants the IPC bridge a restricted core-NATS account limited to mediated IPC subjects;
- moves IPC bridge communication off JetStream management APIs, while publications are still captured by the control-plane stream;
- creates an AgentRun-owned Secret containing bridge credentials and injects it only into `ipc-bridge`, never the adapter/harness container;
- supplies trusted controller, API server, llmfit daemon, and controller density subscriber paths with the control-plane credential;
- retains explicit unauthenticated external-NATS compatibility when the bundled server is disabled.

## Security properties

An external harness cannot connect anonymously to NATS and forge `agent.run.requested` or other control-plane events. It also does not receive the bridge credential. The trusted IPC bridge remains the only adapter-adjacent component able to publish its narrow mediated subject set.

This is role-scoped, not dynamically per-run NATS authorization: the per-run Kubernetes Secret limits credential delivery and lifetime to the run, but all bridges share the restricted broker account. A future NATS JWT/auth-callout design would be required for cryptographic per-run subjects.

## Verification

- `make test`
- `make vet`
- `make build`
- `helm lint charts/sympozium`
- rendered both authenticated and explicitly unauthenticated chart variants
- local rendered NATS ACL check: bridge account published `sympozium.agent.run.completed`; forbidden `sympozium.agent.run.requested` was denied.
- **framework cluster deployment:** controller, API server, webhook, and IPC bridge built from this branch; authenticated NATS enabled. A digest-pinned harness run reached `Succeeded` and recorded its resolved digest. Its primary adapter container had no `NATS_*` environment variables; only `ipc-bridge` received a run-owned credential Secret. An in-cluster forbidden publish authenticated as that bridge account was denied by NATS.
