### PR TITLE
feat(harness): show runtime provenance and reject unsupported settings

### DIFF
--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -22,6 +22,12 @@ platform still controls:
 Normal AgentRuns are not replaced. Harness mode changes only the process that
 drives the agent loop; the surrounding AgentRun machinery remains the same.
 
+Persistent Agent memory remains platform-managed: Sympozium mounts and updates
+it through its normal result-extraction path. An adapter must not assume the
+`agent-runner` conversation-memory or thinking controls apply; explicit
+`useContext` and `model.thinking` are rejected for harness runs until the
+adapter contract defines mediated equivalents.
+
 !!! warning "This is an adapter boundary, not arbitrary image execution"
     An operator approves a contract-compatible adapter image, normally by
     immutable digest. Sympozium does not bless or maintain every upstream

--- a/examples/harness-reference/Dockerfile
+++ b/examples/harness-reference/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.21
+
+RUN addgroup -S -g 1000 agent && adduser -S -D -H -u 1000 -G agent agent
+
+COPY --chmod=0555 examples/harness-reference/adapter.sh /usr/local/bin/sympozium-reference-adapter
+
+USER 1000:1000
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/sympozium-reference-adapter"]

--- a/examples/harness-reference/README.md
+++ b/examples/harness-reference/README.md
@@ -1,0 +1,18 @@
+# Sympozium reference harness adapter
+
+This is a deterministic conformance fixture for the `v1alpha1` harness
+contract. It is not a maintained adapter for an upstream agent harness.
+
+It proves that a contract-compatible image can run as UID 1000 with a
+read-only root filesystem, use the writable HOME supplied by Sympozium, read
+`TASK`, check the contract version, and write both required result channels.
+
+Build it locally:
+
+```bash
+docker build -f examples/harness-reference/Dockerfile -t sympozium-reference-adapter:dev .
+```
+
+For a cluster test, publish it to an operator-approved registry and use its
+digest in an `AgentRuntime`. The policy must explicitly allow that exact image
+prefix and enable `harnessPolicy`.

--- a/examples/harness-reference/adapter.sh
+++ b/examples/harness-reference/adapter.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# A deterministic v1alpha1 adapter-contract fixture. This is intentionally not
+# an upstream harness integration: it exists to prove the container boundary.
+set -eu
+
+result_path="${SYMPOZIUM_RESULT_PATH:-/ipc/output/result.json}"
+contract="${SYMPOZIUM_HARNESS_CONTRACT_VERSION:-}"
+
+emit() {
+  status="$1"
+  case "$status" in
+    success) payload='{"status":"success","response":"reference adapter completed"}' ;;
+    *) payload='{"status":"error","error":"reference adapter preflight failed"}' ;;
+  esac
+  mkdir -p "$(dirname "$result_path")"
+  printf '%s' "$payload" > "$result_path"
+  printf '__SYMPOZIUM_RESULT__\n%s\n__SYMPOZIUM_END__\n' "$payload"
+}
+
+if [ "$contract" != "v1alpha1" ]; then
+  emit error
+  exit 1
+fi
+if ! touch "$HOME/.sympozium-reference-adapter"; then
+  emit error
+  exit 1
+fi
+if [ -z "${TASK:-}" ]; then
+  emit error
+  exit 1
+fi
+
+# Keep output fixed and JSON-safe; the conformance test verifies the task
+# separately through the container environment.
+emit success

