### PR TITLE
fix(harness): probe loopback skill tool server in-container

### DIFF
--- a/internal/controller/agentrun_harness_mode_test.go
+++ b/internal/controller/agentrun_harness_mode_test.go
@@ -570,6 +570,15 @@ func TestBuildContainers_HarnessGetsTheSkillToolServer(t *testing.T) {
 	if srv.StartupProbe == nil {
 		t.Error("without a startup probe the kubelet does not wait for it, and the harness can race it")
 	}
+	if srv.StartupProbe == nil || srv.StartupProbe.Exec == nil {
+		t.Fatal("skill-tools must use an in-container exec probe so its loopback-only listener is reachable")
+	}
+	if srv.StartupProbe.HTTPGet != nil {
+		t.Error("skill-tools must not use an HTTP probe: kubelet probes from outside the pod network namespace")
+	}
+	if got := strings.Join(srv.StartupProbe.Exec.Command, " "); !strings.Contains(got, "127.0.0.1:8771/readyz") {
+		t.Errorf("startup probe = %q, want loopback readiness endpoint", got)
+	}
 	if v, ok := envValueLocal(srv.Env, "MCP_SERVE_SKILL_TOOLS"); !ok || v != "true" {
 		t.Errorf("MCP_SERVE_SKILL_TOOLS = (%q, %v), want true", v, ok)
 	}

--- a/internal/controller/agentrun_skilltools.go
+++ b/internal/controller/agentrun_skilltools.go
@@ -6,7 +6,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/skilltools"
@@ -150,11 +149,15 @@ func (r *AgentRunReconciler) buildSkillToolsContainer(agentRun *sympoziumv1alpha
 		Env:             env,
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/readyz",
-					Port: intstr.FromInt32(skillToolsPort),
-					Host: "127.0.0.1",
-				},
+				// HTTP probes originate in the kubelet's network namespace. They
+				// cannot reach a listener deliberately bound to pod loopback: using
+				// host 127.0.0.1 probes the node loopback, while omitting it probes
+				// the pod IP. Run this probe in the sidecar instead, so the server
+				// stays unreachable outside the shared pod namespace.
+				Exec: &corev1.ExecAction{Command: []string{
+					"/bin/sh", "-c",
+					fmt.Sprintf("wget -q -O /dev/null http://127.0.0.1:%d/readyz", skillToolsPort),
+				}},
 			},
 			PeriodSeconds:    1,
 			FailureThreshold: 30,


### PR DESCRIPTION
Fixes #367.

## Why
Kubernetes HTTP probes run from the kubelet network namespace. Pointing one at `127.0.0.1` probes the node loopback; omitting the host probes the Pod IP. Neither reaches a server intentionally bound to pod loopback only.

## Change
Use an in-container exec startup probe (`wget` against `127.0.0.1:8771/readyz`) so the SkillPack tool server remains loopback-only but a harness run can wait for it reliably.

## Validation
- `go test ./internal/controller`
- `go vet ./internal/controller/...`
- assertion that rejects HTTP probes and requires the loopback exec probe