### PR TITLE
feat(harness): select runtime while creating an agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@
 
 ---
 
+> [!IMPORTANT]
+> **AgentHarness support is landing now.** Run an administrator-approved external
+> agent adapter inside a normal Sympozium AgentRun while keeping Kubernetes
+> policy, per-run identity, skills, memory, MCP, observability, and audit under
+> platform control. Start with the [AgentHarness guide](https://deploy.sympozium.ai/docs/guides/agentharness/)
+> and the digest-pinned [reference adapter](examples/harness-reference/). This
+> is an adapter boundary—not permission to run arbitrary upstream images.
+
+---
+
 ### Quick Install (macOS / Linux)
 
 **Homebrew:**

--- a/config/samples/agentrun_harness.yaml
+++ b/config/samples/agentrun_harness.yaml
@@ -7,7 +7,9 @@
 #
 # BYO means a contract-compatible adapter image, not an arbitrary upstream
 # harness image. External runtimes are disabled unless the backing Agent's
-# policy explicitly opts in. Replace the example image and secret before use.
+# policy explicitly opts in. This sample uses Sympozium's published,
+# deterministic reference adapter; production users should register their own
+# reviewed adapter digest as an AgentRuntime.
 apiVersion: sympozium.ai/v1alpha1
 kind: SympoziumPolicy
 metadata:
@@ -21,7 +23,7 @@ spec:
   imagePolicy:
     allowedRegistries:
       # Digest-pinned: harness images must be pinned, never a mutable tag.
-      - ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - ghcr.io/sympozium-ai/sympozium/harness-reference@sha256:84a025be02de2be67f8d6c7430664819c59c2d0c59aae5dc9fadcaf98c7a598d
 ---
 apiVersion: sympozium.ai/v1alpha1
 kind: Agent
@@ -52,7 +54,7 @@ spec:
       # Required. The adapter image that becomes the pod's primary process.
       # It keeps its own ENTRYPOINT — Sympozium imposes no argv on a binary it
       # did not build. Digest-pinned (@sha256:…): a mutable tag is rejected.
-      image: ghcr.io/acme/my-harness@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      image: ghcr.io/sympozium-ai/sympozium/harness-reference@sha256:84a025be02de2be67f8d6c7430664819c59c2d0c59aae5dc9fadcaf98c7a598d
       # Required. The task text. Object-form tasks have no top-level prompt
       # field, so harness mode takes it from here and sets TASK from it.
       prompt: "Review the latest pull request and provide feedback on code quality"

--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -185,7 +185,9 @@ always distinguish:
 
 The adapter receives the versioned contract and must emit the structured
 Sympozium result protocol. The full adapter contract is documented in
-[`Writing a Harness Adapter`](../modes/harness-adapters.md).
+[`Writing a Harness Adapter`](../modes/harness-adapters.md). The maintained
+adapter program, conformance expectations, and experimental Pi/Hermes plans
+live in [sympozium-ai/harness-adapters](https://github.com/sympozium-ai/harness-adapters).
 
 ## What to inspect after a run
 


### PR DESCRIPTION
## Summary
- add an inline Execution selector to Create Agent
- default to built-in agent-runner and list only ready approved AgentRuntimes
- persist `spec.runtimeRef` atomically through the Create Agent API

## Validation
- `go test ./internal/apiserver`
- `make web-build`
- `git diff --check`