### PR TITLE
docs: explain persistent AgentHarness chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@
 ---
 
 > [!IMPORTANT]
-> **AgentHarness support is landing now.** Run an administrator-approved external
-> agent adapter inside a normal Sympozium AgentRun while keeping Kubernetes
-> policy, per-run identity, skills, memory, MCP, observability, and audit under
-> platform control. Start with the [AgentHarness guide](https://deploy.sympozium.ai/docs/guides/agentharness/)
+> **AgentHarness is available experimentally.** Run an administrator-approved
+> external adapter in an isolated AgentRun, or choose a session-capable runtime
+> for a private, continuing **Agent → Chat** conversation. Kubernetes policy,
+> identity, skills, memory, MCP, observability, and audit remain under platform
+> control. Start with the [AgentHarness guide](https://deploy.sympozium.ai/docs/guides/agentharness/)
 > and the digest-pinned [reference adapter](examples/harness-reference/). This
 > is an adapter boundary—not permission to run arbitrary upstream images.
 

--- a/docs/design/persistent-harness-sessions.md
+++ b/docs/design/persistent-harness-sessions.md
@@ -26,8 +26,9 @@ spec:
 
 The controller resolves and records the immutable runtime digest once, creates
 a Deployment and ClusterIP Service, and reports `Pending`, `Ready`, `Draining`,
-or `Failed`. Deletion, an explicit `desiredState: stopped`, and idle expiry
-remove the workload and its per-session identity.
+or `Failed`. Deletion and an explicit `desiredState: stopped` remove the
+workload. `idleTimeout` is reserved until API activity reporting is available;
+it must not silently stop a session before then.
 
 The API/UI talks to the Session through a Sympozium-owned proxy. It does not
 expose pod exec, a ServiceAccount token, or direct NATS access to a browser.
@@ -50,8 +51,8 @@ substitute for a session.
 ## Security invariants
 
 - The Agent remains the sole authority for provider credential allowlisting.
-- Every session gets a unique ServiceAccount with `automountServiceAccountToken:
-  false`; trusted sidecars receive only the projected tokens they need.
+- Session pods set `automountServiceAccountToken: false`; the adapter receives
+  no Kubernetes API token.
 - The runtime image stays digest-pinned and policy-approved, and the resolved
   digest is recorded in status.
 - Harness containers retain narrowed mounts and cannot publish directly to

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,6 +180,10 @@ The web dashboard provides a graphical interface for **all** Sympozium actions:
 - **Dashboard** — cluster overview with instance counts, run stats, and recent activity
 - **Instances** — list, create, and delete Agents
 - **Runs** — view all AgentRuns, inspect logs, create new runs
+- **Agents → Chat** — start or resume a persistent private conversation when
+  the Agent has a session-capable AgentHarness runtime
+- **Harnesses** — inspect administrator-approved harness runtimes and advanced
+  session state
 - **Policies** — browse SympoziumPolicy rules
 - **Skills** — explore installed SkillPacks
 - **Schedules** — list and manage SympoziumSchedules

--- a/docs/guides/agentharness-ux.md
+++ b/docs/guides/agentharness-ux.md
@@ -18,6 +18,39 @@ The harness is only the process that drives the agent loop. An AgentRun is
 still the unit of execution, lifecycle, scheduling, access control, result,
 and audit. Choosing no harness preserves the built-in `agent-runner` path.
 
+## Choose the right interaction
+
+AgentHarness deliberately has two execution experiences. They are complementary
+and must not be blended in the UI.
+
+| Need | Use | What happens |
+|---|---|---|
+| A normal, continuing conversation | **Agent → Chat** with a session-capable runtime | Sympozium creates or resumes one private `HarnessSession` Deployment. The harness owns live conversation context. |
+| A bounded task, automation, schedule, or auditable batch outcome | **AgentRun** | Sympozium creates an isolated Job, injects the normal run inputs/memory, records a terminal result, then the pod exits. |
+
+For a persistent-capable Agent, **Chat** is the primary affordance. Selecting a
+runtime does not silently consume a pod forever: the first **Start chat**
+action creates the durable session, and subsequent visits resume it. The
+**Harnesses** page remains an operator inventory and an advanced way to manage
+additional sessions; it is not the required first click for ordinary chat.
+
+The chat panel makes lifecycle visible:
+
+- **Connected** — the controller has marked the private session ready and the
+  API proxy can deliver a turn.
+- **Starting** — the controller is creating or resuming the Deployment; input
+  remains disabled until it is ready.
+- **Stop session** — removes the private workload without deleting its
+  `HarnessSession` audit record.
+- **Resume chat** — requests the same approved runtime and Agent binding again.
+
+The browser retains the latest 200 visible turns per namespace/session, so a
+refresh does not look like a new conversation. This is a presentation aid on
+that device, not platform memory: the private adapter owns live context and a
+pod restart can lose it. Sympozium intentionally does not write message bodies
+to CRDs or ConfigMaps. Cross-device/history retention needs a separately
+designed, access-controlled transcript store.
+
 ## The three decisions
 
 ### 1. Approve a runtime (platform operator)
@@ -211,6 +244,11 @@ decisions without knowing Kubernetes internals:
 - [x] Choose an approved one-run override from New Run.
 - [x] Leave the selector at a safe, compatibility-preserving default.
 - [x] Inspect the resolved runtime and executed digest on Run detail.
+- [x] Start or resume a private persistent chat from a session-capable Agent.
+- [x] Display persistent-session connection state and provide stop/resume
+  controls without turning it into an AgentRun.
+- [x] Retain a bounded visible transcript on the current browser/device without
+  copying message content into Kubernetes objects.
 - [ ] See runtime readiness and policy eligibility before submitting.
 - [ ] Distinguish requested routing, platform enforcement, and adapter claims.
 - [ ] See accounting state and the reason an unmetered exception was allowed.

--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -53,18 +53,28 @@ spec:
   desiredState: running
 ```
 
-In the UI, open **Agents → Harnesses**, select a session-capable runtime, then
-choose **Start interactive session**. Select the Agent whose credential
-allowlist should apply and give the session a name. Once its phase is `Ready`,
-choose **Open** to use the proxied chat panel. **Stop** deletes the private
-workload while retaining no browser-to-pod connection.
+For a person using the Agent, the primary route is **Agents → _your Agent_ →
+Chat**. If its selected runtime supports persistent chat, **Start chat** creates
+one deterministic session for that Agent; when it reaches `Ready`, **Open chat**
+resumes the private conversation. The **Harnesses** page is the operator-facing
+inventory for inspecting approved runtimes and managing additional sessions,
+not the normal way to begin a conversation.
+
+The Chat panel reports whether the session is connected, starting, or stopped.
+Stopping removes the private workload while preserving the `HarnessSession`
+record; **Resume chat** starts a new private workload using the same approved
+runtime and Agent credential allowlist. The visible transcript is retained on
+the current browser/device (bounded to the latest 200 turns) so a refresh does
+not make the conversation appear empty. It is deliberately **not** copied into
+CR status, ConfigMaps, or the browser-to-pod API.
 
 The first reference adapter is Pi's experimental `v1alpha2` mode. It keeps
-Pi's own conversation file inside the session pod and serializes turns; it
+Pi's own conversation state inside the session pod and serializes turns; it
 continues to disable tools, skills, and prompt templates. If the pod restarts,
-its ephemeral adapter conversation state is lost. Treat a session as a
-bounded interactive workspace, not durable Agent memory or a general exposed
-OpenAI gateway.
+its ephemeral adapter conversation state is lost even though this browser can
+still display the previous local transcript. Treat a session as a bounded
+interactive workspace, not durable Agent memory or a general exposed OpenAI
+gateway.
 
 For operators, the trust boundary is unchanged:
 

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -148,6 +148,7 @@ func (s *Server) buildMux(frontendFS fs.FS, expected *tokenReader) http.Handler 
 	// route to a session's private in-cluster Service.
 	mux.HandleFunc("GET /api/v1/harness-sessions", s.listHarnessSessions)
 	mux.HandleFunc("POST /api/v1/harness-sessions", s.createHarnessSession)
+	mux.HandleFunc("PATCH /api/v1/harness-sessions/{name}", s.patchHarnessSession)
 	mux.HandleFunc("DELETE /api/v1/harness-sessions/{name}", s.deleteHarnessSession)
 	mux.HandleFunc("POST /api/v1/harness-sessions/{name}/chat", s.chatHarnessSession)
 

--- a/internal/apiserver/server_harnesssession.go
+++ b/internal/apiserver/server_harnesssession.go
@@ -34,6 +34,13 @@ type CreateHarnessSessionRequest struct {
 	IdleTimeout string `json:"idleTimeout,omitempty"`
 }
 
+// PatchHarnessSessionRequest intentionally exposes only lifecycle control. The
+// Agent and runtime binding are immutable for a session: changing either would
+// make the recorded adapter provenance misleading.
+type PatchHarnessSessionRequest struct {
+	DesiredState string `json:"desiredState"`
+}
+
 func requestNamespace(r *http.Request) string {
 	if ns := r.URL.Query().Get("namespace"); ns != "" {
 		return ns
@@ -78,6 +85,34 @@ func (s *Server) createHarnessSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, session)
+}
+
+func (s *Server) patchHarnessSession(w http.ResponseWriter, r *http.Request) {
+	var request PatchHarnessSessionRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4*1024)).Decode(&request); err != nil {
+		http.Error(w, "invalid session patch: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if request.DesiredState != "running" && request.DesiredState != "stopped" {
+		http.Error(w, "desiredState must be running or stopped", http.StatusBadRequest)
+		return
+	}
+	session := &sympoziumv1alpha1.HarnessSession{}
+	key := types.NamespacedName{Name: r.PathValue("name"), Namespace: requestNamespace(r)}
+	if err := s.client.Get(r.Context(), key, session); err != nil {
+		if k8serrors.IsNotFound(err) {
+			http.Error(w, "HarnessSession not found", http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	session.Spec.DesiredState = request.DesiredState
+	if err := s.client.Update(r.Context(), session); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	writeJSON(w, session)
 }
 

--- a/internal/apiserver/server_harnesssession_test.go
+++ b/internal/apiserver/server_harnesssession_test.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
@@ -53,5 +55,29 @@ func TestHarnessSessionAPI_ChatRequiresReadyControllerOwnedService(t *testing.T)
 	server.Handler(nil).ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/api/v1/harness-sessions/not-ready/chat", bytes.NewBufferString(`{}`)))
 	if response.Code != http.StatusConflict {
 		t.Fatalf("chat status = %d, want %d", response.Code, http.StatusConflict)
+	}
+}
+
+func TestHarnessSessionAPI_PatchLifecycleOnly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	session := &sympoziumv1alpha1.HarnessSession{ObjectMeta: metav1.ObjectMeta{Name: "analyst", Namespace: "team-a"}, Spec: sympoziumv1alpha1.HarnessSessionSpec{AgentRef: "agent", RuntimeRef: "pi", DesiredState: "running"}}
+	server := NewServer(fake.NewClientBuilder().WithScheme(scheme).WithObjects(session).Build(), nil, nil, logr.Discard())
+	response := httptest.NewRecorder()
+	server.Handler(nil).ServeHTTP(response, httptest.NewRequest(http.MethodPatch, "/api/v1/harness-sessions/analyst?namespace=team-a", bytes.NewBufferString(`{"desiredState":"stopped"}`)))
+	if response.Code != http.StatusOK {
+		t.Fatalf("patch status = %d: %s", response.Code, response.Body.String())
+	}
+	var updated sympoziumv1alpha1.HarnessSession
+	if err := server.client.Get(context.Background(), client.ObjectKey{Name: "analyst", Namespace: "team-a"}, &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Spec.DesiredState != "stopped" {
+		t.Fatalf("desiredState = %q, want stopped", updated.Spec.DesiredState)
 	}
 }

--- a/web/src/components/harness-session-dialog.tsx
+++ b/web/src/components/harness-session-dialog.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
-import { Bot, Loader2, Send } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Bot, Loader2, Pause, Send, TriangleAlert } from "lucide-react";
 import type { Agent, AgentRuntime, HarnessSession } from "@/lib/api";
-import { useCreateHarnessSession, useHarnessSessionChat } from "@/hooks/use-api";
+import { getNamespace } from "@/lib/api";
+import { useCreateHarnessSession, useHarnessSessionChat, useSetHarnessSessionState } from "@/hooks/use-api";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -9,6 +10,26 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 
 type TranscriptTurn = { role: "user" | "assistant"; content: string };
+
+function transcriptStorageKey(session: HarnessSession) {
+  return `sympozium.harness-session.transcript.${getNamespace()}.${session.metadata.name}`;
+}
+
+function loadTranscript(session: HarnessSession): TranscriptTurn[] {
+  try {
+    const value = localStorage.getItem(transcriptStorageKey(session));
+    if (!value) return [];
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((turn): turn is TranscriptTurn =>
+      !!turn && typeof turn === "object" &&
+      ((turn as TranscriptTurn).role === "user" || (turn as TranscriptTurn).role === "assistant") &&
+      typeof (turn as TranscriptTurn).content === "string",
+    ).slice(-200);
+  } catch {
+    return [];
+  }
+}
 
 export function StartHarnessSessionDialog({ open, onOpenChange, runtime, agents }: { open: boolean; onOpenChange: (open: boolean) => void; runtime: AgentRuntime; agents: Agent[] }) {
   const create = useCreateHarnessSession();
@@ -33,16 +54,37 @@ export function StartHarnessSessionDialog({ open, onOpenChange, runtime, agents 
 
 export function HarnessSessionChatDialog({ session, open, onOpenChange }: { session: HarnessSession; open: boolean; onOpenChange: (open: boolean) => void }) {
   const chat = useHarnessSessionChat();
+  const setSessionState = useSetHarnessSessionState();
   const [message, setMessage] = useState("");
-  const [turns, setTurns] = useState<TranscriptTurn[]>([]);
+  const [turns, setTurns] = useState<TranscriptTurn[]>(() => loadTranscript(session));
+  const [failedMessage, setFailedMessage] = useState<string | null>(null);
+  const transcriptKey = useMemo(() => transcriptStorageKey(session), [session.metadata.name]);
+  const transcriptRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setTurns(loadTranscript(session));
+    setFailedMessage(null);
+  }, [session.metadata.name]);
+
+  useEffect(() => {
+    try { localStorage.setItem(transcriptKey, JSON.stringify(turns.slice(-200))); } catch { /* Browser storage is an enhancement, never a chat failure. */ }
+    transcriptRef.current?.scrollTo({ top: transcriptRef.current.scrollHeight, behavior: "smooth" });
+  }, [transcriptKey, turns]);
+
   function send() {
     const content = message.trim(); if (!content || chat.isPending) return;
-    setMessage(""); setTurns((current) => [...current, { role: "user", content }]);
-    chat.mutate({ name: session.metadata.name, message: content }, { onSuccess: (response) => setTurns((current) => [...current, { role: "assistant", content: response.choices?.[0]?.message?.content || response.error?.message || "The harness returned no message." }]) });
+    setMessage(""); setFailedMessage(null); setTurns((current) => [...current, { role: "user", content }]);
+    chat.mutate({ name: session.metadata.name, message: content }, {
+      onSuccess: (response) => setTurns((current) => [...current, { role: "assistant", content: response.choices?.[0]?.message?.content || response.error?.message || "The harness returned no message." }]),
+      onError: () => setFailedMessage(content),
+    });
   }
+  const ready = session.status?.phase === "Ready";
   return <Dialog open={open} onOpenChange={onOpenChange}><DialogContent className="max-w-2xl">
-    <DialogHeader><DialogTitle className="flex items-center gap-2"><Bot className="h-5 w-5" />{session.metadata.name}</DialogTitle><DialogDescription>Persistent {session.spec.runtimeRef} session for Agent {session.spec.agentRef}. The transcript shown here is browser-local; the adapter owns its session state.</DialogDescription></DialogHeader>
-    <div className="max-h-80 min-h-40 space-y-3 overflow-y-auto border bg-muted/30 p-3 text-sm">{turns.length === 0 ? <p className="text-muted-foreground">Ask the harness a question to begin.</p> : turns.map((turn, index) => <div key={index} className={turn.role === "user" ? "ml-8" : "mr-8"}><p className="mb-1 text-xs text-muted-foreground">{turn.role === "user" ? "You" : "Harness"}</p><p className="whitespace-pre-wrap rounded bg-background p-2">{turn.content}</p></div>)}</div>
-    <div className="flex gap-2"><Textarea value={message} onChange={(event) => setMessage(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); send(); } }} placeholder="Ask a question…" /><Button onClick={send} disabled={!message.trim() || chat.isPending}>{chat.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</Button></div>
+    <DialogHeader><DialogTitle className="flex items-center gap-2"><Bot className="h-5 w-5" />{session.metadata.name}</DialogTitle><DialogDescription>Persistent {session.spec.runtimeRef} session for Agent {session.spec.agentRef}. Conversation context stays in the private harness; this device retains the visible transcript across refreshes.</DialogDescription></DialogHeader>
+    <div className="flex items-center justify-between rounded border px-3 py-2 text-xs"><span className={ready ? "text-emerald-500" : "text-amber-500"}>{ready ? "● Connected" : `● ${session.status?.phase || "Starting"}`}</span><Button variant="ghost" size="sm" onClick={() => setSessionState.mutate({ name: session.metadata.name, desiredState: "stopped" })} disabled={!ready || setSessionState.isPending}><Pause className="mr-1 h-3.5 w-3.5" />Stop session</Button></div>
+    <div ref={transcriptRef} className="max-h-80 min-h-40 space-y-3 overflow-y-auto border bg-muted/30 p-3 text-sm">{turns.length === 0 ? <p className="text-muted-foreground">Ask the harness a question to begin.</p> : turns.map((turn, index) => <div key={index} className={turn.role === "user" ? "ml-8" : "mr-8"}><p className="mb-1 text-xs text-muted-foreground">{turn.role === "user" ? "You" : "Harness"}</p><p className="whitespace-pre-wrap rounded bg-background p-2">{turn.content}</p></div>)}</div>
+    {failedMessage && <div className="flex items-center justify-between rounded border border-destructive/50 bg-destructive/5 p-2 text-sm"><span className="flex items-center gap-2"><TriangleAlert className="h-4 w-4 text-destructive" />Message was not delivered.</span><Button variant="outline" size="sm" onClick={() => { setMessage(failedMessage); setFailedMessage(null); }}>Retry</Button></div>}
+    <div className="flex gap-2"><Textarea value={message} onChange={(event) => setMessage(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); send(); } }} placeholder={ready ? "Ask a question…" : "Waiting for the persistent session…"} disabled={!ready} /><Button onClick={send} disabled={!ready || !message.trim() || chat.isPending}>{chat.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</Button></div>
   </DialogContent></Dialog>;
 }

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -105,6 +105,18 @@ export function useDeleteHarnessSession() {
   });
 }
 
+export function useSetHarnessSessionState() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ name, desiredState }: { name: string; desiredState: "running" | "stopped" }) => api.harnessSessions.setDesiredState(name, desiredState),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ["harness-sessions"] });
+      toast.success(variables.desiredState === "running" ? "Persistent chat is starting" : "Persistent chat stopped");
+    },
+    onError: toastError,
+  });
+}
+
 export function useHarnessSessionChat() {
   return useMutation({ mutationFn: ({ name, message }: { name: string; message: string }) => api.harnessSessions.chat(name, message), onError: toastError });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1336,6 +1336,8 @@ export const api = {
     list: () => apiFetch<HarnessSession[]>("/api/v1/harness-sessions"),
     create: (data: { name: string; agentRef: string; runtimeRef: string; idleTimeout?: string }) =>
       apiFetch<HarnessSession>("/api/v1/harness-sessions", { method: "POST", body: JSON.stringify(data) }),
+    setDesiredState: (name: string, desiredState: "running" | "stopped") =>
+      apiFetch<HarnessSession>(`/api/v1/harness-sessions/${name}`, { method: "PATCH", body: JSON.stringify({ desiredState }) }),
     delete: (name: string) => apiFetch<void>(`/api/v1/harness-sessions/${name}`, { method: "DELETE" }),
     chat: (name: string, message: string) => apiFetch<HarnessSessionChatResponse>(`/api/v1/harness-sessions/${name}/chat`, {
       method: "POST", body: JSON.stringify({ messages: [{ role: "user", content: message }] }),

--- a/web/src/pages/agent-detail.tsx
+++ b/web/src/pages/agent-detail.tsx
@@ -6,6 +6,7 @@ import {
   usePatchAgent,
 	useCreateHarnessSession,
 	useHarnessSessions,
+	useSetHarnessSessionState,
   useRuntimes,
   useRuns,
 } from "@/hooks/use-api";
@@ -93,6 +94,7 @@ export function AgentDetailPage() {
   const { data: runtimes } = useRuntimes();
   const { data: harnessSessions } = useHarnessSessions();
   const createHarnessSession = useCreateHarnessSession();
+  const setHarnessSessionState = useSetHarnessSessionState();
   const [chatOpen, setChatOpen] = useState(false);
   const { data: allRuns } = useRuns();
   const { isUnseen } = useRunsSeen();
@@ -246,7 +248,7 @@ export function AgentDetailPage() {
             <CardHeader><CardTitle className="flex items-center gap-2 text-base"><MessageSquare className="h-4 w-4" />Persistent chat</CardTitle></CardHeader>
             <CardContent className="space-y-4 text-sm">
               <p className="text-muted-foreground">This Agent’s harness is a durable conversation pod. Chat turns stay in that harness; use the Runs tab only for explicit one-shot or workflow executions.</p>
-              {!chatSession ? <Button onClick={startChat} disabled={createHarnessSession.isPending}>{createHarnessSession.isPending ? "Starting chat…" : "Start chat"}</Button> : chatSession.status?.phase === "Ready" ? <div className="flex items-center justify-between rounded border p-3"><div><p className="font-mono text-xs">{chatSession.metadata.name}</p><p className="text-xs text-muted-foreground">Ready · persistent {selectedRuntime.metadata.name} session</p></div><Button onClick={() => setChatOpen(true)}><MessageSquare className="mr-2 h-4 w-4" />Open chat</Button></div> : <div className="rounded border p-3 text-muted-foreground">Starting persistent chat session… <span className="font-mono">{chatSession.status?.phase || "Pending"}</span></div>}
+              {!chatSession ? <Button onClick={startChat} disabled={createHarnessSession.isPending}>{createHarnessSession.isPending ? "Starting chat…" : "Start chat"}</Button> : chatSession.status?.phase === "Ready" ? <div className="flex items-center justify-between rounded border p-3"><div><p className="font-mono text-xs">{chatSession.metadata.name}</p><p className="text-xs text-muted-foreground">Ready · durable {selectedRuntime.metadata.name} conversation</p></div><div className="flex gap-2"><Button variant="outline" onClick={() => setHarnessSessionState.mutate({ name: chatSession.metadata.name, desiredState: "stopped" })} disabled={setHarnessSessionState.isPending}>Stop</Button><Button onClick={() => setChatOpen(true)}><MessageSquare className="mr-2 h-4 w-4" />Open chat</Button></div></div> : chatSession.spec.desiredState === "stopped" || chatSession.status?.phase === "Draining" ? <div className="flex items-center justify-between rounded border p-3"><div><p className="font-mono text-xs">{chatSession.metadata.name}</p><p className="text-xs text-muted-foreground">Chat is stopped. Resume it when you want to continue.</p></div><Button onClick={() => setHarnessSessionState.mutate({ name: chatSession.metadata.name, desiredState: "running" })} disabled={setHarnessSessionState.isPending}>Resume chat</Button></div> : <div className="rounded border p-3 text-muted-foreground">Starting persistent chat session… <span className="font-mono">{chatSession.status?.phase || "Pending"}</span></div>}
             </CardContent>
           </Card>
         </TabsContent>}

--- a/web/src/pages/agents.tsx
+++ b/web/src/pages/agents.tsx
@@ -26,7 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Plus, Trash2, ExternalLink, ShieldAlert } from "lucide-react";
+import { Plus, Trash2, ExternalLink, ShieldAlert, MessageSquare } from "lucide-react";
 import { formatAge } from "@/lib/utils";
 
 export function AgentsPage() {
@@ -257,7 +257,12 @@ export function AgentsPage() {
                 <TableCell className="text-sm text-muted-foreground">
                   {formatAge(inst.metadata.creationTimestamp)}
                 </TableCell>
-                <TableCell>
+                <TableCell><div className="flex items-center gap-1">
+                  {(() => {
+                    const runtime = runtimes?.find((candidate) => candidate.metadata.name === inst.spec.runtimeRef);
+                    const persistent = runtime?.spec.contractVersion === "v1alpha2" && runtime.spec.session?.protocol === "openai-chat";
+                    return persistent ? <Button asChild variant="ghost" size="icon" title="Open persistent chat"><Link to={`/agents/${inst.metadata.name}?tab=chat`}><MessageSquare className="h-4 w-4" /></Link></Button> : null;
+                  })()}
                   <Button
                     variant="ghost"
                     size="icon"
@@ -267,7 +272,7 @@ export function AgentsPage() {
                   >
                     <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
-                </TableCell>
+                </div></TableCell>
               </TableRow>
             ))}
           </TableBody>


### PR DESCRIPTION
## Summary
- document Agent-first persistent chat versus one-shot AgentRuns
- explain connection, stop/resume, browser-local visible transcript, and session context boundaries
- correct session-start and idle-timeout behavior in design docs
- update the README banner and dashboard guide

This is stacked on #400 because it documents its user-facing behavior.

## Validation
- `git diff --check`
- Docs build runs in CI