### PR TITLE
feat(celln): enable labelled KVM hosts by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ GATEWAY_API_CRDS_URL ?= https://github.com/kubernetes-sigs/gateway-api/releases/
 # runs privileged with hostPID and a read-write host-root mount to perform
 # KVM host setup. `make install ENABLE_HERMETIC_WORKLOADS=true` opts in;
 # the plain CLI equivalent is `sympozium install --enable-hermetic-workloads`.
-ENABLE_HERMETIC_WORKLOADS ?= false
+ENABLE_HERMETIC_WORKLOADS ?= true
 
 install: manifests ## Install Sympozium via Helm chart (CRDs, control plane, built-ins)
 	kubectl apply --server-side --force-conflicts -f charts/sympozium/crds/

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -413,15 +413,12 @@ agentSandbox:
 # Requires: Celln router deployed (see celln repo integrations/kubernetes/)
 # and celln host dispatcher installed on each KVM node (scripts/setup-host.sh).
 celln:
-  # -- Enable the Celln backend. Opt-in and OFF by default: the installer
-  # DaemonSet runs privileged with hostPID and a read-write mount of the
-  # host root filesystem to perform KVM host setup, so turning this on is a
-  # deliberate choice, not a side effect of a routine install. When true,
-  # deploys the installer DaemonSet, router DaemonSet, and configures the
-  # controller for celln dispatch. The router forwards to the host
-  # dispatcher on localhost — no IP needed.
-  # `sympozium install --enable-hermetic-workloads` sets this for you.
-  enabled: false
+  # -- Enable the Celln backend. Enabled by default so every standard install
+  # has the router and controller configuration needed for Celln-backed runs.
+  # The privileged installer and router still schedule only on nodes explicitly
+  # labelled celln.dev/kvm=true; label KVM-capable hosts deliberately before
+  # they receive host setup. Set false to omit all Celln resources.
+  enabled: true
   # -- URL of the celln-router Service. The controller POSTs here.
   routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
   # -- API key for your chosen LLM provider. Set ONE of these.

--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -2,7 +2,14 @@
 
 Sympozium optionally integrates with [Celln](https://github.com/sympozium-ai/celln) to run a single bounded, high-risk, or sensitive computation in a hardware-isolated microVM instead of a Kubernetes Job. It is selected per run with `spec.backend: "celln"` on an `AgentRun`.
 
-Celln is **opt-in**: `celln.enabled=false` by default in the Helm chart, because the installer DaemonSet it deploys runs privileged, with `hostPID`, and a read-write mount of the host root filesystem — necessary to set up KVM on the host, but a materially different trust boundary than the rest of Sympozium's pods. Enable it explicitly with `sympozium install --enable-hermetic-workloads` (or `helm upgrade --set celln.enabled=true`). This page covers what that turns on, and the one requirement that's easy to miss: Celln needs its own AI provider access on the host, separate from whatever provider your `Agent`/`AgentRun` is configured with.
+Celln is enabled by default: `celln.enabled=true` installs the router and
+controller configuration with Sympozium. Its installer DaemonSet runs
+privileged, with `hostPID`, and a read-write mount of the host root filesystem
+to set up KVM; it and the router schedule only on nodes explicitly labelled
+`celln.dev/kvm=true`. That label is the deliberate host-setup boundary. Disable
+Celln entirely with `helm upgrade --set celln.enabled=false`. This page covers
+the one requirement that's easy to miss: Celln needs its own AI provider access
+on the host, separate from whatever provider your `Agent`/`AgentRun` is configured with.
 
 The web UI's Runs page shows a live banner if any listed run uses `backend: celln` while the router is unreachable, and the New Run dialog checks live reachability when you select the Celln backend — both backed by `GET /api/v1/capabilities`.
 

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -35,7 +35,11 @@ See [`charts/sympozium/values.yaml`](https://github.com/sympozium-ai/sympozium/b
 
 ### Celln (hermetic execution)
 
-Off by default (`celln.enabled: false`) — opt in with `--set celln.enabled=true`, or via the CLI's `sympozium install --enable-hermetic-workloads`. It deploys a **privileged**, `hostPID` DaemonSet with a read-write mount of the host root filesystem to set up KVM host-side, so treat it as a deliberate opt-in rather than a routine flag. See [Celln Backend](../concepts/celln-backend.md) before enabling it.
+Enabled by default (`celln.enabled: true`) so a standard installation includes
+the Celln router and controller configuration. The privileged installer and
+router schedule only on nodes explicitly labelled `celln.dev/kvm=true`; label
+KVM-capable hosts deliberately before they receive host setup. Disable all
+Celln resources with `--set celln.enabled=false`. See [Celln Backend](../concepts/celln-backend.md).
 
 ## Observability
 


### PR DESCRIPTION
## Summary
- enable Celln by default in the Helm chart and standard install target
- retain the `celln.dev/kvm=true` node selector: privileged host setup occurs only on explicitly labelled KVM nodes
- update deployment/security documentation

## Framework proof
- Helm revision 11 deployed with Celln enabled
- `celln-installer` and `celln-router` DaemonSets Ready on labelled Framework node
- router Service has an endpoint
- `/api/v1/capabilities` reports `celln.available: true`

## Validation
- `helm lint charts/sympozium`
- `git diff --check`