### PR TITLE
feat-harness-require-unmetered-policy-opt-in

### DIFF
--- a/api/v1alpha1/sympoziumpolicy_types.go
+++ b/api/v1alpha1/sympoziumpolicy_types.go
@@ -56,6 +56,13 @@ type HarnessPolicySpec struct {
 	// primary process and receives the run's model and MCP credentials.
 	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
+
+	// AllowUnmetered permits a harness adapter that does not report token usage.
+	// External adapters own their model loop, so Sympozium cannot infer usage;
+	// without this opt-in, an ensemble token budget could appear enforced while
+	// silently receiving no accounting data. Defaults to false.
+	// +optional
+	AllowUnmetered bool `json:"allowUnmetered,omitempty"`
 }
 
 // ModelPolicySpec defines model access restrictions.

--- a/charts/sympozium-crds/templates/sympozium.ai_sympoziumpolicies.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_sympoziumpolicies.yaml
@@ -63,6 +63,13 @@ spec:
                   Sympozium's trusted agent-runner with an external harness adapter image.
                   External harnesses are disabled unless this field is present and enabled.
                 properties:
+                  allowUnmetered:
+                    description: |-
+                      AllowUnmetered permits a harness adapter that does not report token usage.
+                      External adapters own their model loop, so Sympozium cannot infer usage;
+                      without this opt-in, an ensemble token budget could appear enforced while
+                      silently receiving no accounting data. Defaults to false.
+                    type: boolean
                   enabled:
                     default: false
                     description: |-

--- a/charts/sympozium/crds/sympozium.ai_sympoziumpolicies.yaml
+++ b/charts/sympozium/crds/sympozium.ai_sympoziumpolicies.yaml
@@ -63,6 +63,13 @@ spec:
                   Sympozium's trusted agent-runner with an external harness adapter image.
                   External harnesses are disabled unless this field is present and enabled.
                 properties:
+                  allowUnmetered:
+                    description: |-
+                      AllowUnmetered permits a harness adapter that does not report token usage.
+                      External adapters own their model loop, so Sympozium cannot infer usage;
+                      without this opt-in, an ensemble token budget could appear enforced while
+                      silently receiving no accounting data. Defaults to false.
+                    type: boolean
                   enabled:
                     default: false
                     description: |-

--- a/config/crd/bases/sympozium.ai_sympoziumpolicies.yaml
+++ b/config/crd/bases/sympozium.ai_sympoziumpolicies.yaml
@@ -63,6 +63,13 @@ spec:
                   Sympozium's trusted agent-runner with an external harness adapter image.
                   External harnesses are disabled unless this field is present and enabled.
                 properties:
+                  allowUnmetered:
+                    description: |-
+                      AllowUnmetered permits a harness adapter that does not report token usage.
+                      External adapters own their model loop, so Sympozium cannot infer usage;
+                      without this opt-in, an ensemble token budget could appear enforced while
+                      silently receiving no accounting data. Defaults to false.
+                    type: boolean
                   enabled:
                     default: false
                     description: |-

--- a/config/samples/agentrun_harness.yaml
+++ b/config/samples/agentrun_harness.yaml
@@ -16,6 +16,8 @@ metadata:
 spec:
   harnessPolicy:
     enabled: true
+    # Set only for adapters that do not emit usable token metrics.
+    allowUnmetered: true
   imagePolicy:
     allowedRegistries:
       # Digest-pinned: harness images must be pinned, never a mutable tag.

--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -110,6 +110,17 @@ spec:
 With `runtimeRef`, the runtime is inherited by normal entrypoints. Users do
 not need to repeat an object-form harness task for every run.
 
