### PR TITLE
fix(memory): reconcile managed server image

### DIFF
--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -650,11 +650,11 @@ func memoryServerContainer(spec *corev1.PodSpec) *corev1.Container {
 	return nil
 }
 
-// syncMemoryAdminTokenEnv reconciles just the MEMORY_ADMIN_TOKEN env var on an
-// existing memory Deployment: added when adminDelete is switched on, repointed
-// when the Secret name changes, removed when the feature is switched off. It is
-// a no-op when the env already matches, so steady-state reconciles issue no
-// writes and the pod is not restarted.
+// syncMemoryDeployment reconciles controller-owned settings on an existing
+// memory Deployment. The rest of the spec remains create-only, while the
+// memory-server image tracks the configured Sympozium image tag and the
+// admin-token env tracks its Secret reference. It is a no-op when both already
+// match, so steady-state reconciles issue no writes and the pod is not restarted.
 //
 // Shared by the per-agent memory Deployment (AgentReconciler) and the shared
 // workflow memory Deployment (EnsembleReconciler), both of which are otherwise
@@ -663,10 +663,17 @@ func memoryServerContainer(spec *corev1.PodSpec) *corev1.Container {
 // Note this reacts to the Secret *reference* changing, not to the token value
 // inside the Secret. Rotating the value in place leaves the pod holding the old
 // token in its env until it restarts.
-func syncMemoryAdminTokenEnv(ctx context.Context, c client.Client, log logr.Logger, deploy *appsv1.Deployment) error {
+func syncMemoryDeployment(ctx context.Context, c client.Client, log logr.Logger, deploy *appsv1.Deployment, image string) error {
 	container := memoryServerContainer(&deploy.Spec.Template.Spec)
 	if container == nil {
 		return nil
+	}
+
+	changed := false
+	if image != "" && container.Image != image {
+		log.Info("Updating memory server image", "deployment", deploy.Name, "from", container.Image, "to", image)
+		container.Image = image
+		changed = true
 	}
 
 	desired := memoryAdminTokenEnv()
@@ -685,21 +692,33 @@ func syncMemoryAdminTokenEnv(ctx context.Context, c client.Client, log logr.Logg
 
 	switch {
 	case want == nil && idx < 0:
-		return nil // Disabled and absent — nothing to do.
+		// Disabled and absent — nothing to do.
 	case want == nil:
 		container.Env = append(container.Env[:idx], container.Env[idx+1:]...)
 		log.Info("Removing memory admin token env", "deployment", deploy.Name)
+		changed = true
 	case idx < 0:
 		container.Env = append(container.Env, *want)
 		log.Info("Adding memory admin token env", "deployment", deploy.Name)
+		changed = true
 	case equality.Semantic.DeepEqual(container.Env[idx], *want):
-		return nil // Already correct.
+		// Already correct.
 	default:
 		container.Env[idx] = *want
 		log.Info("Updating memory admin token env", "deployment", deploy.Name)
+		changed = true
 	}
 
+	if !changed {
+		return nil
+	}
 	return c.Update(ctx, deploy)
+}
+
+// syncMemoryAdminTokenEnv is retained for callers and focused tests that only
+// need to reconcile the admin token without changing the image.
+func syncMemoryAdminTokenEnv(ctx context.Context, c client.Client, log logr.Logger, deploy *appsv1.Deployment) error {
+	return syncMemoryDeployment(ctx, c, log, deploy, "")
 }
 
 // reconcileMemoryDeployment ensures a Deployment + Service exist for the memory
@@ -733,7 +752,7 @@ func (r *AgentReconciler) reconcileMemoryDeployment(ctx context.Context, log log
 		// Already exists. The rest of the spec is deliberately left alone, but the
 		// admin-token env is reconciled so enabling adminDelete (or pointing it at a
 		// different Secret) takes effect without deleting the Deployment.
-		return syncMemoryAdminTokenEnv(ctx, r.Client, log, &existingDeploy)
+		return syncMemoryDeployment(ctx, r.Client, log, &existingDeploy, image)
 	}
 
 	replicas := int32(1)

--- a/internal/controller/agent_memory_admin_token_test.go
+++ b/internal/controller/agent_memory_admin_token_test.go
@@ -217,6 +217,31 @@ func TestSyncMemoryAdminTokenEnv_NoMemoryServerContainer(t *testing.T) {
 	}
 }
 
+func TestSyncMemoryDeployment_UpdatesOnlyMemoryServerImage(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "")
+
+	sidecar := corev1.Container{Name: "sidecar", Image: "sidecar:v1"}
+	deploy := memoryDeploy("agent-memory", "default", nil, sidecar)
+	memoryServerContainer(&deploy.Spec.Template.Spec).Image = "ghcr.io/sympozium-ai/sympozium/skill-memory:retired"
+	_, cl := newInstanceTestReconciler(t, deploy)
+
+	const wanted = "ghcr.io/sympozium-ai/sympozium/skill-memory:latest"
+	if err := syncMemoryDeployment(context.Background(), cl, logr.Discard(), deploy, wanted); err != nil {
+		t.Fatalf("syncMemoryDeployment: %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "agent-memory", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if image := memoryServerContainer(&got.Spec.Template.Spec).Image; image != wanted {
+		t.Errorf("memory-server image = %q, want %q", image, wanted)
+	}
+	if image := got.Spec.Template.Spec.Containers[0].Image; image != "sidecar:v1" {
+		t.Errorf("sidecar image changed to %q", image)
+	}
+}
+
 // ── reconcileMemoryDeployment entry point ────────────────────────────────────
 
 // TestReconcileMemoryDeployment_UpdatesTokenOnExisting pins the actual bug: the
@@ -242,6 +267,31 @@ func TestReconcileMemoryDeployment_UpdatesTokenOnExisting(t *testing.T) {
 
 	if _, ok := tokenEnvOf(t, cl, "agent-memory", "default"); !ok {
 		t.Error("existing memory Deployment did not pick up MEMORY_ADMIN_TOKEN on reconcile")
+	}
+}
+
+func TestReconcileMemoryDeployment_UpdatesImageOnExisting(t *testing.T) {
+	t.Setenv("SYMPOZIUM_IMAGE_REGISTRY", "registry.example/sympozium")
+
+	instance := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentSpec{Skills: []sympoziumv1alpha1.SkillRef{{SkillPackRef: "memory"}}},
+	}
+	deploy := memoryDeploy("agent-memory", "default", nil)
+	memoryServerContainer(&deploy.Spec.Template.Spec).Image = "registry.example/sympozium/skill-memory:retired"
+	r, cl := newInstanceTestReconciler(t, instance, deploy)
+	r.ImageTag = "latest"
+
+	if err := r.reconcileMemoryDeployment(context.Background(), logr.Discard(), instance); err != nil {
+		t.Fatalf("reconcileMemoryDeployment: %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "agent-memory", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if image := memoryServerContainer(&got.Spec.Template.Spec).Image; image != "registry.example/sympozium/skill-memory:latest" {
+		t.Errorf("memory-server image = %q, want latest configured image", image)
 	}
 }
 
@@ -276,5 +326,32 @@ func TestReconcileSharedMemory_UpdatesTokenOnExisting(t *testing.T) {
 
 	if _, ok := tokenEnvOf(t, cl, "crew-shared-memory", "default"); !ok {
 		t.Error("existing shared memory Deployment did not pick up MEMORY_ADMIN_TOKEN on reconcile")
+	}
+}
+
+func TestReconcileSharedMemory_UpdatesImageOnExisting(t *testing.T) {
+	t.Setenv("SYMPOZIUM_IMAGE_REGISTRY", "registry.example/sympozium")
+	t.Setenv("SYMPOZIUM_IMAGE_TAG", "latest")
+
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "crew", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.EnsembleSpec{SharedMemory: &sympoziumv1alpha1.SharedMemorySpec{Enabled: true}},
+	}
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "crew-shared-memory-db", Namespace: "default"}}
+	deploy := memoryDeploy("crew-shared-memory", "default", nil)
+	memoryServerContainer(&deploy.Spec.Template.Spec).Image = "registry.example/sympozium/skill-memory:retired"
+
+	agentR, cl := newInstanceTestReconciler(t, pack, pvc, deploy)
+	r := &EnsembleReconciler{Client: cl, Scheme: agentR.Scheme, Log: logr.Discard()}
+	if err := r.reconcileSharedMemory(context.Background(), logr.Discard(), pack); err != nil {
+		t.Fatalf("reconcileSharedMemory: %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "crew-shared-memory", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if image := memoryServerContainer(&got.Spec.Template.Spec).Image; image != "registry.example/sympozium/skill-memory:latest" {
+		t.Errorf("memory-server image = %q, want latest configured image", image)
 	}
 }

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -1232,7 +1232,7 @@ func (r *EnsembleReconciler) reconcileSharedMemory(ctx context.Context, log logr
 		// Already exists. The rest of the spec is deliberately left alone, but the
 		// admin-token env is reconciled so enabling adminDelete (or pointing it at a
 		// different Secret) takes effect without deleting the Deployment.
-		if err := syncMemoryAdminTokenEnv(ctx, r.Client, log, &existingDeploy); err != nil {
+		if err := syncMemoryDeployment(ctx, r.Client, log, &existingDeploy, image); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #363.

Existing per-Agent and shared-memory Deployments now update only their controller-owned `memory-server` container image when the configured Sympozium tag changes. PVCs and all other create-mostly Deployment fields are preserved.

Includes Agent and Ensemble reconciliation regression tests. Verified with `make test` and `make vet`.