### PR TITLE
feat: make harness execution a first-class Agent flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,14 +192,17 @@ web-dev-serve: web-install ## Vite hot-reload + port-forward to in-cluster apise
 	if [ -z "$$APISERVER_TOKEN" ]; then \
 		SECRET_NAME=$$(kubectl get deploy -n $(SYMPOZIUM_NAMESPACE) sympozium-apiserver -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SYMPOZIUM_UI_TOKEN")].valueFrom.secretKeyRef.name}' 2>/dev/null); \
 		SECRET_KEY=$$(kubectl get deploy -n $(SYMPOZIUM_NAMESPACE) sympozium-apiserver -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SYMPOZIUM_UI_TOKEN")].valueFrom.secretKeyRef.key}' 2>/dev/null); \
+		if [ -z "$$SECRET_NAME" ]; then \
+			SECRET_NAME=$$(kubectl get deploy -n $(SYMPOZIUM_NAMESPACE) sympozium-apiserver -o jsonpath='{.spec.template.spec.volumes[?(@.name=="sympozium-ui-token")].secret.secretName}' 2>/dev/null); \
+		fi; \
 		if [ -z "$$SECRET_KEY" ]; then SECRET_KEY=token; fi; \
 		if [ -n "$$SECRET_NAME" ]; then \
 			APISERVER_TOKEN=$$(kubectl get secret -n $(SYMPOZIUM_NAMESPACE) "$$SECRET_NAME" -o jsonpath="{.data.$$SECRET_KEY}" 2>/dev/null | base64 -d 2>/dev/null); \
 		fi; \
 	fi; \
 	if [ -z "$$APISERVER_TOKEN" ]; then \
-		echo "ERROR: Could not resolve API token from apiserver deployment."; \
-		echo "  Check: kubectl get deploy -n $(SYMPOZIUM_NAMESPACE) sympozium-apiserver -o yaml | grep SYMPOZIUM_UI_TOKEN"; \
+		echo "ERROR: Could not resolve API token from the apiserver environment or token volume."; \
+		echo "  Check: kubectl get secret -n $(SYMPOZIUM_NAMESPACE) sympozium-ui-token -o jsonpath='{.data.token}'"; \
 		exit 1; \
 	fi; \
 	STALE_PID=$$(lsof -ti tcp:$(API_LOCAL_PORT) 2>/dev/null || true); \

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -143,6 +143,7 @@ func (s *Server) buildMux(frontendFS fs.FS, expected *tokenReader) http.Handler 
 
 	// Administrator-approved harness runtimes
 	mux.HandleFunc("GET /api/v1/runtimes", s.listRuntimes)
+	mux.HandleFunc("POST /api/v1/runtimes/install-defaults", s.installDefaultRuntimes)
 
 	// Run endpoints
 	mux.HandleFunc("GET /api/v1/runs", s.listRuns)
@@ -414,6 +415,100 @@ func (s *Server) listRuntimes(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, list.Items)
 }
 
