### PR TITLE
feat(cli): add dashboard token command

### DIFF
--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -92,6 +92,7 @@ Running without a subcommand launches the interactive TUI.`,
 		newInstallCmd(),
 		newUninstallCmd(),
 		newOnboardCmd(),
+		newTokenCmd(),
 		newAgentsCmd(),
 		newRunsCmd(),
 		newPoliciesCmd(),
@@ -106,6 +107,53 @@ Running without a subcommand launches the interactive TUI.`,
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// uiToken reads the dashboard bearer token from the control-plane Secret.
+// Keep this separate from the Cobra command so the Secret contract is easy to
+// test without printing a credential.
+func uiToken(ctx context.Context, reader client.Reader, systemNamespace string) (string, error) {
+	secret := &corev1.Secret{}
+	if err := reader.Get(ctx, types.NamespacedName{Name: "sympozium-ui-token", Namespace: systemNamespace}, secret); err != nil {
+		if k8serr.IsNotFound(err) {
+			return "", fmt.Errorf("UI token Secret %q was not found in namespace %q; is Sympozium installed there?", "sympozium-ui-token", systemNamespace)
+		}
+		return "", fmt.Errorf("read UI token Secret in namespace %q: %w", systemNamespace, err)
+	}
+
+	token := strings.TrimSpace(string(secret.Data["token"]))
+	if token == "" {
+		return "", fmt.Errorf("UI token Secret %q in namespace %q has no non-empty %q key", "sympozium-ui-token", systemNamespace, "token")
+	}
+	return token, nil
+}
+
+func newTokenCmd() *cobra.Command {
+	var systemNamespace string
+
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Print the web dashboard authentication token",
+		Long: `Print the Sympozium web dashboard bearer token to standard output.
+
+Use this after a manual port-forward, for example:
+  sympozium token | pbcopy
+
+The command requires permission to read the sympozium-ui-token Secret. Treat
+the output as a credential and do not paste it into logs or shell history.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token, err := uiToken(cmd.Context(), k8sClient, systemNamespace)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), token)
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&systemNamespace, "service-namespace", "sympozium-system", "Namespace containing the sympozium-ui-token Secret")
+	return cmd
 }
 
 func initClient() error {

--- a/cmd/sympozium/token_test.go
+++ b/cmd/sympozium/token_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func tokenTestClient(t *testing.T, objects ...runtime.Object) *fake.ClientBuilder {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...)
+}
+
+func TestUIToken(t *testing.T) {
+	reader := tokenTestClient(t, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "sympozium-ui-token", Namespace: "sympozium-system"},
+		Data:       map[string][]byte{"token": []byte(" dashboard-token ")},
+	}).Build()
+
+	token, err := uiToken(context.Background(), reader, "sympozium-system")
+	if err != nil {
+		t.Fatalf("uiToken() error = %v", err)
+	}
+	if token != "dashboard-token" {
+		t.Errorf("uiToken() = %q, want trimmed token", token)
+	}
+}
+
+func TestUITokenMissingSecret(t *testing.T) {
+	_, err := uiToken(context.Background(), tokenTestClient(t).Build(), "sympozium-system")
+	if err == nil || !strings.Contains(err.Error(), "was not found") {
+		t.Errorf("uiToken() error = %v, want missing Secret guidance", err)
+	}
+}
+
+func TestUITokenMissingValue(t *testing.T) {
+	reader := tokenTestClient(t, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "sympozium-ui-token", Namespace: "sympozium-system"},
+	}).Build()
+
+	_, err := uiToken(context.Background(), reader, "sympozium-system")
+	if err == nil || !strings.Contains(err.Error(), "no non-empty") {
+		t.Errorf("uiToken() error = %v, want missing token-key guidance", err)
+	}
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,8 +170,7 @@ kubectl port-forward -n sympozium-system svc/sympozium-apiserver 8080:8080
 Retrieve the UI token:
 
 ```bash
-kubectl get secret sympozium-ui-token -n sympozium-system \
-  -o jsonpath='{.data.token}' | base64 -d
+sympozium token
 ```
 
 ### What you can do

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,6 +20,7 @@ sympozium onboard --console              # plain text fallback for CI
 ```bash
 sympozium                                # launch the interactive TUI (default command)
 sympozium serve                          # open the web dashboard in your browser
+sympozium token                          # print the web dashboard authentication token
 ```
 
 ### `sympozium serve` Options
@@ -29,6 +30,16 @@ sympozium serve                          # open the web dashboard in your browse
 | `--port` | `9090` | Local port to forward to |
 | `--open` | `false` | Automatically open a browser |
 | `--service-namespace` | `sympozium-system` | Namespace of the apiserver service |
+
+### `sympozium token`
+
+Prints only the dashboard bearer token, which is useful after a manual
+port-forward. It requires permission to read the `sympozium-ui-token` Secret.
+
+```bash
+sympozium token
+sympozium token --service-namespace sympozium-system
+```
 
 ## Resource Management
 


### PR DESCRIPTION
## Summary
- add `sympozium token`, which prints only the dashboard bearer token
- read the Secret through the configured Kubernetes client with actionable missing/empty errors
- document the manual port-forward flow

## Validation
- `go test ./...`
- `go vet ./cmd/sympozium`
- `go run ./cmd/sympozium token --service-namespace sympozium-system >/dev/null` against Framework