### PR TITLE
feat: make persistent harness chat resumable

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -148,6 +148,7 @@ func (s *Server) buildMux(frontendFS fs.FS, expected *tokenReader) http.Handler 
 	// route to a session's private in-cluster Service.
 	mux.HandleFunc("GET /api/v1/harness-sessions", s.listHarnessSessions)
 	mux.HandleFunc("POST /api/v1/harness-sessions", s.createHarnessSession)
+	mux.HandleFunc("PATCH /api/v1/harness-sessions/{name}", s.patchHarnessSession)
 	mux.HandleFunc("DELETE /api/v1/harness-sessions/{name}", s.deleteHarnessSession)
 	mux.HandleFunc("POST /api/v1/harness-sessions/{name}/chat", s.chatHarnessSession)
 

--- a/internal/apiserver/server_harnesssession.go
+++ b/internal/apiserver/server_harnesssession.go
@@ -34,6 +34,13 @@ type CreateHarnessSessionRequest struct {
 	IdleTimeout string `json:"idleTimeout,omitempty"`
 }
 
+// PatchHarnessSessionRequest intentionally exposes only lifecycle control. The
+// Agent and runtime binding are immutable for a session: changing either would
+// make the recorded adapter provenance misleading.
+type PatchHarnessSessionRequest struct {
+	DesiredState string `json:"desiredState"`
+}
+
 func requestNamespace(r *http.Request) string {
 	if ns := r.URL.Query().Get("namespace"); ns != "" {
 		return ns
@@ -78,6 +85,34 @@ func (s *Server) createHarnessSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, session)
+}
+
+func (s *Server) patchHarnessSession(w http.ResponseWriter, r *http.Request) {
+	var request PatchHarnessSessionRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4*1024)).Decode(&request); err != nil {
+		http.Error(w, "invalid session patch: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if request.DesiredState != "running" && request.DesiredState != "stopped" {
+		http.Error(w, "desiredState must be running or stopped", http.StatusBadRequest)
+		return
+	}
+	session := &sympoziumv1alpha1.HarnessSession{}
+	key := types.NamespacedName{Name: r.PathValue("name"), Namespace: requestNamespace(r)}
+	if err := s.client.Get(r.Context(), key, session); err != nil {
+		if k8serrors.IsNotFound(err) {
+			http.Error(w, "HarnessSession not found", http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	session.Spec.DesiredState = request.DesiredState
+	if err := s.client.Update(r.Context(), session); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	writeJSON(w, session)
 }
 

--- a/internal/apiserver/server_harnesssession_test.go
+++ b/internal/apiserver/server_harnesssession_test.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
@@ -53,5 +55,29 @@ func TestHarnessSessionAPI_ChatRequiresReadyControllerOwnedService(t *testing.T)
 	server.Handler(nil).ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/api/v1/harness-sessions/not-ready/chat", bytes.NewBufferString(`{}`)))
 	if response.Code != http.StatusConflict {
 		t.Fatalf("chat status = %d, want %d", response.Code, http.StatusConflict)
+	}
+}
+
+func TestHarnessSessionAPI_PatchLifecycleOnly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	session := &sympoziumv1alpha1.HarnessSession{ObjectMeta: metav1.ObjectMeta{Name: "analyst", Namespace: "team-a"}, Spec: sympoziumv1alpha1.HarnessSessionSpec{AgentRef: "agent", RuntimeRef: "pi", DesiredState: "running"}}
+	server := NewServer(fake.NewClientBuilder().WithScheme(scheme).WithObjects(session).Build(), nil, nil, logr.Discard())
+	response := httptest.NewRecorder()
+	server.Handler(nil).ServeHTTP(response, httptest.NewRequest(http.MethodPatch, "/api/v1/harness-sessions/analyst?namespace=team-a", bytes.NewBufferString(`{"desiredState":"stopped"}`)))
+	if response.Code != http.StatusOK {
+		t.Fatalf("patch status = %d: %s", response.Code, response.Body.String())
+	}
+	var updated sympoziumv1alpha1.HarnessSession
+	if err := server.client.Get(context.Background(), client.ObjectKey{Name: "analyst", Namespace: "team-a"}, &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Spec.DesiredState != "stopped" {
+		t.Fatalf("desiredState = %q, want stopped", updated.Spec.DesiredState)
 	}
 }

--- a/web/src/components/harness-session-dialog.tsx
+++ b/web/src/components/harness-session-dialog.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
-import { Bot, Loader2, Send } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Bot, Loader2, Pause, Send, TriangleAlert } from "lucide-react";
 import type { Agent, AgentRuntime, HarnessSession } from "@/lib/api";
-import { useCreateHarnessSession, useHarnessSessionChat } from "@/hooks/use-api";
+import { getNamespace } from "@/lib/api";
+import { useCreateHarnessSession, useHarnessSessionChat, useSetHarnessSessionState } from "@/hooks/use-api";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -9,6 +10,26 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 
 type TranscriptTurn = { role: "user" | "assistant"; content: string };
+
+function transcriptStorageKey(session: HarnessSession) {
+  return `sympozium.harness-session.transcript.${getNamespace()}.${session.metadata.name}`;
+}
+
+function loadTranscript(session: HarnessSession): TranscriptTurn[] {
+  try {
+    const value = localStorage.getItem(transcriptStorageKey(session));
+    if (!value) return [];
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((turn): turn is TranscriptTurn =>
+      !!turn && typeof turn === "object" &&
+      ((turn as TranscriptTurn).role === "user" || (turn as TranscriptTurn).role === "assistant") &&
+      typeof (turn as TranscriptTurn).content === "string",
+    ).slice(-200);
+  } catch {
+    return [];
+  }
+}
 
 export function StartHarnessSessionDialog({ open, onOpenChange, runtime, agents }: { open: boolean; onOpenChange: (open: boolean) => void; runtime: AgentRuntime; agents: Agent[] }) {
   const create = useCreateHarnessSession();
@@ -33,16 +54,37 @@ export function StartHarnessSessionDialog({ open, onOpenChange, runtime, agents 
 
 export function HarnessSessionChatDialog({ session, open, onOpenChange }: { session: HarnessSession; open: boolean; onOpenChange: (open: boolean) => void }) {
   const chat = useHarnessSessionChat();
+  const setSessionState = useSetHarnessSessionState();
   const [message, setMessage] = useState("");
-  const [turns, setTurns] = useState<TranscriptTurn[]>([]);
+  const [turns, setTurns] = useState<TranscriptTurn[]>(() => loadTranscript(session));
+  const [failedMessage, setFailedMessage] = useState<string | null>(null);
+  const transcriptKey = useMemo(() => transcriptStorageKey(session), [session.metadata.name]);
+  const transcriptRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setTurns(loadTranscript(session));
+    setFailedMessage(null);
+  }, [session.metadata.name]);
+
+  useEffect(() => {
+    try { localStorage.setItem(transcriptKey, JSON.stringify(turns.slice(-200))); } catch { /* Browser storage is an enhancement, never a chat failure. */ }
+    transcriptRef.current?.scrollTo({ top: transcriptRef.current.scrollHeight, behavior: "smooth" });
+  }, [transcriptKey, turns]);
+
   function send() {
     const content = message.trim(); if (!content || chat.isPending) return;
-    setMessage(""); setTurns((current) => [...current, { role: "user", content }]);
-    chat.mutate({ name: session.metadata.name, message: content }, { onSuccess: (response) => setTurns((current) => [...current, { role: "assistant", content: response.choices?.[0]?.message?.content || response.error?.message || "The harness returned no message." }]) });
+    setMessage(""); setFailedMessage(null); setTurns((current) => [...current, { role: "user", content }]);
+    chat.mutate({ name: session.metadata.name, message: content }, {
+      onSuccess: (response) => setTurns((current) => [...current, { role: "assistant", content: response.choices?.[0]?.message?.content || response.error?.message || "The harness returned no message." }]),
+      onError: () => setFailedMessage(content),
+    });
   }
+  const ready = session.status?.phase === "Ready";
   return <Dialog open={open} onOpenChange={onOpenChange}><DialogContent className="max-w-2xl">
-    <DialogHeader><DialogTitle className="flex items-center gap-2"><Bot className="h-5 w-5" />{session.metadata.name}</DialogTitle><DialogDescription>Persistent {session.spec.runtimeRef} session for Agent {session.spec.agentRef}. The transcript shown here is browser-local; the adapter owns its session state.</DialogDescription></DialogHeader>
-    <div className="max-h-80 min-h-40 space-y-3 overflow-y-auto border bg-muted/30 p-3 text-sm">{turns.length === 0 ? <p className="text-muted-foreground">Ask the harness a question to begin.</p> : turns.map((turn, index) => <div key={index} className={turn.role === "user" ? "ml-8" : "mr-8"}><p className="mb-1 text-xs text-muted-foreground">{turn.role === "user" ? "You" : "Harness"}</p><p className="whitespace-pre-wrap rounded bg-background p-2">{turn.content}</p></div>)}</div>
-    <div className="flex gap-2"><Textarea value={message} onChange={(event) => setMessage(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); send(); } }} placeholder="Ask a question…" /><Button onClick={send} disabled={!message.trim() || chat.isPending}>{chat.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</Button></div>
+    <DialogHeader><DialogTitle className="flex items-center gap-2"><Bot className="h-5 w-5" />{session.metadata.name}</DialogTitle><DialogDescription>Persistent {session.spec.runtimeRef} session for Agent {session.spec.agentRef}. Conversation context stays in the private harness; this device retains the visible transcript across refreshes.</DialogDescription></DialogHeader>
+    <div className="flex items-center justify-between rounded border px-3 py-2 text-xs"><span className={ready ? "text-emerald-500" : "text-amber-500"}>{ready ? "● Connected" : `● ${session.status?.phase || "Starting"}`}</span><Button variant="ghost" size="sm" onClick={() => setSessionState.mutate({ name: session.metadata.name, desiredState: "stopped" })} disabled={!ready || setSessionState.isPending}><Pause className="mr-1 h-3.5 w-3.5" />Stop session</Button></div>
+    <div ref={transcriptRef} className="max-h-80 min-h-40 space-y-3 overflow-y-auto border bg-muted/30 p-3 text-sm">{turns.length === 0 ? <p className="text-muted-foreground">Ask the harness a question to begin.</p> : turns.map((turn, index) => <div key={index} className={turn.role === "user" ? "ml-8" : "mr-8"}><p className="mb-1 text-xs text-muted-foreground">{turn.role === "user" ? "You" : "Harness"}</p><p className="whitespace-pre-wrap rounded bg-background p-2">{turn.content}</p></div>)}</div>
+    {failedMessage && <div className="flex items-center justify-between rounded border border-destructive/50 bg-destructive/5 p-2 text-sm"><span className="flex items-center gap-2"><TriangleAlert className="h-4 w-4 text-destructive" />Message was not delivered.</span><Button variant="outline" size="sm" onClick={() => { setMessage(failedMessage); setFailedMessage(null); }}>Retry</Button></div>}
+    <div className="flex gap-2"><Textarea value={message} onChange={(event) => setMessage(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); send(); } }} placeholder={ready ? "Ask a question…" : "Waiting for the persistent session…"} disabled={!ready} /><Button onClick={send} disabled={!ready || !message.trim() || chat.isPending}>{chat.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</Button></div>
   </DialogContent></Dialog>;
 }

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -105,6 +105,18 @@ export function useDeleteHarnessSession() {
   });
 }
 
