### PR TITLE
fix(harness): preserve inherited runtime provenance

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -401,6 +401,23 @@ type AgentRunStatus struct {
 	// +optional
 	HarnessImageDigest string `json:"harnessImageDigest,omitempty"`
 
+	// HarnessRuntimeRef records the AgentRuntime that was resolved for this
+	// harness run. It remains populated when an Agent's runtimeRef converted a
+	// normal string task into harness mode, so audit and UI do not have to infer
+	// the selected runtime from the current Agent configuration.
+	// +optional
+	HarnessRuntimeRef string `json:"harnessRuntimeRef,omitempty"`
+
+	// HarnessContractVersion records the harness contract supplied to the
+	// adapter that executed this run.
+	// +optional
+	HarnessContractVersion string `json:"harnessContractVersion,omitempty"`
+
+	// HarnessRuntimeSource records whether the resolved runtime came from the
+	// Agent default ("agent-default") or the AgentRun ("run").
+	// +optional
+	HarnessRuntimeSource string `json:"harnessRuntimeSource,omitempty"`
+
 	// PostRunJobName is the name of the Job created for postRun lifecycle hooks.
 	// +optional
 	PostRunJobName string `json:"postRunJobName,omitempty"`

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -2803,12 +2803,29 @@ spec:
                   One of: approved, rejected, rewritten, timeout, error, allowed-by-default.
                   Empty when no gate hook is configured.
                 type: string
+              harnessContractVersion:
+                description: |-
+                  HarnessContractVersion records the harness contract supplied to the
+                  adapter that executed this run.
+                type: string
               harnessImageDigest:
                 description: |-
                   HarnessImageDigest records the digest of the external harness adapter image
                   that executed this run. Populated only for `task.mode: harness` runs, and
                   only once the run has been admitted and dispatched. Empty for all other
                   modes and backends.
+                type: string
+              harnessRuntimeRef:
+                description: |-
+                  HarnessRuntimeRef records the AgentRuntime that was resolved for this
+                  harness run. It remains populated when an Agent's runtimeRef converted a
+                  normal string task into harness mode, so audit and UI do not have to infer
+                  the selected runtime from the current Agent configuration.
+                type: string
+              harnessRuntimeSource:
+                description: |-
+                  HarnessRuntimeSource records whether the resolved runtime came from the
+                  Agent default ("agent-default") or the AgentRun ("run").
                 type: string
               jobName:
                 description: JobName is the name of the Job created for this run.

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -2803,12 +2803,29 @@ spec:
                   One of: approved, rejected, rewritten, timeout, error, allowed-by-default.
                   Empty when no gate hook is configured.
                 type: string
+              harnessContractVersion:
+                description: |-
+                  HarnessContractVersion records the harness contract supplied to the
+                  adapter that executed this run.
+                type: string
               harnessImageDigest:
                 description: |-
                   HarnessImageDigest records the digest of the external harness adapter image
                   that executed this run. Populated only for `task.mode: harness` runs, and
                   only once the run has been admitted and dispatched. Empty for all other
                   modes and backends.
+                type: string
+              harnessRuntimeRef:
+                description: |-
+                  HarnessRuntimeRef records the AgentRuntime that was resolved for this
+                  harness run. It remains populated when an Agent's runtimeRef converted a
+                  normal string task into harness mode, so audit and UI do not have to infer
+                  the selected runtime from the current Agent configuration.
+                type: string
+              harnessRuntimeSource:
+                description: |-
+                  HarnessRuntimeSource records whether the resolved runtime came from the
+                  Agent default ("agent-default") or the AgentRun ("run").
                 type: string
               jobName:
                 description: JobName is the name of the Job created for this run.

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -2803,12 +2803,29 @@ spec:
                   One of: approved, rejected, rewritten, timeout, error, allowed-by-default.
                   Empty when no gate hook is configured.
                 type: string
+              harnessContractVersion:
+                description: |-
+                  HarnessContractVersion records the harness contract supplied to the
+                  adapter that executed this run.
+                type: string
               harnessImageDigest:
                 description: |-
                   HarnessImageDigest records the digest of the external harness adapter image
                   that executed this run. Populated only for `task.mode: harness` runs, and
                   only once the run has been admitted and dispatched. Empty for all other
                   modes and backends.
+                type: string
+              harnessRuntimeRef:
+                description: |-
+                  HarnessRuntimeRef records the AgentRuntime that was resolved for this
+                  harness run. It remains populated when an Agent's runtimeRef converted a
+                  normal string task into harness mode, so audit and UI do not have to infer
+                  the selected runtime from the current Agent configuration.
+                type: string
+              harnessRuntimeSource:
+                description: |-
+                  HarnessRuntimeSource records whether the resolved runtime came from the
+                  Agent default ("agent-default") or the AgentRun ("run").
                 type: string
               jobName:
                 description: JobName is the name of the Job created for this run.

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -726,7 +726,15 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		}
 		return ctrl.Result{}, fmt.Errorf("reading Agent %q while resolving runtime: %w", agentRun.Spec.AgentRef, err)
 	}