+The web UI exposes the same administrator action on the Agent detail page:
+choose **Agent Harness Runtime**, select an approved runtime, or select
+**Built-in agent-runner** to clear it. This is distinct from persona settings
+because Ensemble reconciliation intentionally preserves an administrator-set
+runtime reference.
+
+For a one-off override, open **Runs → New Run** and choose **Harness runtime**.
+Leaving that field on **Use agent default** preserves normal AgentRun behavior
+and inherits the Agent's `runtimeRef`; choosing a runtime creates an explicit
+harness AgentRun for that invocation only.
+
 ### 4. Create a normal AgentRun
 
 ```yaml
@@ -156,7 +167,8 @@ Sympozium result protocol. The full adapter contract is documented in
 
 ## What to inspect after a run
 
-When runtime provenance surfaces in the API and UI, operators should be able to
+Run detail shows the runtime identity, executed digest, contract version,
+support owner, and adapter-claimed capabilities. Operators should be able to
 answer four questions without reading pod internals:
 
 1. Which AgentRuntime was requested or inherited?
@@ -165,8 +177,8 @@ answer four questions without reading pod internals:
 4. Did the run fail at policy, image pull, startup, MCP, result validation,
    timeout/cancellation, or metrics/accounting?
 
-Until those fields are exposed in every UI surface, `AgentRun.status` and the
-controller logs remain the source of truth.
+`AgentRun.status` and controller logs remain the source of truth for low-level
+pod and admission diagnostics.
 
 ## Support boundaries
 

--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -60,6 +60,9 @@ metadata:
 spec:
   harnessPolicy:
     enabled: true
+    # The reference adapter reports no token usage. Production adapters should
+    # emit real metrics instead of enabling this exception.
+    allowUnmetered: true
   imagePolicy:
     allowedRegistries:
       - ghcr.io/acme/codex-adapter@sha256:<64-hex-digest>

--- a/examples/harness-reference/manifests.yaml
+++ b/examples/harness-reference/manifests.yaml
@@ -23,6 +23,7 @@ metadata:
 spec:
   harnessPolicy:
     enabled: true
+    allowUnmetered: true
   imagePolicy:
     allowedRegistries:
       - ghcr.io/sympozium-ai/sympozium/harness-reference@sha256:84a025be02de2be67f8d6c7430664819c59c2d0c59aae5dc9fadcaf98c7a598d

--- a/internal/controller/agentrun_celln_test.go
+++ b/internal/controller/agentrun_celln_test.go
@@ -313,7 +313,7 @@ func TestReconcilePending_CellnAndAgentContainerOverride_Rejected(t *testing.T) 
 	policy := &sympoziumv1alpha1.SympoziumPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: run.Namespace},
 		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 	r := newAgentRunTestReconciler(t, run, agent, policy)

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -2403,6 +2403,9 @@ func (r *AgentRunReconciler) validatePolicy(ctx context.Context, agentRun *sympo
 		(policy.Spec.HarnessPolicy == nil || !policy.Spec.HarnessPolicy.Enabled) {
 		return fmt.Errorf("task.mode %q is disabled by policy; set spec.harnessPolicy.enabled: true to opt in", taskmodes.Harness)
 	}
+	if taskmodes.HarnessImage(agentRun.Spec.Task) != "" && !policy.Spec.HarnessPolicy.AllowUnmetered {
+		return fmt.Errorf("task.mode %q may not run unmetered under this policy; set spec.harnessPolicy.allowUnmetered: true only for an adapter whose accounting risk you accept", taskmodes.Harness)
+	}
 
 	// Validate the harness image against the registry allowlist.
 	//

--- a/internal/controller/agentrun_harness_image_test.go
+++ b/internal/controller/agentrun_harness_image_test.go
@@ -24,7 +24,7 @@ func policyWithRegistries(name string, registries ...string) *sympoziumv1alpha1.
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
 		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
 			ImagePolicy:   &sympoziumv1alpha1.ImagePolicySpec{AllowedRegistries: registries},
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 }

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -196,6 +196,9 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 		(policy.Spec.HarnessPolicy == nil || !policy.Spec.HarnessPolicy.Enabled) {
 		return admission.Denied("task.mode \"harness\" is disabled by policy; set spec.harnessPolicy.enabled: true to opt in")
 	}
+	if taskmodes.HarnessImage(run.Spec.Task) != "" && !policy.Spec.HarnessPolicy.AllowUnmetered {
+		return admission.Denied("task.mode \"harness\" may not run unmetered under this policy; set spec.harnessPolicy.allowUnmetered: true only for an adapter whose accounting risk you accept")
+	}
 
 	// Validate sandbox policy
 	if policy.Spec.SandboxPolicy != nil && policy.Spec.SandboxPolicy.Required {

--- a/internal/webhook/task_mode_capabilities_test.go
+++ b/internal/webhook/task_mode_capabilities_test.go
@@ -36,7 +36,7 @@ func capabilityEnforcer(t *testing.T) *PolicyEnforcer {
 	policy := &sympoziumv1alpha1.SympoziumPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: "default"},
 		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, policy).Build()
@@ -104,6 +104,29 @@ func TestPolicyEnforcer_HarnessRequiresExplicitPolicyOptIn(t *testing.T) {
 	}
 }
 
+func TestPolicyEnforcer_HarnessRequiresUnmeteredOptIn(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	agent := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentSpec{PolicyRef: "harness-enabled"},
+	}
+	policy := &sympoziumv1alpha1.SympoziumPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: "default"},
+		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, policy).Build()
+	pe := &PolicyEnforcer{Client: cl, Log: logr.Discard(), Decoder: decoderFor(t, scheme)}
+	resp := pe.Handle(context.Background(), admissionRequestFor(t, capabilityRun(harnessTaskSpec(nil))))
+	if resp.Allowed || !strings.Contains(resp.Result.Message, "allowUnmetered") {
+		t.Fatalf("expected unmetered opt-in denial, got allowed=%t message=%q", resp.Allowed, resp.Result.Message)
+	}
+}
+
 func TestPolicyEnforcer_RejectsUnmediatedHarnessCapabilityClaim(t *testing.T) {
 	pe := capabilityEnforcer(t)
 	run := capabilityRun(harnessTaskSpec(map[string]string{
@@ -146,7 +169,7 @@ func TestPolicyEnforcer_ResolvesRuntimeReference(t *testing.T) {
 	policy := &sympoziumv1alpha1.SympoziumPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: "default"},
 		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 	runtimeObj := &sympoziumv1alpha1.AgentRuntime{
@@ -205,7 +228,7 @@ func TestPolicyEnforcer_InheritsAgentRuntimeRef(t *testing.T) {
 	policy := &sympoziumv1alpha1.SympoziumPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: "default"},
 		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 	runtimeObj := &sympoziumv1alpha1.AgentRuntime{
@@ -406,7 +429,7 @@ func TestPolicyEnforcer_DeniesHarnessImageOutsideAllowedRegistries(t *testing.T)
 			ImagePolicy: &sympoziumv1alpha1.ImagePolicySpec{
 				AllowedRegistries: []string{"ghcr.io/sympozium-ai/"},
 			},
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 	agent := &sympoziumv1alpha1.Agent{
@@ -441,7 +464,7 @@ func TestPolicyEnforcer_AllowsHarnessImageInsideAllowedRegistries(t *testing.T) 
 			ImagePolicy: &sympoziumv1alpha1.ImagePolicySpec{
 				AllowedRegistries: []string{"ghcr.io/acme/"},
 			},
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 	agent := &sympoziumv1alpha1.Agent{
@@ -507,7 +530,7 @@ func TestPolicyEnforcer_AllowsOrdinaryMCPServerName(t *testing.T) {
 	policy := &sympoziumv1alpha1.SympoziumPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "harness-enabled", Namespace: "default"},
 		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
-			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true},
+			HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true, AllowUnmetered: true},
 		},
 	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, policy).Build()

--- a/test/integration/test-harness-mode.sh
+++ b/test/integration/test-harness-mode.sh
@@ -90,6 +90,7 @@ metadata:
 spec:
   harnessPolicy:
     enabled: true
+    allowUnmetered: true
 ---
 apiVersion: sympozium.ai/v1alpha1
 kind: Agent


### PR DESCRIPTION
external-harnesses-default-denied-unless-policy-accepts-unmetered-accounting-risk