### PR TITLE
feat: stream persistent harness chat responses

### DIFF
--- a/internal/apiserver/server_harnesssession.go
+++ b/internal/apiserver/server_harnesssession.go
@@ -41,6 +41,21 @@ type PatchHarnessSessionRequest struct {
 	DesiredState string `json:"desiredState"`
 }
 
+// flushingWriter prevents a buffering proxy from turning adapter SSE into a
+// delayed, completed response. The adapter is still constrained by the same
+// fixed target, timeout, and response-size limit as non-streaming chat.
+type flushingWriter struct {
+	w http.ResponseWriter
+}
+
+func (w flushingWriter) Write(data []byte) (int, error) {
+	n, err := w.w.Write(data)
+	if flusher, ok := w.w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return n, err
+}
+
 func requestNamespace(r *http.Request) string {
 	if ns := r.URL.Query().Get("namespace"); ns != "" {
 		return ns
@@ -178,6 +193,20 @@ func (s *Server) chatHarnessSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer response.Body.Close()
+	if strings.HasPrefix(response.Header.Get("Content-Type"), "text/event-stream") {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(response.StatusCode)
+		written, copyErr := io.Copy(flushingWriter{w}, io.LimitReader(response.Body, 2_000_001))
+		if copyErr != nil {
+			return
+		}
+		if written > 2_000_000 {
+			s.log.Info("harness session stream exceeded response limit", "session", name)
+		}
+		return
+	}
 	responseBody, err := io.ReadAll(io.LimitReader(response.Body, 2_000_001))
 	if err != nil {
 		http.Error(w, "could not read session response", http.StatusBadGateway)

--- a/web/src/components/harness-session-dialog.tsx
+++ b/web/src/components/harness-session-dialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Bot, Loader2, Pause, Send, TriangleAlert } from "lucide-react";
 import type { Agent, AgentRuntime, HarnessSession } from "@/lib/api";
 import { getNamespace } from "@/lib/api";
-import { useCreateHarnessSession, useHarnessSessionChat, useSetHarnessSessionState } from "@/hooks/use-api";
+import { useCreateHarnessSession, useHarnessSessionChatStream, useSetHarnessSessionState } from "@/hooks/use-api";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -53,7 +53,7 @@ export function StartHarnessSessionDialog({ open, onOpenChange, runtime, agents 
 }
 
 export function HarnessSessionChatDialog({ session, open, onOpenChange }: { session: HarnessSession; open: boolean; onOpenChange: (open: boolean) => void }) {
-  const chat = useHarnessSessionChat();
+  const chat = useHarnessSessionChatStream();
   const setSessionState = useSetHarnessSessionState();
   const [message, setMessage] = useState("");
   const [turns, setTurns] = useState<TranscriptTurn[]>(() => loadTranscript(session));
@@ -73,9 +73,11 @@ export function HarnessSessionChatDialog({ session, open, onOpenChange }: { sess
 
   function send() {
     const content = message.trim(); if (!content || chat.isPending) return;
-    setMessage(""); setFailedMessage(null); setTurns((current) => [...current, { role: "user", content }]);
-    chat.mutate({ name: session.metadata.name, message: content }, {
-      onSuccess: (response) => setTurns((current) => [...current, { role: "assistant", content: response.choices?.[0]?.message?.content || response.error?.message || "The harness returned no message." }]),
+    setMessage(""); setFailedMessage(null); setTurns((current) => [...current, { role: "user", content }, { role: "assistant", content: "" }]);
+    chat.mutate({ name: session.metadata.name, message: content, onDelta: (delta) => setTurns((current) => {
+      const last = current[current.length - 1];
+      return last?.role === "assistant" ? [...current.slice(0, -1), { role: "assistant", content: last.content + delta }] : current;
+    }) }, {
       onError: () => setFailedMessage(content),
     });
   }
@@ -83,7 +85,7 @@ export function HarnessSessionChatDialog({ session, open, onOpenChange }: { sess
   return <Dialog open={open} onOpenChange={onOpenChange}><DialogContent className="max-w-2xl">
     <DialogHeader><DialogTitle className="flex items-center gap-2"><Bot className="h-5 w-5" />{session.metadata.name}</DialogTitle><DialogDescription>Persistent {session.spec.runtimeRef} session for Agent {session.spec.agentRef}. Conversation context stays in the private harness; this device retains the visible transcript across refreshes.</DialogDescription></DialogHeader>
     <div className="flex items-center justify-between rounded border px-3 py-2 text-xs"><span className={ready ? "text-emerald-500" : "text-amber-500"}>{ready ? "● Connected" : `● ${session.status?.phase || "Starting"}`}</span><Button variant="ghost" size="sm" onClick={() => setSessionState.mutate({ name: session.metadata.name, desiredState: "stopped" })} disabled={!ready || setSessionState.isPending}><Pause className="mr-1 h-3.5 w-3.5" />Stop session</Button></div>
-    <div ref={transcriptRef} className="max-h-80 min-h-40 space-y-3 overflow-y-auto border bg-muted/30 p-3 text-sm">{turns.length === 0 ? <p className="text-muted-foreground">Ask the harness a question to begin.</p> : turns.map((turn, index) => <div key={index} className={turn.role === "user" ? "ml-8" : "mr-8"}><p className="mb-1 text-xs text-muted-foreground">{turn.role === "user" ? "You" : "Harness"}</p><p className="whitespace-pre-wrap rounded bg-background p-2">{turn.content}</p></div>)}</div>
+    <div ref={transcriptRef} className="max-h-80 min-h-40 space-y-3 overflow-y-auto border bg-muted/30 p-3 text-sm">{turns.length === 0 ? <p className="text-muted-foreground">Ask the harness a question to begin.</p> : turns.map((turn, index) => <div key={index} className={turn.role === "user" ? "ml-8" : "mr-8"}><p className="mb-1 text-xs text-muted-foreground">{turn.role === "user" ? "You" : "Harness"}</p><p className="whitespace-pre-wrap rounded bg-background p-2">{turn.content || (chat.isPending && turn.role === "assistant" ? <Loader2 className="h-4 w-4 animate-spin" /> : "The harness returned no message.")}</p></div>)}</div>
     {failedMessage && <div className="flex items-center justify-between rounded border border-destructive/50 bg-destructive/5 p-2 text-sm"><span className="flex items-center gap-2"><TriangleAlert className="h-4 w-4 text-destructive" />Message was not delivered.</span><Button variant="outline" size="sm" onClick={() => { setMessage(failedMessage); setFailedMessage(null); }}>Retry</Button></div>}
     <div className="flex gap-2"><Textarea value={message} onChange={(event) => setMessage(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); send(); } }} placeholder={ready ? "Ask a question…" : "Waiting for the persistent session…"} disabled={!ready} /><Button onClick={send} disabled={!ready || !message.trim() || chat.isPending}>{chat.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</Button></div>
   </DialogContent></Dialog>;

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -121,6 +121,13 @@ export function useHarnessSessionChat() {
   return useMutation({ mutationFn: ({ name, message }: { name: string; message: string }) => api.harnessSessions.chat(name, message), onError: toastError });
 }
 
+export function useHarnessSessionChatStream() {
+  return useMutation({
+    mutationFn: ({ name, message, onDelta }: { name: string; message: string; onDelta: (content: string) => void }) => api.harnessSessions.chatStream(name, message, onDelta),
+    onError: toastError,
+  });
+}
+
 export function useAgent(name: string) {
   return useQuery({
     queryKey: ["agents", name],

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1342,6 +1342,34 @@ export const api = {
     chat: (name: string, message: string) => apiFetch<HarnessSessionChatResponse>(`/api/v1/harness-sessions/${name}/chat`, {
       method: "POST", body: JSON.stringify({ messages: [{ role: "user", content: message }] }),
     }),
+    chatStream: async (name: string, message: string, onDelta: (content: string) => void) => {
+      const token = getToken();
+      const headers = new Headers({ "Content-Type": "application/json", Accept: "text/event-stream" });
+      if (token) headers.set("Authorization", `Bearer ${token.replace(/[^\x00-\xFF]/g, "")}`);
+      const response = await fetch(`/api/v1/harness-sessions/${name}/chat?namespace=${encodeURIComponent(getNamespace())}`, {
+        method: "POST", headers, body: JSON.stringify({ stream: true, messages: [{ role: "user", content: message }] }),
+      });
+      if (!response.ok) throw new Error((await response.text()) || `Chat failed (${response.status})`);
+      if (!response.body) throw new Error("The browser did not expose the chat stream");
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let pending = "";
+      for (;;) {
+        const { value, done } = await reader.read();
+        pending += decoder.decode(value, { stream: !done });
+        const events = pending.split("\n\n");
+        pending = events.pop() || "";
+        for (const event of events) {
+          const data = event.split("\n").find((line) => line.startsWith("data: "))?.slice(6);
+          if (!data || data === "[DONE]") continue;
+          const payload = JSON.parse(data) as { choices?: Array<{ delta?: { content?: string } }>; error?: { message?: string } };
+          if (payload.error?.message) throw new Error(payload.error.message);
+          const content = payload.choices?.[0]?.delta?.content;
+          if (content) onDelta(content);
+        }
+        if (done) return;
+      }
+    },
   },
 
   policies: {


### PR DESCRIPTION
Supersedes #402 after rebasing onto squash-merged #400.

- proxy v1alpha2 adapter SSE without buffering
- render streamed OpenAI-style deltas in Agent Chat
- retain fixed-target proxy boundaries, redirect refusal, timeout, and 2 MiB response cap

Depends on merged harness-adapters#5.

Validation: `go test ./internal/apiserver`; `cd web && npm run build`.