+	// Remember the source before an Agent default converts a string task into a
+	// harness task. The normalized task is intentionally not persisted to spec;
+	// status is the immutable execution record used by run detail and audit.
+	inheritedHarnessRuntime := strings.TrimSpace(runtimeInstance.Spec.RuntimeRef) != "" &&
+		(agentRun.Spec.Task.IsString() || (agentRun.Spec.Task.GetMode() == taskmodes.Harness &&
+			strings.TrimSpace(agentRun.Spec.Task.Parameters["image"]) == "" &&
+			strings.TrimSpace(agentRun.Spec.Task.Parameters["runtime"]) == ""))
 	agentRun.Spec.Task = taskmodes.ApplyAgentRuntime(agentRun.Spec.Task, runtimeInstance.Spec.RuntimeRef)
+	harnessRuntimeRef := taskmodes.HarnessRuntimeRef(agentRun.Spec.Task)
 	if normalized, err := taskmodes.NormalizeHarnessTask(agentRun.Namespace, agentRun.Spec.Task, func(ns, name string) (*sympoziumv1alpha1.AgentRuntime, error) {
 		var rt sympoziumv1alpha1.AgentRuntime
 		if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &rt); err != nil {
@@ -857,6 +865,13 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		// requested.
 		if d := taskmodes.HarnessImageDigest(agentRun.Spec.Task); d != "" {
 			ar.Status.HarnessImageDigest = d
+			ar.Status.HarnessRuntimeRef = harnessRuntimeRef
+			ar.Status.HarnessContractVersion = taskmodes.HarnessContractVersion
+			if inheritedHarnessRuntime {
+				ar.Status.HarnessRuntimeSource = "agent-default"
+			} else {
+				ar.Status.HarnessRuntimeSource = "run"
+			}
 		}
 
 		// Set the trace ID so operators can look up the full distributed trace.

--- a/internal/controller/taskmodes/harness.go
+++ b/internal/controller/taskmodes/harness.go
@@ -315,6 +315,16 @@ func HarnessImageDigest(task *sympoziumv1alpha1.TaskSpec) string {
 	return digest
 }
 
+// HarnessRuntimeRef returns the AgentRuntime name named by a harness task, or
+// an empty string when the task uses an inline image or is not harness mode.
+// The controller records this before normalization removes the runtime name.
+func HarnessRuntimeRef(task *sympoziumv1alpha1.TaskSpec) string {
+	if task == nil || task.IsString() || task.GetMode() != Harness {
+		return ""
+	}
+	return strings.TrimSpace(task.Parameters[harnessParamRuntime])
+}
+
 // ApplyAgentRuntime applies an Agent's default runtime to a task. String-form
 // tasks are converted to harness mode while preserving their prompt; this is
 // the path used by channels, schedules, the API, the UI, and other ordinary run

--- a/internal/controller/taskmodes/harness_test.go
+++ b/internal/controller/taskmodes/harness_test.go
@@ -553,6 +553,16 @@ func TestHarnessImageDigest(t *testing.T) {
 	}
 }
 
+func TestHarnessRuntimeRef(t *testing.T) {
+	task := &sympoziumv1alpha1.TaskSpec{Mode: Harness, Parameters: map[string]string{harnessParamRuntime: " reference-v1 "}}
+	if got := HarnessRuntimeRef(task); got != "reference-v1" {
+		t.Errorf("HarnessRuntimeRef = %q, want reference-v1", got)
+	}
+	if got := HarnessRuntimeRef(sympoziumv1alpha1.NewStringTask("normal task")); got != "" {
+		t.Errorf("HarnessRuntimeRef(string task) = %q, want empty", got)
+	}
+}
+
 // readyRuntime returns an AgentRuntime whose Ready condition is true, so
 // NormalizeHarnessTask accepts it.
 func readyRuntime(name string, capabilities ...string) *sympoziumv1alpha1.AgentRuntime {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -240,6 +240,10 @@ export interface AgentRunStatus {
   exitCode?: number;
   tokenUsage?: TokenUsage;
   costEstimate?: CostEstimate;
+  harnessImageDigest?: string;
+  harnessRuntimeRef?: string;
+  harnessContractVersion?: string;
+  harnessRuntimeSource?: "agent-default" | "run";
   postRunJobName?: string;
   gateVerdict?: string;
   delegates?: DelegateStatus[];

--- a/web/src/pages/run-detail.tsx
+++ b/web/src/pages/run-detail.tsx
@@ -65,8 +65,9 @@ export function RunDetailPage() {
     : "—";
   const est = effectiveCost(run);
   const taskMode = typeof run.spec.task === "object" ? run.spec.task : undefined;
-  const runtimeName = taskMode?.mode === "harness" ? taskMode.parameters?.runtime : undefined;
+  const runtimeName = (taskMode?.mode === "harness" ? taskMode.parameters?.runtime : undefined) || run.status?.harnessRuntimeRef;
   const runtime = runtimeName ? runtimes.data?.find((item) => item.metadata.name === runtimeName) : undefined;
+  const isHarnessRun = Boolean(runtimeName || run.status?.harnessImageDigest);
 
   return (
     <div className="space-y-6">
@@ -283,7 +284,7 @@ export function RunDetailPage() {
         </div>
       )}
 
-      {runtimeName && (
+      {isHarnessRun && (
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-base">
@@ -292,9 +293,10 @@ export function RunDetailPage() {
             </CardTitle>
           </CardHeader>
           <CardContent className="grid gap-3 text-sm sm:grid-cols-2">
-            <div><span className="text-muted-foreground">Runtime</span><p className="font-mono">{runtimeName}</p></div>
+            <div><span className="text-muted-foreground">Runtime</span><p className="font-mono">{runtimeName || "inline image"}</p></div>
+            <div><span className="text-muted-foreground">Selection</span><p>{run.status?.harnessRuntimeSource === "agent-default" ? "Agent default" : "Run override"}</p></div>
             <div><span className="text-muted-foreground">Image digest</span><p className="font-mono break-all">{run.status?.harnessImageDigest || runtime?.status?.resolvedImageDigest || "pending"}</p></div>
-            <div><span className="text-muted-foreground">Contract</span><p>{runtime?.spec.contractVersion || "not declared"}</p></div>
+            <div><span className="text-muted-foreground">Contract</span><p>{run.status?.harnessContractVersion || runtime?.spec.contractVersion || "not declared"}</p></div>
             <div><span className="text-muted-foreground">Support owner</span><p>{runtime?.spec.supportOwner || "not declared"}</p></div>
             <div className="sm:col-span-2"><span className="text-muted-foreground">Capability provenance</span><p>{runtime?.spec.capabilities?.length ? runtime.spec.capabilities.join(", ") + " (runtime claim; platform policy still enforced)" : "No runtime capabilities claimed"}</p></div>
           </CardContent>

--- a/web/src/pages/topology-demo.tsx
+++ b/web/src/pages/topology-demo.tsx
@@ -547,13 +547,17 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[]; simDevices: SimDev
 
   const simDevices: SimDevice[] = [];
   for (const pn of k8sNodes) {
-    const { devices, sims } = demoAccelerators(pn.name, pn.fitness.gpuName, pn.fitness.stale);
+    // Demo inventory is intentionally heterogeneous; older fixture entries do
+    // not carry the optional fitness snapshot. Keep their declared accelerator
+    // inventory while still enriching newer entries when it is present.
+    const fitness = (pn as typeof pn & { fitness?: { gpuName: string; stale: boolean } }).fitness;
+    const { devices, sims } = demoAccelerators(pn.name, fitness?.gpuName ?? "", fitness?.stale ?? Boolean(pn.stale));
     simDevices.push(...sims);
     nodes.push({
       id: `node-${pn.name}`,
       type: "workstation",
       position: P,
-      data: { ...pn, accelerators: devices },
+      data: { ...pn, accelerators: devices.length > 0 ? devices : pn.accelerators },
     });
   }
 


### PR DESCRIPTION
## Summary
- record the resolved runtime, contract, and selection source in AgentRun status
- show provenance for Agent-inherited harness runs as well as explicit overrides
- update the web API type and repair the topology demo typing issue exposed by its production build

## Validation
- `go test ./internal/controller/taskmodes ./internal/controller`
- `go vet ./internal/controller/...`
- `make web-build`
- `git diff --check`

Framework proof before this fix demonstrated inherited execution but exposed that Run detail could not identify an inherited runtime. This change closes that UX/audit gap.