+export function useSetHarnessSessionState() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ name, desiredState }: { name: string; desiredState: "running" | "stopped" }) => api.harnessSessions.setDesiredState(name, desiredState),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ["harness-sessions"] });
+      toast.success(variables.desiredState === "running" ? "Persistent chat is starting" : "Persistent chat stopped");
+    },
+    onError: toastError,
+  });
+}
+
 export function useHarnessSessionChat() {
   return useMutation({ mutationFn: ({ name, message }: { name: string; message: string }) => api.harnessSessions.chat(name, message), onError: toastError });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1336,6 +1336,8 @@ export const api = {
     list: () => apiFetch<HarnessSession[]>("/api/v1/harness-sessions"),
     create: (data: { name: string; agentRef: string; runtimeRef: string; idleTimeout?: string }) =>
       apiFetch<HarnessSession>("/api/v1/harness-sessions", { method: "POST", body: JSON.stringify(data) }),
+    setDesiredState: (name: string, desiredState: "running" | "stopped") =>
+      apiFetch<HarnessSession>(`/api/v1/harness-sessions/${name}`, { method: "PATCH", body: JSON.stringify({ desiredState }) }),
     delete: (name: string) => apiFetch<void>(`/api/v1/harness-sessions/${name}`, { method: "DELETE" }),
     chat: (name: string, message: string) => apiFetch<HarnessSessionChatResponse>(`/api/v1/harness-sessions/${name}/chat`, {
       method: "POST", body: JSON.stringify({ messages: [{ role: "user", content: message }] }),

--- a/web/src/pages/agent-detail.tsx
+++ b/web/src/pages/agent-detail.tsx
@@ -6,6 +6,7 @@ import {
   usePatchAgent,
 	useCreateHarnessSession,
 	useHarnessSessions,
+	useSetHarnessSessionState,
   useRuntimes,
   useRuns,
 } from "@/hooks/use-api";
@@ -93,6 +94,7 @@ export function AgentDetailPage() {
   const { data: runtimes } = useRuntimes();
   const { data: harnessSessions } = useHarnessSessions();
   const createHarnessSession = useCreateHarnessSession();
+  const setHarnessSessionState = useSetHarnessSessionState();
   const [chatOpen, setChatOpen] = useState(false);
   const { data: allRuns } = useRuns();
   const { isUnseen } = useRunsSeen();
@@ -246,7 +248,7 @@ export function AgentDetailPage() {
             <CardHeader><CardTitle className="flex items-center gap-2 text-base"><MessageSquare className="h-4 w-4" />Persistent chat</CardTitle></CardHeader>
             <CardContent className="space-y-4 text-sm">
               <p className="text-muted-foreground">This Agent’s harness is a durable conversation pod. Chat turns stay in that harness; use the Runs tab only for explicit one-shot or workflow executions.</p>
-              {!chatSession ? <Button onClick={startChat} disabled={createHarnessSession.isPending}>{createHarnessSession.isPending ? "Starting chat…" : "Start chat"}</Button> : chatSession.status?.phase === "Ready" ? <div className="flex items-center justify-between rounded border p-3"><div><p className="font-mono text-xs">{chatSession.metadata.name}</p><p className="text-xs text-muted-foreground">Ready · persistent {selectedRuntime.metadata.name} session</p></div><Button onClick={() => setChatOpen(true)}><MessageSquare className="mr-2 h-4 w-4" />Open chat</Button></div> : <div className="rounded border p-3 text-muted-foreground">Starting persistent chat session… <span className="font-mono">{chatSession.status?.phase || "Pending"}</span></div>}
+              {!chatSession ? <Button onClick={startChat} disabled={createHarnessSession.isPending}>{createHarnessSession.isPending ? "Starting chat…" : "Start chat"}</Button> : chatSession.status?.phase === "Ready" ? <div className="flex items-center justify-between rounded border p-3"><div><p className="font-mono text-xs">{chatSession.metadata.name}</p><p className="text-xs text-muted-foreground">Ready · durable {selectedRuntime.metadata.name} conversation</p></div><div className="flex gap-2"><Button variant="outline" onClick={() => setHarnessSessionState.mutate({ name: chatSession.metadata.name, desiredState: "stopped" })} disabled={setHarnessSessionState.isPending}>Stop</Button><Button onClick={() => setChatOpen(true)}><MessageSquare className="mr-2 h-4 w-4" />Open chat</Button></div></div> : chatSession.spec.desiredState === "stopped" || chatSession.status?.phase === "Draining" ? <div className="flex items-center justify-between rounded border p-3"><div><p className="font-mono text-xs">{chatSession.metadata.name}</p><p className="text-xs text-muted-foreground">Chat is stopped. Resume it when you want to continue.</p></div><Button onClick={() => setHarnessSessionState.mutate({ name: chatSession.metadata.name, desiredState: "running" })} disabled={setHarnessSessionState.isPending}>Resume chat</Button></div> : <div className="rounded border p-3 text-muted-foreground">Starting persistent chat session… <span className="font-mono">{chatSession.status?.phase || "Pending"}</span></div>}
             </CardContent>
           </Card>
         </TabsContent>}

--- a/web/src/pages/agents.tsx
+++ b/web/src/pages/agents.tsx
@@ -26,7 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Plus, Trash2, ExternalLink, ShieldAlert } from "lucide-react";
+import { Plus, Trash2, ExternalLink, ShieldAlert, MessageSquare } from "lucide-react";
 import { formatAge } from "@/lib/utils";
 
 export function AgentsPage() {
@@ -257,7 +257,12 @@ export function AgentsPage() {
                 <TableCell className="text-sm text-muted-foreground">
                   {formatAge(inst.metadata.creationTimestamp)}
                 </TableCell>
-                <TableCell>
+                <TableCell><div className="flex items-center gap-1">
+                  {(() => {
+                    const runtime = runtimes?.find((candidate) => candidate.metadata.name === inst.spec.runtimeRef);
+                    const persistent = runtime?.spec.contractVersion === "v1alpha2" && runtime.spec.session?.protocol === "openai-chat";
+                    return persistent ? <Button asChild variant="ghost" size="icon" title="Open persistent chat"><Link to={`/agents/${inst.metadata.name}?tab=chat`}><MessageSquare className="h-4 w-4" /></Link></Button> : null;
+                  })()}
                   <Button
                     variant="ghost"
                     size="icon"
@@ -267,7 +272,7 @@ export function AgentsPage() {
                   >
                     <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
-                </TableCell>
+                </div></TableCell>
               </TableRow>
             ))}
           </TableBody>


### PR DESCRIPTION
## Summary
- retain a bounded visible transcript per persistent HarnessSession in the browser across refreshes
- add connected/starting state, delivery retry, direct Agent-list Chat access, and stop/resume lifecycle controls
- add a lifecycle-only HarnessSession PATCH API; Agent/runtime bindings remain immutable

The harness remains the owner of conversation context. Message content is intentionally not written into CR status or ConfigMaps. AgentRuns are unchanged.

## Validation
- `go test ./internal/apiserver ./internal/controller`
- `cd web && npm run build`