### PR TITLE
fix-harness-allow-default-use-context-setting

### DIFF
--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -24,9 +24,10 @@ drives the agent loop; the surrounding AgentRun machinery remains the same.
 
 Persistent Agent memory remains platform-managed: Sympozium mounts and updates
 it through its normal result-extraction path. An adapter must not assume the
-`agent-runner` conversation-memory or thinking controls apply; explicit
-`useContext` and `model.thinking` are rejected for harness runs until the
-adapter contract defines mediated equivalents.
+`agent-runner` conversation-memory or thinking controls apply; `useContext:
+false` and `model.thinking` are rejected for harness runs until the adapter
+contract defines mediated equivalents. The historical/default
+`useContext: true` remains accepted because it requests no adapter behavior.
 
 !!! warning "This is an adapter boundary, not arbitrary image execution"
     An operator approves a contract-compatible adapter image, normally by

--- a/internal/controller/taskmodes/capabilities.go
+++ b/internal/controller/taskmodes/capabilities.go
@@ -250,7 +250,10 @@ func ValidateRunCompatibility(run *sympoziumv1alpha1.AgentRun) error {
 	if run.Spec.CanaryMode {
 		unsupported = append(unsupported, "canaryMode")
 	}
-	if run.Spec.UseContext != nil {
+	// The CRD defaults UseContext to true. That historical/default value has no
+	// effect on an external adapter, so accept it; only false requests the
+	// agent-runner-specific "forget context" behaviour we cannot honour.
+	if run.Spec.UseContext != nil && !*run.Spec.UseContext {
 		unsupported = append(unsupported, "useContext")
 	}
 	if run.Spec.Model.Thinking != "" {

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -471,6 +471,17 @@ func TestValidateRunCompatibility_AllowsOrdinaryHarnessRun(t *testing.T) {
 	}
 }
 
+func TestValidateRunCompatibility_AllowsDefaultUseContext(t *testing.T) {
+	value := true // This is what CRD defaulting applies to omitted useContext.
+	run := &sympoziumv1alpha1.AgentRun{Spec: sympoziumv1alpha1.AgentRunSpec{
+		Task:       harnessTask(nil),
+		UseContext: &value,
+	}}
+	if err := ValidateRunCompatibility(run); err != nil {
+		t.Fatalf("default useContext=true rejected: %v", err)
+	}
+}
+
 func TestOverrideFor_NilForStringAndOtherModes(t *testing.T) {
 	stringTask := sympoziumv1alpha1.NewStringTask("do the thing")
 	if override, err := OverrideFor(stringTask); err != nil || override != nil {


### PR DESCRIPTION
fix-crd-default-use-context-true-and-retain-rejection-for-false