### PR TITLE
feat: install Pi persistent session runtime by default

### DIFF
--- a/charts/sympozium/templates/harness-examples.yaml
+++ b/charts/sympozium/templates/harness-examples.yaml
@@ -10,6 +10,10 @@ the catalog instead of failing on a nil map.
     "enabled" true
     "name" "pi-v0-84-4"
     "image" "ghcr.io/sympozium-ai/harness-adapters/pi@sha256:b0d50402dc0a25b2c46f86dbd6b5de963487fa0ffa44058cb324ab2c68934f3b")
+  "piSession" (dict
+    "enabled" true
+    "name" "pi-session-v0-84-4"
+    "image" "ghcr.io/sympozium-ai/harness-adapters/pi@sha256:cb35578a1f1ace8870a2a9c08e9efe7cf720bfd938cec503d24a4eda10384141")
   "hermes" (dict
     "enabled" true
     "name" "hermes-v0-20-6"
@@ -17,11 +21,14 @@ the catalog instead of failing on a nil map.
 }}
 {{- $examples := mergeOverwrite $defaults (default (dict) .Values.harnessExamples) }}
 {{- if $examples.enabled }}
-{{- if not (or $examples.pi.enabled $examples.hermes.enabled) }}
-{{- fail "harnessExamples.enabled requires pi.enabled or hermes.enabled" }}
+{{- if not (or $examples.pi.enabled $examples.piSession.enabled $examples.hermes.enabled) }}
+{{- fail "harnessExamples.enabled requires pi.enabled, piSession.enabled, or hermes.enabled" }}
 {{- end }}
 {{- if and $examples.pi.enabled (not (regexMatch "@sha256:[a-f0-9]{64}$" $examples.pi.image)) }}
 {{- fail "harnessExamples.pi.image must be a digest-pinned OCI reference" }}
+{{- end }}
+{{- if and $examples.piSession.enabled (not (regexMatch "@sha256:[a-f0-9]{64}$" $examples.piSession.image)) }}
+{{- fail "harnessExamples.piSession.image must be a digest-pinned OCI reference" }}
 {{- end }}
 {{- if and $examples.hermes.enabled (not (regexMatch "@sha256:[a-f0-9]{64}$" $examples.hermes.image)) }}
 {{- fail "harnessExamples.hermes.image must be a digest-pinned OCI reference" }}
@@ -49,6 +56,9 @@ spec:
     {{- if $examples.pi.enabled }}
       - {{ $examples.pi.image | quote }}
     {{- end }}
+    {{- if $examples.piSession.enabled }}
+      - {{ $examples.piSession.image | quote }}
+    {{- end }}
     {{- if $examples.hermes.enabled }}
       - {{ $examples.hermes.image | quote }}
     {{- end }}
@@ -70,6 +80,28 @@ spec:
     status: conformant
     owner: sympozium-maintainers
     reference: https://github.com/sympozium-ai/harness-adapters/blob/main/docs/conformance.md
+{{- end }}
+{{- if $examples.piSession.enabled }}
+---
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: {{ $examples.piSession.name }}
+  labels:
+    sympozium.ai/builtin: "true"
+    sympozium.ai/harness-example: "true"
+    {{- include "sympozium.labels" . | nindent 4 }}
+spec:
+  image: {{ $examples.piSession.image | quote }}
+  contractVersion: v1alpha2
+  session:
+    protocol: openai-chat
+    port: 8080
+  supportOwner: sympozium-maintainers
+  conformance:
+    status: pending
+    owner: sympozium-maintainers
+    reference: https://github.com/sympozium-ai/harness-adapters/blob/main/docs/adapter-contract.md
 {{- end }}
 {{- if $examples.hermes.enabled }}
 ---

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -222,6 +222,10 @@ harnessExamples:
     enabled: true
     name: pi-v0-84-4
     image: ghcr.io/sympozium-ai/harness-adapters/pi@sha256:b0d50402dc0a25b2c46f86dbd6b5de963487fa0ffa44058cb324ab2c68934f3b
+  piSession:
+    enabled: true
+    name: pi-session-v0-84-4
+    image: ghcr.io/sympozium-ai/harness-adapters/pi@sha256:cb35578a1f1ace8870a2a9c08e9efe7cf720bfd938cec503d24a4eda10384141
   hermes:
     enabled: true
     name: hermes-v0-20-6