--- a/internal/controller/taskmodes/capabilities.go
+++ b/internal/controller/taskmodes/capabilities.go
@@ -250,6 +250,12 @@ func ValidateRunCompatibility(run *sympoziumv1alpha1.AgentRun) error {
 	if run.Spec.CanaryMode {
 		unsupported = append(unsupported, "canaryMode")
 	}
+	if run.Spec.UseContext != nil {
+		unsupported = append(unsupported, "useContext")
+	}
+	if run.Spec.Model.Thinking != "" {
+		unsupported = append(unsupported, "model.thinking")
+	}
 	if run.Spec.AgentSandbox != nil && run.Spec.AgentSandbox.WarmPoolRef != "" {
 		unsupported = append(unsupported, "agentSandbox.warmPoolRef")
 	}

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -447,6 +447,8 @@ func TestValidateRunCompatibility_RejectsAgentRunnerOnlyControls(t *testing.T) {
 		{name: "server", mutate: func(r *sympoziumv1alpha1.AgentRun) { r.Spec.Mode = "server" }, want: "mode=server"},
 		{name: "dry-run", mutate: func(r *sympoziumv1alpha1.AgentRun) { r.Spec.DryRun = true }, want: "dryRun"},
 		{name: "canary", mutate: func(r *sympoziumv1alpha1.AgentRun) { r.Spec.CanaryMode = true }, want: "canaryMode"},
+		{name: "context", mutate: func(r *sympoziumv1alpha1.AgentRun) { value := false; r.Spec.UseContext = &value }, want: "useContext"},
+		{name: "thinking", mutate: func(r *sympoziumv1alpha1.AgentRun) { r.Spec.Model.Thinking = "high" }, want: "model.thinking"},
 		{name: "warm pool", mutate: func(r *sympoziumv1alpha1.AgentRun) {
 			r.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxSpec{Enabled: true, WarmPoolRef: "wp-test"}
 		}, want: "agentSandbox.warmPoolRef"},

--- a/web/src/pages/run-detail.tsx
+++ b/web/src/pages/run-detail.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { useRun, useGateVerdict } from "@/hooks/use-api";
+import { useRun, useGateVerdict, useRuntimes } from "@/hooks/use-api";
 import { StatusBadge } from "@/components/status-badge";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -31,6 +31,7 @@ export function RunDetailPage() {
   const { name } = useParams<{ name: string }>();
   const { data: run, isLoading } = useRun(name || "");
   const gateVerdict = useGateVerdict();
+  const runtimes = useRuntimes();
   const { markSeenUpTo } = useRunsSeen();
 
   const isAwaitingGate =
@@ -63,6 +64,9 @@ export function RunDetailPage() {
     ? `${(usage.durationMs / 1000).toFixed(1)}s`
     : "—";
   const est = effectiveCost(run);
+  const taskMode = typeof run.spec.task === "object" ? run.spec.task : undefined;
+  const runtimeName = taskMode?.mode === "harness" ? taskMode.parameters?.runtime : undefined;
+  const runtime = runtimeName ? runtimes.data?.find((item) => item.metadata.name === runtimeName) : undefined;
 
   return (
     <div className="space-y-6">
@@ -277,6 +281,24 @@ export function RunDetailPage() {
             Response gate: {run.status.gateVerdict}
           </span>
         </div>
+      )}
+
+      {runtimeName && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <ShieldCheck className="h-4 w-4 text-cyan-400" />
+              External runtime provenance
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 text-sm sm:grid-cols-2">
+            <div><span className="text-muted-foreground">Runtime</span><p className="font-mono">{runtimeName}</p></div>
+            <div><span className="text-muted-foreground">Image digest</span><p className="font-mono break-all">{run.status?.harnessImageDigest || runtime?.status?.resolvedImageDigest || "pending"}</p></div>
+            <div><span className="text-muted-foreground">Contract</span><p>{runtime?.spec.contractVersion || "not declared"}</p></div>
+            <div><span className="text-muted-foreground">Support owner</span><p>{runtime?.spec.supportOwner || "not declared"}</p></div>
+            <div className="sm:col-span-2"><span className="text-muted-foreground">Capability provenance</span><p>{runtime?.spec.capabilities?.length ? runtime.spec.capabilities.join(", ") + " (runtime claim; platform policy still enforced)" : "No runtime capabilities claimed"}</p></div>
+          </CardContent>
+        </Card>
       )}
 
       <Tabs defaultValue="task">


### PR DESCRIPTION
## Summary
- show selected AgentRuntime identity on harness run details
- surface executed image digest, contract version, support owner, and capability claims
- reject `useContext` and `model.thinking` for harness runs rather than silently letting an adapter ignore them
- document platform-managed memory semantics
- add a deterministic non-root reference adapter fixture for v1alpha1 conformance

## Validation
- `go test ./internal/controller/taskmodes ./internal/webhook`
- reference adapter local contract smoke (valid result file + stdout marker)
- `git diff --check`

Closes #360