+// InstallDefaultRuntimesResponse records an idempotent installation of the
+// curated harness catalog into a namespace. The API takes no image input: it
+// can only copy the chart-managed catalog from sympozium-system.
+type InstallDefaultRuntimesResponse struct {
+	SourceNamespace string   `json:"sourceNamespace"`
+	TargetNamespace string   `json:"targetNamespace"`
+	Copied          []string `json:"copied"`
+	AlreadyPresent  []string `json:"alreadyPresent"`
+}
+
+func (s *Server) installDefaultRuntimes(w http.ResponseWriter, r *http.Request) {
+	targetNS := r.URL.Query().Get("namespace")
+	if targetNS == "" {
+		targetNS = "default"
+	}
+	const sourceNS = "sympozium-system"
+	const catalogLabel = "sympozium.ai/harness-example"
+
+	// A harness runtime is only usable under the accompanying policy. Copy the
+	// policy first and never replace a namespace owner's object of the same name.
+	var sourcePolicy sympoziumv1alpha1.SympoziumPolicy
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: "harness-examples", Namespace: sourceNS}, &sourcePolicy); err != nil {
+		if k8serrors.IsNotFound(err) {
+			http.Error(w, "default harness catalog is not installed in sympozium-system", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if sourcePolicy.Labels[catalogLabel] != "true" || sourcePolicy.Spec.HarnessPolicy == nil || !sourcePolicy.Spec.HarnessPolicy.Enabled {
+		http.Error(w, "default harness catalog policy is invalid", http.StatusInternalServerError)
+		return
+	}
+
+	var sourceRuntimes sympoziumv1alpha1.AgentRuntimeList
+	if err := s.client.List(r.Context(), &sourceRuntimes, client.InNamespace(sourceNS), client.MatchingLabels{catalogLabel: "true"}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(sourceRuntimes.Items) == 0 {
+		http.Error(w, "default harness catalog contains no runtimes", http.StatusNotFound)
+		return
+	}
+
+	resp := InstallDefaultRuntimesResponse{SourceNamespace: sourceNS, TargetNamespace: targetNS, Copied: []string{}, AlreadyPresent: []string{}}
+	installPolicy := &sympoziumv1alpha1.SympoziumPolicy{ObjectMeta: metav1.ObjectMeta{Name: sourcePolicy.Name, Namespace: targetNS, Labels: sourcePolicy.Labels, Annotations: sourcePolicy.Annotations}, Spec: sourcePolicy.Spec}
+	var existingPolicy sympoziumv1alpha1.SympoziumPolicy
+	err := s.client.Get(r.Context(), types.NamespacedName{Name: installPolicy.Name, Namespace: targetNS}, &existingPolicy)
+	if err == nil {
+		resp.AlreadyPresent = append(resp.AlreadyPresent, "policy/"+installPolicy.Name)
+	} else if !k8serrors.IsNotFound(err) {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else if err := s.client.Create(r.Context(), installPolicy); err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			resp.AlreadyPresent = append(resp.AlreadyPresent, "policy/"+installPolicy.Name)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		resp.Copied = append(resp.Copied, "policy/"+installPolicy.Name)
+	}
+
+	for _, src := range sourceRuntimes.Items {
+		if src.Spec.Image == "" { // Defensive: never turn malformed catalog data into a target resource.
+			http.Error(w, "default harness catalog contains an invalid runtime", http.StatusInternalServerError)
+			return
+		}
+		var existing sympoziumv1alpha1.AgentRuntime
+		err := s.client.Get(r.Context(), types.NamespacedName{Name: src.Name, Namespace: targetNS}, &existing)
+		if err == nil {
+			resp.AlreadyPresent = append(resp.AlreadyPresent, "runtime/"+src.Name)
+			continue
+		}
+		if !k8serrors.IsNotFound(err) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		runtime := &sympoziumv1alpha1.AgentRuntime{ObjectMeta: metav1.ObjectMeta{Name: src.Name, Namespace: targetNS, Labels: src.Labels, Annotations: src.Annotations}, Spec: src.Spec}
+		if err := s.client.Create(r.Context(), runtime); err != nil {
+			if k8serrors.IsAlreadyExists(err) {
+				resp.AlreadyPresent = append(resp.AlreadyPresent, "runtime/"+src.Name)
+				continue
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		resp.Copied = append(resp.Copied, "runtime/"+src.Name)
+	}
+
+	writeJSON(w, resp)
+}
+
 func (s *Server) getAgent(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	ns := r.URL.Query().Get("namespace")
@@ -643,6 +738,7 @@ type CreateInstanceRequest struct {
 	AWSSecretAccessKey string                                  `json:"awsSecretAccessKey,omitempty"`
 	AWSSessionToken    string                                  `json:"awsSessionToken,omitempty"`
 	PolicyRef          string                                  `json:"policyRef,omitempty"`
+	RuntimeRef         string                                  `json:"runtimeRef,omitempty"`
 	Skills             []sympoziumv1alpha1.SkillRef            `json:"skills,omitempty"`
 	Channels           []sympoziumv1alpha1.ChannelSpec         `json:"channels,omitempty"`
 	HeartbeatInterval  string                                  `json:"heartbeatInterval,omitempty"`
@@ -796,6 +892,9 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 
 	if req.PolicyRef != "" {
 		inst.Spec.PolicyRef = req.PolicyRef
+	}
+	if req.RuntimeRef != "" {
+		inst.Spec.RuntimeRef = req.RuntimeRef
 	}
 
 	if len(req.Skills) > 0 {

--- a/internal/apiserver/server_agent_test.go
+++ b/internal/apiserver/server_agent_test.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +35,52 @@ func newInstanceTestServer(t *testing.T) (*Server, *runtime.Scheme) {
 		Build()
 
 	return NewServer(cl, nil, nil, logr.Discard()), scheme
+}
+
+func TestInstallDefaultRuntimes(t *testing.T) {
+	policy := &sympoziumv1alpha1.SympoziumPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "harness-examples", Namespace: "sympozium-system", Labels: map[string]string{"sympozium.ai/harness-example": "true"}},
+		Spec:       sympoziumv1alpha1.SympoziumPolicySpec{HarnessPolicy: &sympoziumv1alpha1.HarnessPolicySpec{Enabled: true}},
+	}
+	runtime := &sympoziumv1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "pi-v0-84-4", Namespace: "sympozium-system", Labels: map[string]string{"sympozium.ai/harness-example": "true"}},
+		Spec:       sympoziumv1alpha1.AgentRuntimeSpec{Image: "ghcr.io/sympozium-ai/harness-adapters/pi@sha256:1234"},
+	}
+	srv, cl := newTestServer(t, policy, runtime)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runtimes/install-defaults?namespace=team-a", nil)
+	rec := httptest.NewRecorder()
+	srv.buildMux(nil, nil).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var response InstallDefaultRuntimesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Copied) != 2 {
+		t.Fatalf("copied = %v, want policy and runtime", response.Copied)
+	}
+	var installed sympoziumv1alpha1.AgentRuntime
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: runtime.Name, Namespace: "team-a"}, &installed); err != nil {
+		t.Fatalf("get installed runtime: %v", err)
+	}
+	if installed.Spec.Image != runtime.Spec.Image {
+		t.Fatalf("image = %q, want %q", installed.Spec.Image, runtime.Spec.Image)
+	}
+
+	// Installation is idempotent and must not replace namespaced objects.
+	rec = httptest.NewRecorder()
+	srv.buildMux(nil, nil).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.AlreadyPresent) != 2 {
+		t.Fatalf("alreadyPresent = %v, want policy and runtime", response.AlreadyPresent)
+	}
 }
 
 func TestCreateInstance_NoHardcodedOTLPEndpoint(t *testing.T) {

--- a/internal/apiserver/server_agent_test.go
+++ b/internal/apiserver/server_agent_test.go
@@ -87,9 +87,10 @@ func TestCreateInstance_NoHardcodedOTLPEndpoint(t *testing.T) {
 	srv, _ := newInstanceTestServer(t)
 
 	body, _ := json.Marshal(CreateInstanceRequest{
-		Name:     "test-adhoc",
-		Provider: "lm-studio",
-		Model:    "qwen/qwen3.5-35b-a3b",
+		Name:       "test-adhoc",
+		Provider:   "lm-studio",
+		Model:      "qwen/qwen3.5-35b-a3b",
+		RuntimeRef: "pi-v0-84-4",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents?namespace=default", bytes.NewReader(body))
@@ -118,6 +119,9 @@ func TestCreateInstance_NoHardcodedOTLPEndpoint(t *testing.T) {
 	}
 	if inst.Spec.Observability.OTLPProtocol != "" {
 		t.Errorf("expected empty OTLPProtocol (should not be hardcoded), got %q", inst.Spec.Observability.OTLPProtocol)
+	}
+	if inst.Spec.RuntimeRef != "pi-v0-84-4" {
+		t.Errorf("RuntimeRef = %q, want Agent-level harness selection preserved", inst.Spec.RuntimeRef)
 	}
 }
 

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-B7NFCDsG.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DY_YBoFB.css">
+    <script type="module" crossorigin src="/assets/index-CrAlZc4o.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CLS68YST.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">
     <script>

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from "@/components/auth-provider";
 import { getNamespace, setNamespace } from "@/lib/api";
-import { useNamespaces, useCanaryConfig } from "@/hooks/use-api";
+import { useNamespaces, useCanaryConfig, useRuntimes, useInstallDefaultRuntimes } from "@/hooks/use-api";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -23,8 +23,11 @@ export function Header() {
   const { connected } = useWebSocket();
   const { data: namespaces } = useNamespaces();
   const { data: canary } = useCanaryConfig();
+  const { data: runtimes } = useRuntimes();
+  const installDefaultRuntimes = useInstallDefaultRuntimes();
   const [ns, setNs] = useState(getNamespace());
   const [createOpen, setCreateOpen] = useState(false);
+  const [choosingHarness, setChoosingHarness] = useState(false);
   const navigate = useNavigate();
 
   const handleNsChange = (value: string) => {
@@ -112,16 +115,37 @@ export function Header() {
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Create</DialogTitle>
-            <DialogDescription>Choose the resource you want to create in namespace <span className="font-mono">{ns}</span>.</DialogDescription>
+            <DialogTitle>{choosingHarness ? "Create Agent with a Harness" : "Create"}</DialogTitle>
+            <DialogDescription>{choosingHarness ? "Choose the persistent execution runtime to bind to the new Agent." : <>Choose the resource you want to create in namespace <span className="font-mono">{ns}</span>.</>}</DialogDescription>
           </DialogHeader>
+          {choosingHarness ? (
+            <div className="space-y-3">
+              {(runtimes || []).length === 0 ? (
+                <div className="space-y-3 rounded-lg border border-border p-4">
+                  <p className="text-sm">No approved harnesses are installed in this namespace.</p>
+                  <p className="text-xs text-muted-foreground">Install the curated Pi and Hermes runtimes plus their approving policy. This creates persistent namespace resources and never accepts an arbitrary image.</p>
+                  <Button size="sm" onClick={() => installDefaultRuntimes.mutate()} disabled={installDefaultRuntimes.isPending}>{installDefaultRuntimes.isPending ? "Installing…" : "Install default harnesses"}</Button>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {(runtimes || []).map((runtime) => (
+                    <button key={runtime.metadata.name} className="w-full rounded-lg border border-border p-3 text-left transition-colors hover:border-amber-500/60 hover:bg-amber-500/5" onClick={() => { setCreateOpen(false); setChoosingHarness(false); navigate(`/agents?create=1&runtime=${encodeURIComponent(runtime.metadata.name)}&policy=harness-examples`); }}>
+                      <div className="flex items-center gap-2"><Shield className="h-4 w-4 text-amber-500" /><span className="font-medium">{runtime.metadata.name}</span></div>
+                      <p className="mt-1 text-xs text-muted-foreground">Creates an Agent persistently bound to this harness. Provider, model, and credentials are configured on the Agent.</p>
+                    </button>
+                  ))}
+                </div>
+              )}
+              <Button variant="ghost" size="sm" onClick={() => setChoosingHarness(false)}>Back</Button>
+            </div>
+          ) : <>
           <div className="grid gap-3 sm:grid-cols-2">
             <button className="rounded-lg border border-border p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5" onClick={() => { setCreateOpen(false); navigate("/runs?create=1"); }}>
               <Play className="mb-3 h-5 w-5 text-primary" />
               <p className="font-medium">AgentRun</p>
               <p className="mt-1 text-xs text-muted-foreground">Run an existing Agent once. It inherits that Agent’s configured harness by default.</p>
             </button>
-            <button className="rounded-lg border border-border p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5" onClick={() => { setCreateOpen(false); navigate("/harnesses"); }}>
+            <button className="rounded-lg border border-border p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5" onClick={() => setChoosingHarness(true)}>
               <Shield className="mb-3 h-5 w-5 text-amber-500" />
               <p className="font-medium">Agent Harness</p>
               <p className="mt-1 text-xs text-muted-foreground">Install or choose a trusted external execution adapter, then create an Agent bound to it.</p>
@@ -130,6 +154,7 @@ export function Header() {
           <button className="text-left text-xs text-muted-foreground hover:text-foreground" onClick={() => { setCreateOpen(false); navigate("/agents"); }}>
             <Bot className="mr-1 inline h-3 w-3" /> Or create a standard Agent with the built-in runner.
           </button>
+          </>}
         </DialogContent>
       </Dialog>
     </header>

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -14,6 +14,9 @@ import { useWebSocket } from "@/hooks/use-websocket";
 import { useState } from "react";
 import { formatAge } from "@/lib/utils";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { useNavigate } from "react-router-dom";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Bot, Play, Plus, Shield } from "lucide-react";
 
 export function Header() {
   const { logout } = useAuth();
@@ -21,6 +24,8 @@ export function Header() {
   const { data: namespaces } = useNamespaces();
   const { data: canary } = useCanaryConfig();
   const [ns, setNs] = useState(getNamespace());
+  const [createOpen, setCreateOpen] = useState(false);
+  const navigate = useNavigate();
 
   const handleNsChange = (value: string) => {
     setNs(value);
@@ -48,6 +53,9 @@ export function Header() {
         </div>
       </div>
       <div className="flex items-center gap-3">
+        <Button size="sm" onClick={() => setCreateOpen(true)}>
+          <Plus className="mr-1.5 h-4 w-4" /> Create
+        </Button>
         {/* Canary health indicator */}
         {canary?.enabled && canary.healthStatus && (
           <div
@@ -101,6 +109,29 @@ export function Header() {
           <LogOut className="h-4 w-4" />
         </Button>
       </div>
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Create</DialogTitle>
+            <DialogDescription>Choose the resource you want to create in namespace <span className="font-mono">{ns}</span>.</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <button className="rounded-lg border border-border p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5" onClick={() => { setCreateOpen(false); navigate("/runs?create=1"); }}>
+              <Play className="mb-3 h-5 w-5 text-primary" />
+              <p className="font-medium">AgentRun</p>
+              <p className="mt-1 text-xs text-muted-foreground">Run an existing Agent once. It inherits that Agent’s configured harness by default.</p>
+            </button>
+            <button className="rounded-lg border border-border p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5" onClick={() => { setCreateOpen(false); navigate("/harnesses"); }}>
+              <Shield className="mb-3 h-5 w-5 text-amber-500" />
+              <p className="font-medium">Agent Harness</p>
+              <p className="mt-1 text-xs text-muted-foreground">Install or choose a trusted external execution adapter, then create an Agent bound to it.</p>
+            </button>
+          </div>
+          <button className="text-left text-xs text-muted-foreground hover:text-foreground" onClick={() => { setCreateOpen(false); navigate("/agents"); }}>
+            <Bot className="mr-1 inline h-3 w-3" /> Or create a standard Agent with the built-in runner.
+          </button>
+        </DialogContent>
+      </Dialog>
     </header>
   );
 }

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -259,14 +259,16 @@ type WizardStep =
   | "confirm"
   | "channelAction";
 
-function stepsForMode(mode: "agent" | "persona" | "canary"): WizardStep[] {
+function stepsForMode(
+  mode: "agent" | "persona" | "canary",
+  runtimePreselected = false,
+): WizardStep[] {
   if (mode === "canary") {
     return ["provider", "apikey", "model"];
   }
   if (mode === "agent") {
-    return [
+    const steps: WizardStep[] = [
       "name",
-      "runtime",
       "provider",
       "apikey",
       "model",
@@ -276,6 +278,10 @@ function stepsForMode(mode: "agent" | "persona" | "canary"): WizardStep[] {
       "confirm",
       "channelAction",
     ];
+    // The dedicated Create → Agent Harness flow has already selected a
+    // persistent runtime. Do not make the user confirm the same decision.
+    if (!runtimePreselected) steps.splice(1, 0, "runtime");
+    return steps;
   }
   return [
     "provider",
@@ -536,7 +542,7 @@ export function OnboardingWizard({
   onComplete,
   isPending,
 }: OnboardingWizardProps) {
-  const steps = stepsForMode(mode);
+  const steps = stepsForMode(mode, !!defaults?.runtimeRef);
   const [step, setStep] = useState<WizardStep>(steps[0]);
   const [form, setForm] = useState<WizardResult>({
     name: defaults?.name || "",

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -236,6 +236,8 @@ interface OnboardingWizardProps {
   availableRuntimes?: AgentRuntime[];
   /** Policies available in the current namespace. */
   availablePolicies?: SympoziumPolicy[];
+  /** SkillPacks that harness isolation cannot safely combine with. */
+  harnessIncompatibleSkills?: string[];
   /** Pre-fill form values */
   defaults?: Partial<WizardResult>;
   /** Called when the user clicks Activate / Create */
@@ -529,6 +531,7 @@ export function OnboardingWizard({
   availableSkills = [],
   availableRuntimes = [],
   availablePolicies = [],
+  harnessIncompatibleSkills = [],
   defaults,
   onComplete,
   isPending,
@@ -542,7 +545,9 @@ export function OnboardingWizard({
     secretName: defaults?.secretName || "",
     model: defaults?.model || "",
     baseURL: defaults?.baseURL || "",
-    skills: Array.from(new Set([...(defaults?.skills || []), "memory"])),
+    skills: Array.from(new Set([...(defaults?.skills || []), "memory"])).filter(
+      (skill) => !defaults?.runtimeRef || !harnessIncompatibleSkills.includes(skill),
+    ),
     channels: defaults?.channels || Object.keys(defaults?.channelConfigs || {}),
     channelConfigs: defaults?.channelConfigs || {},
     heartbeatInterval: defaults?.heartbeatInterval || "",
@@ -748,7 +753,9 @@ export function OnboardingWizard({
       secretName: d.secretName || "",
       model: d.model || "",
       baseURL: d.baseURL || "",
-      skills: d.skills || [],
+      skills: (d.skills || []).filter(
+        (skill) => !d.runtimeRef || !harnessIncompatibleSkills.includes(skill),
+      ),
       channels: d.channels || Object.keys(d.channelConfigs || {}),
       channelConfigs: d.channelConfigs || {},
       heartbeatInterval: d.heartbeatInterval || "",
@@ -868,7 +875,14 @@ export function OnboardingWizard({
               onValueChange={(value) => {
                 const runtimeRef = value === "builtin" ? "" : value;
                 const isDefaultCatalog = availableRuntimes.some((runtime) => runtime.metadata.name === runtimeRef && runtime.metadata.labels?.["sympozium.ai/harness-example"] === "true");
-                setForm({ ...form, runtimeRef, policyRef: runtimeRef && isDefaultCatalog ? "harness-examples" : runtimeRef ? form.policyRef : "" });
+                setForm({
+                  ...form,
+                  runtimeRef,
+                  policyRef: runtimeRef && isDefaultCatalog ? "harness-examples" : runtimeRef ? form.policyRef : "",
+                  skills: runtimeRef
+                    ? form.skills.filter((skill) => !harnessIncompatibleSkills.includes(skill))
+                    : form.skills,
+                });
               }}
             >
               <SelectTrigger><SelectValue /></SelectTrigger>
@@ -1300,13 +1314,14 @@ export function OnboardingWizard({
                       .map((skill) => {
                         const selected = form.skills.includes(skill);
                         const locked = skill === "memory";
+                        const incompatible = !!form.runtimeRef && harnessIncompatibleSkills.includes(skill);
                         return (
                           <button
                             key={skill}
                             type="button"
-                            disabled={locked}
+                            disabled={locked || incompatible}
                             onClick={() => {
-                              if (locked) return;
+                              if (locked || incompatible) return;
                               const next = selected
                                 ? form.skills.filter((s) => s !== skill)
                                 : [...form.skills, skill];
@@ -1314,7 +1329,7 @@ export function OnboardingWizard({
                             }}
                             className={cn(
                               "flex w-full items-center justify-between rounded-md border px-2.5 py-2 text-left text-xs transition-colors",
-                              locked
+                              locked || incompatible
                                 ? "border-blue-500/40 bg-blue-500/15 text-blue-300 opacity-70 cursor-not-allowed"
                                 : selected
                                   ? "border-blue-500/40 bg-blue-500/15 text-blue-300"
@@ -1325,6 +1340,8 @@ export function OnboardingWizard({
                             <span className="text-[10px]">
                               {locked
                                 ? "Required"
+                                : incompatible
+                                  ? "Not compatible with harnesses"
                                 : selected
                                   ? "Selected"
                                   : "Select"}

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -44,6 +44,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useCapabilities, useModels } from "@/hooks/use-api";
 import { api } from "@/lib/api";
+import type { AgentRuntime, SympoziumPolicy } from "@/lib/api";
 import {
   YamlModal,
   instanceYamlFromWizard,
@@ -214,6 +215,10 @@ export interface WizardResult {
   requireApproval?: boolean;
   /** References a cluster-local Model CR for inference (no API key needed). */
   modelRef?: string;
+  /** Administrator-approved external harness used by this Agent's normal runs. */
+  runtimeRef?: string;
+  /** Policy required to authorize the selected harness. */
+  policyRef?: string;
 }
 
 interface OnboardingWizardProps {
@@ -227,6 +232,10 @@ interface OnboardingWizardProps {
   agentConfigCount?: number;
   /** Available SkillPacks to choose from */
   availableSkills?: string[];
+  /** Administrator-approved harnesses available in the current namespace. */
+  availableRuntimes?: AgentRuntime[];
+  /** Policies available in the current namespace. */
+  availablePolicies?: SympoziumPolicy[];
   /** Pre-fill form values */
   defaults?: Partial<WizardResult>;
   /** Called when the user clicks Activate / Create */
@@ -238,6 +247,7 @@ interface OnboardingWizardProps {
 
 type WizardStep =
   | "name"
+  | "runtime"
   | "provider"
   | "apikey"
   | "model"
@@ -254,6 +264,7 @@ function stepsForMode(mode: "agent" | "persona" | "canary"): WizardStep[] {
   if (mode === "agent") {
     return [
       "name",
+      "runtime",
       "provider",
       "apikey",
       "model",
@@ -287,6 +298,7 @@ function StepIndicator({
 }) {
   const labels: Record<WizardStep, string> = {
     name: "Name",
+    runtime: "Execution",
     provider: "Provider",
     apikey: "Auth",
     model: "Model",
@@ -298,6 +310,7 @@ function StepIndicator({
   };
   const icons: Record<WizardStep, React.ReactNode> = {
     name: <Server className="h-3.5 w-3.5" />,
+    runtime: <Terminal className="h-3.5 w-3.5" />,
     provider: <Bot className="h-3.5 w-3.5" />,
     apikey: <Key className="h-3.5 w-3.5" />,
     model: <Sparkles className="h-3.5 w-3.5" />,
@@ -514,6 +527,8 @@ export function OnboardingWizard({
   targetName,
   agentConfigCount,
   availableSkills = [],
+  availableRuntimes = [],
+  availablePolicies = [],
   defaults,
   onComplete,
   isPending,
@@ -545,6 +560,8 @@ export function OnboardingWizard({
     awsAccessKeyId: defaults?.awsAccessKeyId || "",
     awsSecretAccessKey: defaults?.awsSecretAccessKey || "",
     awsSessionToken: defaults?.awsSessionToken || "",
+    runtimeRef: defaults?.runtimeRef || "",
+    policyRef: defaults?.policyRef || "",
   });
   const [inferenceMode, setInferenceMode] = useState<"workload" | "node">(
     "workload",
@@ -745,6 +762,8 @@ export function OnboardingWizard({
       awsAccessKeyId: d.awsAccessKeyId || "",
       awsSecretAccessKey: d.awsSecretAccessKey || "",
       awsSessionToken: d.awsSessionToken || "",
+      runtimeRef: d.runtimeRef || "",
+      policyRef: d.policyRef || "",
     });
     setStep(steps[0]);
     setChannelActionIdx(0);
@@ -832,6 +851,49 @@ export function OnboardingWizard({
               />
               {nameError && <p className="text-xs text-red-500">{nameError}</p>}
             </div>
+          </div>
+        )}
+
+        {/* ── Execution step (Agent only) ───────────────────────────── */}
+        {step === "runtime" && (
+          <div className="space-y-4">
+            <div>
+              <Label>How will this Agent execute?</Label>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Choose the Agent's default execution runtime. Normal AgentRuns inherit this choice; a run may make a one-off override later.
+              </p>
+            </div>
+            <Select
+              value={form.runtimeRef || "builtin"}
+              onValueChange={(value) => {
+                const runtimeRef = value === "builtin" ? "" : value;
+                const isDefaultCatalog = availableRuntimes.some((runtime) => runtime.metadata.name === runtimeRef && runtime.metadata.labels?.["sympozium.ai/harness-example"] === "true");
+                setForm({ ...form, runtimeRef, policyRef: runtimeRef && isDefaultCatalog ? "harness-examples" : runtimeRef ? form.policyRef : "" });
+              }}
+            >
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="builtin">Built-in Agent runner — recommended default</SelectItem>
+                {availableRuntimes.map((runtime) => (
+                  <SelectItem key={runtime.metadata.name} value={runtime.metadata.name}>
+                    {runtime.metadata.name}{runtime.spec.supportOwner ? ` — ${runtime.spec.supportOwner}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {form.runtimeRef ? (
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">Harness selected: {form.runtimeRef}.</span>{" "}
+                This external adapter becomes the primary process for this Agent's runs. Your provider, model, endpoint, and credential selected in the next steps remain the Agent configuration passed to it. Sympozium still enforces identity, policy, mounts, NATS permissions, and lifecycle.
+              </div>
+            ) : (
+              <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+                The built-in Agent runner will execute this Agent's runs.
+              </div>
+            )}
+            {form.runtimeRef && !availablePolicies.some((policy) => policy.metadata.name === form.policyRef) && (
+              <p className="text-xs text-amber-500">The selected harness needs an approving policy. Install the default harnesses for this namespace, or ask an administrator to provide one.</p>
+            )}
           </div>
         )}
 
@@ -1613,6 +1675,12 @@ export function OnboardingWizard({
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Name</span>
                   <span className="font-mono text-blue-400">{form.name}</span>
+                </div>
+              )}
+              {mode === "agent" && (
+                <div className="flex justify-between gap-4">
+                  <span className="text-muted-foreground">Execution</span>
+                  <span className="font-mono text-right">{form.runtimeRef || "Built-in Agent runner"}</span>
                 </div>
               )}
               {mode === "persona" && targetName && (

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -69,6 +69,20 @@ export function useRuntimes() {
   return useQuery({ queryKey: ["runtimes"], queryFn: api.runtimes.list });
 }
 
+export function useInstallDefaultRuntimes() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: api.runtimes.installDefaults,
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["runtimes"] });
+      qc.invalidateQueries({ queryKey: ["policies"] });
+      const installed = data.copied.filter((name) => name.startsWith("runtime/")).length;
+      toast.success(installed ? `Installed ${installed} default harness${installed === 1 ? "" : "es"}` : "Default harnesses are already installed");
+    },
+    onError: toastError,
+  });
+}
+
 export function useAgent(name: string) {
   return useQuery({
     queryKey: ["agents", name],

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -754,6 +754,13 @@ export interface InstallDefaultMCPServersResponse {
   alreadyPresent: string[];
 }
 
+export interface InstallDefaultRuntimesResponse {
+  sourceNamespace: string;
+  targetNamespace: string;
+  copied: string[];
+  alreadyPresent: string[];
+}
+
 export interface MCPServerAuthStatusResponse {
   status: string;
   secretName: string;
@@ -1253,6 +1260,7 @@ export const api = {
       awsSecretAccessKey?: string;
       awsSessionToken?: string;
       policyRef?: string;
+	  runtimeRef?: string;
       skills?: SkillRef[];
       channels?: ChannelSpec[];
       heartbeatInterval?: string;
@@ -1293,6 +1301,10 @@ export const api = {
 
   runtimes: {
     list: () => apiFetch<AgentRuntime[]>("/api/v1/runtimes"),
+    installDefaults: () =>
+      apiFetch<InstallDefaultRuntimesResponse>("/api/v1/runtimes/install-defaults", {
+        method: "POST",
+      }),
   },
 
   policies: {

--- a/web/src/pages/agents.tsx
+++ b/web/src/pages/agents.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import {
   useAgents,
@@ -40,6 +40,17 @@ export function AgentsPage() {
   const [wizardOpen, setWizardOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [whatsAppInstance, setWhatsAppInstance] = useState<string | null>(null);
+  const autoOpenConsumed = useRef(false);
+  const harnessIncompatibleSkills = (skillPacks || [])
+    .filter((skill) => skill.spec.sidecar?.hostAccess?.enabled)
+    .map((skill) => skill.metadata.name);
+
+  useEffect(() => {
+    if (searchParams.get("create") === "1" && !autoOpenConsumed.current) {
+      autoOpenConsumed.current = true;
+      setWizardOpen(true);
+    }
+  }, [searchParams]);
 
   const filtered = (data || [])
     .filter((inst) =>
@@ -271,6 +282,7 @@ export function AgentsPage() {
         availableSkills={(skillPacks || []).map((s) => s.metadata.name)}
         availableRuntimes={runtimes || []}
         availablePolicies={policies || []}
+        harnessIncompatibleSkills={harnessIncompatibleSkills}
         defaults={{
           provider: "openai",
           model: "gpt-4o",

--- a/web/src/pages/agents.tsx
+++ b/web/src/pages/agents.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   useAgents,
   useDeleteAgent,
   useCreateAgent,
   useSkills,
+  useRuntimes,
+  usePolicies,
 } from "@/hooks/use-api";
 import { StatusBadge } from "@/components/status-badge";
 import {
@@ -30,6 +32,9 @@ import { formatAge } from "@/lib/utils";
 export function AgentsPage() {
   const { data, isLoading } = useAgents();
   const { data: skillPacks } = useSkills();
+  const { data: runtimes } = useRuntimes();
+  const { data: policies } = usePolicies();
+  const [searchParams] = useSearchParams();
   const deleteAgent = useDeleteAgent();
   const createAgent = useCreateAgent();
   const [wizardOpen, setWizardOpen] = useState(false);
@@ -55,6 +60,8 @@ export function AgentsPage() {
         awsAccessKeyId: result.awsAccessKeyId || undefined,
         awsSecretAccessKey: result.awsSecretAccessKey || undefined,
         awsSessionToken: result.awsSessionToken || undefined,
+        runtimeRef: result.runtimeRef || undefined,
+        policyRef: result.policyRef || undefined,
         skills: result.skills.map((skillPackRef) => {
           if (skillPackRef === "web-endpoint") {
             const params: Record<string, string> = {};
@@ -262,10 +269,16 @@ export function AgentsPage() {
         onClose={() => setWizardOpen(false)}
         mode="agent"
         availableSkills={(skillPacks || []).map((s) => s.metadata.name)}
+        availableRuntimes={runtimes || []}
+        availablePolicies={policies || []}
         defaults={{
           provider: "openai",
           model: "gpt-4o",
           skills: ["k8s-ops", "llmfit", "memory"],
+          ...(searchParams.get("runtime") ? {
+            runtimeRef: searchParams.get("runtime") || "",
+            policyRef: searchParams.get("policy") || "harness-examples",
+          } : {}),
         }}
         onComplete={handleComplete}
         isPending={createAgent.isPending}

--- a/web/src/pages/harnesses.tsx
+++ b/web/src/pages/harnesses.tsx
@@ -1,9 +1,10 @@
 import { Link } from "react-router-dom";
-import { useRuntimes } from "@/hooks/use-api";
+import { useRuntimes, useInstallDefaultRuntimes } from "@/hooks/use-api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ShieldCheck, ShieldX, ExternalLink } from "lucide-react";
+import { ShieldCheck, ShieldX, ExternalLink, Download, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 function ready(runtime: import("@/lib/api").AgentRuntime) {
   return runtime.status?.conditions?.some(
@@ -13,6 +14,7 @@ function ready(runtime: import("@/lib/api").AgentRuntime) {
 
 export function HarnessesPage() {
   const { data: runtimes, isLoading } = useRuntimes();
+  const installDefaults = useInstallDefaultRuntimes();
 
   if (isLoading) {
     return <Skeleton className="h-64 w-full" />;
@@ -20,20 +22,27 @@ export function HarnessesPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Harnesses</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Administrator-approved execution adapters. These are trusted runtime
-          profiles, not arbitrary container images.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Harnesses</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Administrator-approved execution adapters. These are trusted runtime
+            profiles, not arbitrary container images.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => installDefaults.mutate()} disabled={installDefaults.isPending}>
+          <Download className="mr-2 h-4 w-4" /> {installDefaults.isPending ? "Installing…" : "Install defaults"}
+        </Button>
       </div>
 
       {(runtimes || []).length === 0 ? (
         <Card>
-          <CardContent className="py-8 text-sm text-muted-foreground">
-            No approved harnesses are registered in this namespace. Create an
-            <code className="mx-1 rounded bg-muted px-1">AgentRuntime</code>
-            before selecting one on an Agent.
+          <CardContent className="space-y-4 py-8 text-sm text-muted-foreground">
+            <p>No approved harnesses are registered in this namespace.</p>
+            <p>Install Pi and Hermes as curated, digest-pinned defaults. This also installs the required harness policy; it does not create an Agent or credentials.</p>
+            <Button size="sm" onClick={() => installDefaults.mutate()} disabled={installDefaults.isPending}>
+              <Download className="mr-2 h-4 w-4" /> {installDefaults.isPending ? "Installing…" : "Install default harnesses"}
+            </Button>
           </CardContent>
         </Card>
       ) : (
@@ -82,8 +91,8 @@ export function HarnessesPage() {
                     <Link to={`/harnesses/${runtime.metadata.name}`} className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300">
                       Inspect harness <ExternalLink className="h-3 w-3" />
                     </Link>
-                    <Link to="/agents" className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300">
-                      Select from an Agent <ExternalLink className="h-3 w-3" />
+                    <Link to={`/agents?runtime=${encodeURIComponent(runtime.metadata.name)}&policy=harness-examples`} className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300">
+                      <Plus className="h-3 w-3" /> Create Agent using this harness
                     </Link>
                   </div>
                 </CardContent>

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   useRuns,
   useDeleteRun,
@@ -78,6 +78,7 @@ export function RunsPage() {
   const createRun = useCreateRun();
   const gateVerdict = useGateVerdict();
   const [open, setOpen] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [search, setSearch] = useState("");
   const { isUnseen, markAllSeen } = useRunsSeen();
   const markedRef = useRef(false);
@@ -89,6 +90,14 @@ export function RunsPage() {
     backend: "job",
     runtimeRef: "",
   });
+  const selectedAgent = (instances.data || []).find((agent) => agent.metadata.name === form.agentRef);
+
+  useEffect(() => {
+    if (searchParams.get("create") === "1") {
+      setOpen(true);
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
 
   // Mark all runs as seen after a short delay so "new" dots are visible briefly.
   useEffect(() => {
@@ -183,16 +192,16 @@ export function RunsPage() {
                 />
               </div>
               <div className="space-y-2">
-                <Label>Harness runtime (optional)</Label>
+                <Label>One-run harness override (advanced)</Label>
                 <Select
                   value={form.runtimeRef || "inherit"}
                   onValueChange={(v) => setForm({ ...form, runtimeRef: v === "inherit" ? "" : v })}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder="Use agent default" />
+                    <SelectValue placeholder="Use Agent default" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="inherit">Use agent default</SelectItem>
+                    <SelectItem value="inherit">Use Agent default{selectedAgent?.spec.runtimeRef ? ` — ${selectedAgent.spec.runtimeRef}` : " — built-in runner"}</SelectItem>
                     {(runtimes.data || []).map((runtime) => (
                       <SelectItem key={runtime.metadata.name} value={runtime.metadata.name}>
                         {runtime.metadata.name}{runtime.spec.supportOwner ? ` — ${runtime.spec.supportOwner}` : ""}
@@ -201,7 +210,7 @@ export function RunsPage() {
                   </SelectContent>
                 </Select>
                 <p className="text-xs text-muted-foreground">
-                  Choose an administrator-approved adapter. Leaving this empty preserves the agent’s configured runtime and normal AgentRun behaviour.
+                  This is normally not needed: runs inherit <span className="font-mono">{selectedAgent?.spec.runtimeRef || "the built-in runner"}</span> from the selected Agent. Choose another approved harness only for this run.
                 </p>
               </div>
               <div className="grid grid-cols-2 gap-4">

--- a/web/src/pages/topology.tsx
+++ b/web/src/pages/topology.tsx
@@ -39,6 +39,7 @@ import {
   useGatewayConfig,
   useDensityNodes,
   useDraNodes,
+  useRuntimes,
 } from "@/hooks/use-api";
 import { StimulusDialogProvider, StimulusDialogCtx } from "@/components/canvas-primitives";
 import type { StimulusNodeData } from "@/components/canvas-primitives";
@@ -64,6 +65,7 @@ import {
   ListOrdered,
   Eye,
   Network,
+  Shield,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type {
@@ -71,6 +73,7 @@ import type {
   Ensemble,
   Model,
   AgentRun,
+  AgentRuntime,
   ProviderNode,
   NodeProvider,
   GatewayConfigResponse,
@@ -348,6 +351,27 @@ interface AgentRunNodeData {
   [key: string]: unknown;
 }
 
+interface HarnessNodeData {
+  name: string;
+  ready: boolean;
+  owner: string;
+  [key: string]: unknown;
+}
+
+function HarnessNode({ data }: NodeProps<Node<HarnessNodeData>>) {
+  return (
+    <div className="border border-amber-500/40 bg-amber-500/5 px-3 py-2 shadow-sm min-w-[150px]">
+      <Handle type="target" position={Position.Top} className="!bg-amber-400 !w-1.5 !h-1.5" />
+      <Handle type="source" position={Position.Bottom} className="!bg-amber-400 !w-1.5 !h-1.5" />
+      <div className="flex items-center gap-1.5">
+        <Shield className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+        <Link to={`/harnesses/${data.name}`} className="text-[11px] font-medium hover:underline truncate">{data.name}</Link>
+      </div>
+      <p className="mt-0.5 text-[9px] text-muted-foreground">{data.ready ? "Ready" : "Not ready"}{data.owner ? ` · ${data.owner}` : ""}</p>
+    </div>
+  );
+}
+
 const runPhaseBorder: Record<string, string> = {
   Running: "border-blue-500/50 bg-blue-500/5",
   Pending: "border-yellow-500/50 bg-yellow-500/5",
@@ -525,6 +549,7 @@ export const nodeTypes = {
   persona: PersonaNode,
   agent: StandaloneAgentNode,
   agentRun: AgentRunNode,
+  harness: HarnessNode,
   cloudProvider: CloudProviderNode,
   gateway: GatewayNode,
 };
@@ -542,6 +567,7 @@ export const NODE_SIZES: Record<string, [number, number]> = {
   persona:       [150, 50],
   agent:         [170, 56],
   agentRun:      [140, 40],
+  harness:       [170, 56],
 };
 
 /** Run dagre layout on nodes and edges, positioning top-to-bottom. */
@@ -587,6 +613,7 @@ function entityFingerprint(
   models: Model[],
   ensembles: Ensemble[],
   agents: Agent[],
+  runtimes: AgentRuntime[],
   hasGateway: boolean,
   draNodes?: DraNodeSummary[],
 ): string {
@@ -596,6 +623,7 @@ function entityFingerprint(
     models.map((m) => m.metadata.name).sort().join(","),
     ensembles.map((e) => e.metadata.name).sort().join(","),
     agents.map((a) => a.metadata.name).sort().join(","),
+    runtimes.map((r) => r.metadata.name).sort().join(","),
     hasGateway ? "gw" : "",
   ];
   return parts.join("|");
@@ -610,6 +638,7 @@ function buildTopology(
   models: Model[],
   ensembles: Ensemble[],
   agents: Agent[],
+  runtimes: AgentRuntime[],
   gateway: GatewayConfigResponse | undefined,
   runningByEnsemble: Record<string, number>,
   webEndpointAgents: string[],
@@ -633,6 +662,23 @@ function buildTopology(
   const standaloneAgents = agents.filter(
     (a) => !ensembleAgentRefs.has(a.metadata.name),
   );
+
+  // A harness is execution infrastructure. Render only harnesses actually
+  // selected by an Agent, keeping the topology focused on live relationships.
+  const referencedRuntimeNames = new Set(
+    agents.map((agent) => agent.spec.runtimeRef).filter(Boolean),
+  );
+  for (const runtime of runtimes.filter((runtime) => referencedRuntimeNames.has(runtime.metadata.name))) {
+    const ready = runtime.status?.conditions?.some(
+      (condition) => condition.type === "Ready" && condition.status === "True",
+    ) || false;
+    nodes.push({
+      id: `harness-${runtime.metadata.name}`,
+      type: "harness",
+      position: P,
+      data: { name: runtime.metadata.name, ready, owner: runtime.spec.supportOwner || "" },
+    });
+  }
 
   // ── Provider detection ─────────────────────────────────────────────────
   const PROVIDER_LABELS: Record<string, string> = {
@@ -851,6 +897,19 @@ function buildTopology(
         runPhase: runPhases[agent.metadata.name],
       },
     });
+    if (agent.spec.runtimeRef && runtimes.some((runtime) => runtime.metadata.name === agent.spec.runtimeRef)) {
+      edges.push({
+        id: `e-${agentId}-harness-${agent.spec.runtimeRef}`,
+        source: agentId,
+        target: `harness-${agent.spec.runtimeRef}`,
+        style: { stroke: "#f59e0b", strokeWidth: 1.5, strokeDasharray: "4 3" },
+        markerEnd: { type: MarkerType.ArrowClosed, color: "#f59e0b" },
+        label: "executes with",
+        labelStyle: { fontSize: 9, fill: "#8a8c82" },
+        labelBgStyle: { fill: "#09090b", fillOpacity: 0.8 },
+        labelBgPadding: [4, 2] as [number, number],
+      });
+    }
     const modelName = agentModelMap.get(agent.metadata.name);
     if (modelName) {
       edges.push({
@@ -1212,6 +1271,7 @@ function TopologyCanvas() {
   const { data: ensembles } = useEnsembles();
   const { data: models } = useModels();
   const { data: agents } = useAgents();
+  const { data: runtimes } = useRuntimes();
   const { data: runs } = useRuns();
   const { data: providerNodes } = useProviderNodes(true);
   const { data: gateway } = useGatewayConfig();
@@ -1331,6 +1391,7 @@ function TopologyCanvas() {
       models || [],
       ensembles || [],
       agents || [],
+      runtimes || [],
       !!gateway,
       draData?.nodes,
     ) + "|runs:" + activeRunFingerprint;
@@ -1344,6 +1405,7 @@ function TopologyCanvas() {
         models || [],
         ensembles || [],
         agents || [],
+        runtimes || [],
         gateway,
         runningByEnsemble,
         webEndpointAgents,
@@ -1380,6 +1442,7 @@ function TopologyCanvas() {
           models || [],
           ensembles || [],
           agents || [],
+          runtimes || [],
           gateway,
           runningByEnsemble,
           webEndpointAgents,
@@ -1403,6 +1466,7 @@ function TopologyCanvas() {
           models || [],
           ensembles || [],
           agents || [],
+          runtimes || [],
           gateway,
           runningByEnsemble,
           webEndpointAgents,
@@ -1414,7 +1478,7 @@ function TopologyCanvas() {
         return freshEdges;
       });
     }
-  }, [providerNodes, models, ensembles, agents, gateway, runningByEnsemble, webEndpointAgents, runPhases, activeRuns, activeRunFingerprint, densityData, draData]);
+  }, [providerNodes, models, ensembles, agents, runtimes, gateway, runningByEnsemble, webEndpointAgents, runPhases, activeRuns, activeRunFingerprint, densityData, draData]);
 
   // Save positions to localStorage after any node drag ends.
   const handleNodesChange = useCallback(


### PR DESCRIPTION
## What changes
- adds an idempotent, no-image-input API to install the curated Pi/Hermes harness catalog and its approving policy into the current namespace
- makes execution runtime an explicit Agent creation step; provider, model, endpoint, and credential remain Agent configuration passed to the selected harness
- adds a global Create chooser for AgentRun vs Agent Harness, plus Harness page install and create-Agent actions
- makes AgentRun inherit the Agent harness by default and labels per-run selection as an advanced override
- renders selected harnesses as distinct topology nodes with Agent → Harness execution links

## Safety
The installer only copies the chart-managed `sympozium-system` catalog, requires the catalog label and an enabled harness policy, accepts no caller-supplied image, and never overwrites namespace-owned resources.

## Verification
- `go test ./internal/apiserver`
- `cd web && npm run build`
