### PR TITLE
fix(eventbus): bound Core NATS publish flushes

### DIFF
--- a/internal/eventbus/core_nats.go
+++ b/internal/eventbus/core_nats.go
@@ -19,6 +19,12 @@ type CoreNATSEventBus struct {
 	conn *nats.Conn
 }
 
+const coreNATSFlushTimeout = 5 * time.Second
+
+func coreNATSFlushContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, coreNATSFlushTimeout)
+}
+
 // NewCoreNATSEventBus creates a core-NATS client. NATS_USERNAME and
 // NATS_PASSWORD are optional so existing unauthenticated external NATS
 // installations remain supported during migration.
@@ -43,7 +49,12 @@ func (n *CoreNATSEventBus) Publish(ctx context.Context, topic string, event *Eve
 	// Unlike JetStream Publish, core NATS publish is asynchronous. Flush before
 	// returning because the bridge may terminate immediately after writing a
 	// terminal result and must not lose that result during connection close.
-	if err := n.conn.FlushWithContext(ctx); err != nil {
+	// FlushWithContext requires a context with a deadline. IPC bridge watchers
+	// are deliberately long-lived and receive a cancellation-only context, so
+	// derive a bounded child context for the synchronous core-NATS flush.
+	flushCtx, cancel := coreNATSFlushContext(ctx)
+	defer cancel()
+	if err := n.conn.FlushWithContext(flushCtx); err != nil {
 		return fmt.Errorf("flushing publish to %s: %w", msg.Subject, err)
 	}
 	return nil

--- a/internal/eventbus/core_nats_test.go
+++ b/internal/eventbus/core_nats_test.go
@@ -1,0 +1,36 @@
+package eventbus
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCoreNATSFlushContextHasBoundedDeadline(t *testing.T) {
+	ctx, cancel := coreNATSFlushContext(context.Background())
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("flush context must have a deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > coreNATSFlushTimeout {
+		t.Fatalf("flush deadline remaining = %s, want within (0, %s]", remaining, coreNATSFlushTimeout)
+	}
+}
+
+func TestCoreNATSFlushContextPreservesEarlierCallerDeadline(t *testing.T) {
+	parent, cancelParent := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelParent()
+	ctx, cancel := coreNATSFlushContext(parent)
+	defer cancel()
+
+	parentDeadline, _ := parent.Deadline()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("flush context must have a deadline")
+	}
+	if deadline.After(parentDeadline) {
+		t.Fatalf("flush deadline %s must not extend caller deadline %s", deadline, parentDeadline)
+	}
+}


### PR DESCRIPTION
Fixes the IPC bridge tool-publish regression observed after NATS authentication/ACL rollout.

Core NATS `FlushWithContext` requires a deadline, while bridge filesystem watchers pass their long-lived cancellation-only context. Derive a five-second bounded child context for each flush, preserving a shorter caller deadline.

This affects all mediated bridge publishes, including tool exec requests.

Verified with `make test` and `make vet`.