--- a/internal/controller/harnesssession_controller.go
+++ b/internal/controller/harnesssession_controller.go
@@ -115,13 +115,46 @@ func (r *HarnessSessionReconciler) resolveInputs(ctx context.Context, session *s
 	if runtime.Spec.ContractVersion != "v1alpha2" || runtime.Spec.Session == nil || runtime.Spec.Session.Protocol != "openai-chat" || runtime.Spec.Session.Port == 0 {
 		return nil, nil, fmt.Sprintf("AgentRuntime %q does not declare the v1alpha2 openai-chat session contract", runtime.Name)
 	}
-	if runtime.Spec.Model == nil || strings.TrimSpace(runtime.Spec.Model.Provider) == "" || strings.TrimSpace(runtime.Spec.Model.Model) == "" {
-		return nil, nil, fmt.Sprintf("AgentRuntime %q must declare spec.model.provider and spec.model.model for sessions", runtime.Name)
+	model, modelReason := resolveSessionModel(agent, runtime)
+	if modelReason != "" {
+		return nil, nil, modelReason
 	}
-	if !agentAllowsModelCredential(agent, runtime.Spec.Model.Provider, runtime.Spec.Model.AuthSecretRef) {
-		return nil, nil, fmt.Sprintf("Agent %q does not allow runtime model credential %q for provider %q", agent.Name, runtime.Spec.Model.AuthSecretRef, runtime.Spec.Model.Provider)
+	// This is an in-memory resolved copy, not a mutation of the admin-owned
+	// AgentRuntime. The Agent remains the owner of the default model route and
+	// credential allowlist when the runtime deliberately leaves model blank.
+	runtime.Spec.Model = model
+	if !agentAllowsModelCredential(agent, model.Provider, model.AuthSecretRef) {
+		return nil, nil, fmt.Sprintf("Agent %q does not allow runtime model credential %q for provider %q", agent.Name, model.AuthSecretRef, model.Provider)
 	}
 	return agent, runtime, ""
+}
+
+func resolveSessionModel(agent *sympoziumv1alpha1.Agent, runtime *sympoziumv1alpha1.AgentRuntime) (*sympoziumv1alpha1.AgentRuntimeModel, string) {
+	model := &sympoziumv1alpha1.AgentRuntimeModel{}
+	if runtime.Spec.Model != nil {
+		*model = *runtime.Spec.Model
+	}
+	if model.Model == "" {
+		model.Model = agent.Spec.Agents.Default.Model
+	}
+	if model.BaseURL == "" {
+		model.BaseURL = agent.Spec.Agents.Default.BaseURL
+	}
+	if model.Provider == "" && len(agent.Spec.AuthRefs) == 1 {
+		model.Provider = agent.Spec.AuthRefs[0].Provider
+	}
+	if model.AuthSecretRef == "" {
+		for _, ref := range agent.Spec.AuthRefs {
+			if ref.Provider == "" || strings.EqualFold(ref.Provider, model.Provider) {
+				model.AuthSecretRef = ref.Secret
+				break
+			}
+		}
+	}
+	if strings.TrimSpace(model.Provider) == "" || strings.TrimSpace(model.Model) == "" {
+		return nil, fmt.Sprintf("AgentRuntime %q needs spec.model.provider/model, or an Agent with exactly one provider credential and a default model", runtime.Name)
+	}
+	return model, ""
 }
 
 func sessionWorkloadName(session *sympoziumv1alpha1.HarnessSession) string {

--- a/internal/controller/harnesssession_controller_test.go
+++ b/internal/controller/harnesssession_controller_test.go
@@ -114,3 +114,21 @@ func TestHarnessSessionFailsClosedForOneShotRuntime(t *testing.T) {
 		t.Fatalf("unexpected failed status: %#v", got.Status)
 	}
 }
+
+func TestResolveSessionModelInheritsSingleAgentCredential(t *testing.T) {
+	agent := &sympoziumv1alpha1.Agent{
+		Spec: sympoziumv1alpha1.AgentSpec{
+			Agents:   sympoziumv1alpha1.AgentsSpec{Default: sympoziumv1alpha1.AgentConfig{Model: "qwen", BaseURL: "http://model:9473/v1"}},
+			AuthRefs: []sympoziumv1alpha1.SecretRef{{Provider: "openai-compatible", Secret: "model-key"}},
+		},
+	}
+	runtime := readySessionRuntime()
+	runtime.Spec.Model = nil
+	model, reason := resolveSessionModel(agent, runtime)
+	if reason != "" {
+		t.Fatalf("resolveSessionModel returned %q", reason)
+	}
+	if model.Provider != "openai-compatible" || model.Model != "qwen" || model.AuthSecretRef != "model-key" {
+		t.Fatalf("unexpected inherited model: %#v", model)
+	}
+}


### PR DESCRIPTION
Adds a curated digest-pinned Pi v1alpha2 session runtime to the default harness catalog and lets a session runtime inherit the selected Agent’s single model credential/default model route. This makes **Harnesses → Start interactive session** usable without manually authoring a runtime.

Verified with focused Go tests and Helm lint/template rendering.