### PR TITLE
feat(harness): expose runtime selection in New Run

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -141,6 +141,9 @@ func (s *Server) buildMux(frontendFS fs.FS, expected *tokenReader) http.Handler 
 	mux.HandleFunc("PATCH /api/v1/agents/{name}", s.patchAgent)
 	mux.HandleFunc("GET /api/v1/agents/{name}/web-endpoint", s.getWebEndpointStatus)
 
+	// Administrator-approved harness runtimes
+	mux.HandleFunc("GET /api/v1/runtimes", s.listRuntimes)
+
 	// Run endpoints
 	mux.HandleFunc("GET /api/v1/runs", s.listRuns)
 	mux.HandleFunc("GET /api/v1/runs/{name}", s.getRun)
@@ -393,6 +396,21 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(list.Items, func(i, j int) bool {
 		return list.Items[i].Name < list.Items[j].Name
 	})
+	writeJSON(w, list.Items)
+}
+
+func (s *Server) listRuntimes(w http.ResponseWriter, r *http.Request) {
+	ns := r.URL.Query().Get("namespace")
+	if ns == "" {
+		ns = "default"
+	}
+
+	var list sympoziumv1alpha1.AgentRuntimeList
+	if err := s.client.List(r.Context(), &list, client.InNamespace(ns)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	sort.Slice(list.Items, func(i, j int) bool { return list.Items[i].Name < list.Items[j].Name })
 	writeJSON(w, list.Items)
 }
 
@@ -902,6 +920,9 @@ type CreateRunRequest struct {
 	Model      string `json:"model,omitempty"`
 	Timeout    string `json:"timeout,omitempty"`
 	Backend    string `json:"backend,omitempty"`
+	// RuntimeRef selects an administrator-approved AgentRuntime. When omitted,
+	// the Agent's runtimeRef inheritance and legacy string-task behaviour apply.
+	RuntimeRef string `json:"runtimeRef,omitempty"`
 }
 
 func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
@@ -1014,6 +1035,14 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 			Env:              inst.Spec.Agents.Default.Env,
 			Timeout:          timeout,
 		},
+	}
+	if strings.TrimSpace(req.RuntimeRef) != "" {
+		run.Spec.Task = &sympoziumv1alpha1.TaskSpec{
+			Mode: "harness",
+			Parameters: map[string]string{
+				"runtime": strings.TrimSpace(req.RuntimeRef),
+			},
+		}
 	}
 
 	if err := s.client.Create(r.Context(), run); err != nil {

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -65,6 +65,10 @@ export function useAgents() {
   return useQuery({ queryKey: ["agents"], queryFn: api.agents.list });
 }
 
+export function useRuntimes() {
+  return useQuery({ queryKey: ["runtimes"], queryFn: api.runtimes.list });
+}
+
 export function useAgent(name: string) {
   return useQuery({
     queryKey: ["agents", name],

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -130,6 +130,20 @@ export interface Agent {
   status?: AgentStatus;
 }
 
+export interface AgentRuntime {
+  metadata: ObjectMeta;
+  spec: {
+    image: string;
+    contractVersion?: string;
+    capabilities?: string[];
+    supportOwner?: string;
+  };
+  status?: {
+    resolvedImageDigest?: string;
+    conditions?: Condition[];
+  };
+}
+
 // ── AgentRun ─────────────────────────────────────────────────────────────────
 
 export interface ModelSpec {
@@ -1250,6 +1264,7 @@ export const api = {
       model?: string;
       timeout?: string;
       backend?: string;
+      runtimeRef?: string;
     }) =>
       apiFetch<AgentRun>("/api/v1/runs", {
         method: "POST",
@@ -1261,7 +1276,11 @@ export const api = {
       apiFetch<AgentRun>(`/api/v1/runs/${name}/gate-verdict`, {
         method: "POST",
         body: JSON.stringify(data),
-      }),
+    }),
+  },
+
+  runtimes: {
+    list: () => apiFetch<AgentRuntime[]>("/api/v1/runtimes"),
   },
 
   policies: {

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -8,6 +8,7 @@ import {
   useObservabilityMetrics,
   useGateVerdict,
   useCapabilities,
+  useRuntimes,
 } from "@/hooks/use-api";
 import { StatusBadge } from "@/components/status-badge";
 import {
@@ -72,6 +73,7 @@ export function RunsPage() {
   const instances = useAgents();
   const observability = useObservabilityMetrics();
   const capabilities = useCapabilities();
+  const runtimes = useRuntimes();
   const deleteRun = useDeleteRun();
   const createRun = useCreateRun();
   const gateVerdict = useGateVerdict();
@@ -85,6 +87,7 @@ export function RunsPage() {
     model: "",
     timeout: "5m",
     backend: "job",
+    runtimeRef: "",
   });
 
   // Mark all runs as seen after a short delay so "new" dots are visible briefly.
@@ -118,7 +121,7 @@ export function RunsPage() {
     createRun.mutate(form, {
       onSuccess: () => {
         setOpen(false);
-        setForm({ agentRef: "", task: "", model: "", timeout: "5m", backend: "job" });
+        setForm({ agentRef: "", task: "", model: "", timeout: "5m", backend: "job", runtimeRef: "" });
       },
     });
   };
@@ -178,6 +181,28 @@ export function RunsPage() {
                   placeholder="Describe the task for the agent…"
                   rows={4}
                 />
+              </div>
+              <div className="space-y-2">
+                <Label>Harness runtime (optional)</Label>
+                <Select
+                  value={form.runtimeRef || "inherit"}
+                  onValueChange={(v) => setForm({ ...form, runtimeRef: v === "inherit" ? "" : v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Use agent default" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="inherit">Use agent default</SelectItem>
+                    {(runtimes.data || []).map((runtime) => (
+                      <SelectItem key={runtime.metadata.name} value={runtime.metadata.name}>
+                        {runtime.metadata.name}{runtime.spec.supportOwner ? ` — ${runtime.spec.supportOwner}` : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Choose an administrator-approved adapter. Leaving this empty preserves the agent’s configured runtime and normal AgentRun behaviour.
+                </p>
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add read-only `/api/v1/runtimes` endpoint
- let New Run select an administrator-approved AgentRuntime
- preserve legacy AgentRun string tasks when no runtime is selected

## Validation
- `make test-short`
- `make vet`
- `git diff --check`
- `npm run build` (blocked by pre-existing topology-demo fitness type errors)

Closes #360