### PR TITLE
feat(harness): install maintained adapter catalog

### DIFF
--- a/charts/sympozium/templates/harness-examples.yaml
+++ b/charts/sympozium/templates/harness-examples.yaml
@@ -1,0 +1,93 @@
+{{- /*
+Existing Helm releases upgraded with --reuse-values do not contain this new
+value block. Keep defaults here as well as values.yaml so those upgrades gain
+the catalog instead of failing on a nil map.
+*/}}
+{{- $defaults := dict
+  "enabled" true
+  "policy" (dict "name" "harness-examples")
+  "pi" (dict
+    "enabled" true
+    "name" "pi-v0-84-4"
+    "image" "ghcr.io/sympozium-ai/harness-adapters/pi@sha256:b0d50402dc0a25b2c46f86dbd6b5de963487fa0ffa44058cb324ab2c68934f3b")
+  "hermes" (dict
+    "enabled" true
+    "name" "hermes-v0-20-6"
+    "image" "ghcr.io/sympozium-ai/harness-adapters/hermes@sha256:df66d30c56e7a82c74b9df1d8ef4034127f017640f460c0d3aa7c15f28550ab4")
+}}
+{{- $examples := mergeOverwrite $defaults (default (dict) .Values.harnessExamples) }}
+{{- if $examples.enabled }}
+{{- if not (or $examples.pi.enabled $examples.hermes.enabled) }}
+{{- fail "harnessExamples.enabled requires pi.enabled or hermes.enabled" }}
+{{- end }}
+{{- if and $examples.pi.enabled (not (regexMatch "@sha256:[a-f0-9]{64}$" $examples.pi.image)) }}
+{{- fail "harnessExamples.pi.image must be a digest-pinned OCI reference" }}
+{{- end }}
+{{- if and $examples.hermes.enabled (not (regexMatch "@sha256:[a-f0-9]{64}$" $examples.hermes.image)) }}
+{{- fail "harnessExamples.hermes.image must be a digest-pinned OCI reference" }}
+{{- end }}
+---
+# The chart registers examples but does not bind this policy to any Agent.
+# An operator selects it explicitly along with one of the runtimes below.
+apiVersion: sympozium.ai/v1alpha1
+kind: SympoziumPolicy
+metadata:
+  name: {{ $examples.policy.name }}
+  labels:
+    sympozium.ai/builtin: "true"
+    sympozium.ai/harness-example: "true"
+    {{- include "sympozium.labels" . | nindent 4 }}
+spec:
+  harnessPolicy:
+    enabled: true
+    # Pi and Hermes are intentionally stateless examples and do not currently
+    # provide usage metrics. The policy scopes this exception to their exact
+    # digest-pinned images below.
+    allowUnmetered: true
+  imagePolicy:
+    allowedRegistries:
+    {{- if $examples.pi.enabled }}
+      - {{ $examples.pi.image | quote }}
+    {{- end }}
+    {{- if $examples.hermes.enabled }}
+      - {{ $examples.hermes.image | quote }}
+    {{- end }}
+{{- if $examples.pi.enabled }}
+---
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: {{ $examples.pi.name }}
+  labels:
+    sympozium.ai/builtin: "true"
+    sympozium.ai/harness-example: "true"
+    {{- include "sympozium.labels" . | nindent 4 }}
+spec:
+  image: {{ $examples.pi.image | quote }}
+  contractVersion: v1alpha1
+  supportOwner: sympozium-maintainers
+  conformance:
+    status: conformant
+    owner: sympozium-maintainers
+    reference: https://github.com/sympozium-ai/harness-adapters/blob/main/docs/conformance.md
+{{- end }}
+{{- if $examples.hermes.enabled }}
+---
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: {{ $examples.hermes.name }}
+  labels:
+    sympozium.ai/builtin: "true"
+    sympozium.ai/harness-example: "true"
+    {{- include "sympozium.labels" . | nindent 4 }}
+spec:
+  image: {{ $examples.hermes.image | quote }}
+  contractVersion: v1alpha1
+  supportOwner: sympozium-maintainers
+  conformance:
+    status: conformant
+    owner: sympozium-maintainers
+    reference: https://github.com/sympozium-ai/harness-adapters/blob/main/docs/conformance.md
+{{- end }}
+{{- end }}

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -208,6 +208,25 @@ defaultPersonas:
   # -- Install built-in persona pack definitions (disabled by default, must be activated after install)
   enabled: true
 
