### PR TITLE
fix(harness): restrict model credentials to Agent allowlist

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -361,6 +361,25 @@ type agentRunInputs struct {
 	allowedOutboundChannels []string
 }
 
+// agentAllowsModelCredential checks the Agent-owned allowlist for a model
+// Secret. An empty reference is valid for cluster-local and unauthenticated
+// providers. Empty provider on an AuthRef is an explicit provider-agnostic
+// grant by the Agent owner.
+func agentAllowsModelCredential(agent *sympoziumv1alpha1.Agent, provider, secret string) bool {
+	if strings.TrimSpace(secret) == "" {
+		return true
+	}
+	for _, ref := range agent.Spec.AuthRefs {
+		if ref.Secret != secret {
+			continue
+		}
+		if ref.Provider == "" || strings.EqualFold(ref.Provider, provider) {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveAgentRunInputs looks up the backing Agent, folds its configuration into
 // the AgentRun in place (skills, ensemble label, run timeout), and returns the
 // derived values buildAgentPodTemplate needs.
@@ -719,7 +738,6 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 	} else {
 		agentRun.Spec.Task = normalized
 	}
-
 	// Validate against policy
 	if err := r.validatePolicy(ctx, agentRun); err != nil {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("policy validation failed: %v", err))
@@ -755,6 +773,9 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf(
 			"task.mode %q replaces the agent container, which backend: celln never creates; use the default job backend (or agentSandbox) for this mode",
 			agentRun.Spec.Task.GetMode()))
+	}
+	if taskmodes.HarnessImage(agentRun.Spec.Task) != "" && !agentAllowsModelCredential(&runtimeInstance, agentRun.Spec.Model.Provider, agentRun.Spec.Model.AuthSecretRef) {
+		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("harness model credential %q is not declared in Agent %q spec.authRefs for provider %q", agentRun.Spec.Model.AuthSecretRef, runtimeInstance.Name, agentRun.Spec.Model.Provider))
 	}
 
 	// Agent Sandbox mode — create Sandbox CR instead of Job.

--- a/internal/controller/agentrun_credential_test.go
+++ b/internal/controller/agentrun_credential_test.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"testing"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestAgentAllowsModelCredential(t *testing.T) {
+	agent := &sympoziumv1alpha1.Agent{Spec: sympoziumv1alpha1.AgentSpec{AuthRefs: []sympoziumv1alpha1.SecretRef{
+		{Provider: "openai", Secret: "openai-key"},
+		{Secret: "provider-agnostic-key"},
+	}}}
+
+	for _, tt := range []struct {
+		name     string
+		provider string
+		secret   string
+		want     bool
+	}{
+		{name: "empty local credential", provider: "custom", want: true},
+		{name: "matching provider", provider: "openai", secret: "openai-key", want: true},
+		{name: "provider case is insensitive", provider: "OpenAI", secret: "openai-key", want: true},
+		{name: "missing provider does not match provider-specific grant", secret: "openai-key", want: false},
+		{name: "agent provider-agnostic grant", provider: "anthropic", secret: "provider-agnostic-key", want: true},
+		{name: "mismatched provider", provider: "anthropic", secret: "openai-key", want: false},
+		{name: "undeclared secret", provider: "openai", secret: "other-key", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentAllowsModelCredential(agent, tt.provider, tt.secret); got != tt.want {
+				t.Fatalf("agentAllowsModelCredential(%q, %q) = %t, want %t", tt.provider, tt.secret, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/model_credential_test.go
+++ b/internal/webhook/model_credential_test.go
@@ -1,0 +1,25 @@
+package webhook
+
+import (
+	"testing"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestAgentAllowsModelCredential(t *testing.T) {
+	agent := &sympoziumv1alpha1.Agent{Spec: sympoziumv1alpha1.AgentSpec{AuthRefs: []sympoziumv1alpha1.SecretRef{
+		{Provider: "openai", Secret: "openai-key"},
+	}}}
+	if !agentAllowsModelCredential(agent, "openai", "openai-key") {
+		t.Fatal("expected Agent-declared credential to be allowed")
+	}
+	if agentAllowsModelCredential(agent, "anthropic", "openai-key") {
+		t.Fatal("credential must not cross a provider boundary")
+	}
+	if agentAllowsModelCredential(agent, "", "openai-key") {
+		t.Fatal("missing provider must not match a provider-specific credential")
+	}
+	if agentAllowsModelCredential(agent, "openai", "other-key") {
+		t.Fatal("undeclared credential must be denied")
+	}
+}

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -121,6 +121,14 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 	}
 	run.Spec.Task = normalized
 
+	// A harness replaces trusted agent-runner and receives the selected model
+	// credential as environment variables. Do not let a run author turn that
+	// into an arbitrary Secret read: the backing Agent is the authority that
+	// grants a provider credential to this execution identity.
+	if taskmodes.HarnessImage(run.Spec.Task) != "" && !agentAllowsModelCredential(&instance, run.Spec.Model.Provider, run.Spec.Model.AuthSecretRef) {
+		return admission.Denied(fmt.Sprintf("task.mode %q may use only model credentials declared in Agent %q spec.authRefs; secret %q is not allowed for provider %q", taskmodes.Harness, instance.Name, run.Spec.Model.AuthSecretRef, run.Spec.Model.Provider))
+	}
+
 	// Validate user-supplied volumes (AgentRun + resolved SkillPack sidecars).
 	// This catches reserved-name collisions and same-name-different-source
 	// collisions before they become silent mismounts at runtime.
@@ -237,6 +245,25 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	return admission.Allowed("policy validated")
+}
+
+// agentAllowsModelCredential checks the Agent-owned allowlist for a model
+// Secret. An empty reference is valid for cluster-local and unauthenticated
+// providers. Empty provider on an AuthRef means the Agent deliberately grants
+// that Secret independent of provider naming.
+func agentAllowsModelCredential(agent *sympoziumv1alpha1.Agent, provider, secret string) bool {
+	if strings.TrimSpace(secret) == "" {
+		return true
+	}
+	for _, ref := range agent.Spec.AuthRefs {
+		if ref.Secret != secret {
+			continue
+		}
+		if ref.Provider == "" || strings.EqualFold(ref.Provider, provider) {
+			return true
+		}
+	}
+	return false
 }
 
 func (pe *PolicyEnforcer) validateResources(run *sympoziumv1alpha1.AgentRun, policy *sympoziumv1alpha1.SympoziumPolicy) error {


### PR DESCRIPTION
Closes the model-credential boundary in #349. Harness-mode runs can now use only an auth Secret explicitly listed by the backing Agent for the selected provider (or an intentionally provider-agnostic Agent auth ref). Empty references remain valid for cluster-local/unauthenticated models. Enforcement exists in both admission and controller reconciliation, so it remains active if the webhook is unavailable.

Tests: `make test`, `make vet`.