+# -- Maintained experimental AgentHarness examples. The chart registers the
+# digest-pinned Pi and Hermes adapters and a policy that permits only those
+# images. No Agent is created or changed: an operator must select the policy
+# and runtime explicitly on an Agent before either adapter can execute.
+harnessExamples:
+  # -- Install the Pi and Hermes AgentRuntime catalog entries.
+  enabled: true
+  policy:
+    # -- Policy an Agent must reference before it can execute either example.
+    name: harness-examples
+  pi:
+    enabled: true
+    name: pi-v0-84-4
+    image: ghcr.io/sympozium-ai/harness-adapters/pi@sha256:b0d50402dc0a25b2c46f86dbd6b5de963487fa0ffa44058cb324ab2c68934f3b
+  hermes:
+    enabled: true
+    name: hermes-v0-20-6
+    image: ghcr.io/sympozium-ai/harness-adapters/hermes@sha256:df66d30c56e7a82c74b9df1d8ef4034127f017640f460c0d3aa7c15f28550ab4
+
 # -- Default MCPServer catalog entries to install (github, grafana, kubernetes, argocd, postgres)
 defaultMcpServers:
   # -- Install built-in MCP server definitions (must be configured with credentials after install)

--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -71,6 +71,22 @@ contract defines mediated equivalents. The historical/default
 
 ## Quickstart
 
+### Built-in Pi and Hermes catalog
+
+The Helm chart installs the maintained experimental Pi and Hermes runtimes in
+the chart namespace by default, just as it installs the Ensemble catalog. In
+the web UI, switch to that namespace (normally `sympozium-system`) and open
+**Agents → Harnesses**. The `harness-examples` policy permits only those exact
+digest-pinned images; select that policy and either runtime explicitly on an
+Agent before running it. No Agent or credential is created by the catalog.
+
+These examples are stateless model-call adapters. They deliberately provide no
+MCP/SkillPack tools, native tools, persona mapping, resume, subagents, or
+usage metrics. See the [adapter conformance report](https://github.com/sympozium-ai/harness-adapters/blob/main/docs/conformance.md)
+before enabling them.
+
+### Bring your own adapter
+
 The checked-in examples use placeholder image digests and credentials. Replace
 those values with an adapter image and Secret that your operator has approved.
 

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -41,6 +41,32 @@ router schedule only on nodes explicitly labelled `celln.dev/kvm=true`; label
 KVM-capable hosts deliberately before they receive host setup. Disable all
 Celln resources with `--set celln.enabled=false`. See [Celln Backend](../concepts/celln-backend.md).
 
+### AgentHarness examples
+
+The chart installs the maintained, experimental Pi and Hermes adapter catalog
+entries by default, alongside the built-in Ensemble catalog. They appear in
+**Agents → Harnesses** when the UI is set to the chart namespace (normally
+`sympozium-system`). Each is pinned to an immutable digest and carries its
+conformance reference.
+
+The chart also creates a `harness-examples` policy that permits only these two
+images. It does **not** create or modify an Agent, so no external harness runs
+until an operator explicitly selects both that policy and a runtime on an
+Agent. The examples are stateless and currently unmetered; they do not support
+MCP/SkillPack tools, native tool filtering, personas, resume, or subagents.
+
+Disable the catalog, or select only one adapter, with values such as:
+
+```yaml
+harnessExamples:
+  enabled: false
+  # Or retain the catalog but install Pi only:
+  pi:
+    enabled: true
+  hermes:
+    enabled: false
+```
+
 ## Observability
 
 The Helm chart deploys a built-in OpenTelemetry collector by default:


### PR DESCRIPTION
## Summary
- install digest-pinned Pi and Hermes AgentRuntime examples with the Helm catalog
- install a `harness-examples` policy limited to those exact images
- keep execution opt-in: no Agent or credential is created or modified
- make defaults work for existing `helm upgrade --reuse-values` installations

## Validation
- `helm lint charts/sympozium`
- `helm template` with defaults, catalog disabled, and Hermes disabled
- `helm upgrade --install --reuse-values --dry-run --debug` against Framework
- invalid unpinned image fails template rendering