### PR TITLE
fix: support keyless local harness inference

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -842,6 +842,33 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	secretAutoCreated := false
+	// First-party harness adapters configure local OpenAI-compatible routes
+	// through Pi/Hermes provider files. Those clients require an API-key field
+	// even when the endpoint itself is intentionally keyless (LocalAI,
+	// llama.cpp, LM Studio, Ollama, and similar). Give only harness-backed,
+	// explicitly keyless Agents a scoped compatibility value; the built-in
+	// runner and genuinely authenticated providers retain their existing
+	// credential behavior.
+	if req.RuntimeRef != "" && req.APIKey == "" && req.SecretName == "" && inst.Spec.Agents.Default.BaseURL != "" {
+		secretAutoCreated = true
+		req.SecretName = defaultProviderSecretName(req.Name, "harness-local")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      req.SecretName,
+				Namespace: ns,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "sympozium",
+					"sympozium.ai/instance":        req.Name,
+					"sympozium.ai/credential-kind": "harness-local-compatibility",
+				},
+			},
+			StringData: map[string]string{"OPENAI_API_KEY": "local-no-key"},
+		}
+		if err := createOrUpdateSecret(r.Context(), s.client, secret); err != nil {
+			http.Error(w, "failed to create harness compatibility secret: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
 	if req.Provider != "" && req.APIKey != "" && req.SecretName == "" {
 		secretAutoCreated = true
 		req.SecretName = defaultProviderSecretName(req.Name, req.Provider)

--- a/internal/apiserver/server_agent_test.go
+++ b/internal/apiserver/server_agent_test.go
@@ -123,6 +123,47 @@ func TestCreateInstance_NoHardcodedOTLPEndpoint(t *testing.T) {
 	if inst.Spec.RuntimeRef != "pi-v0-84-4" {
 		t.Errorf("RuntimeRef = %q, want Agent-level harness selection preserved", inst.Spec.RuntimeRef)
 	}
+	if len(inst.Spec.AuthRefs) != 1 || inst.Spec.AuthRefs[0].Provider != "lm-studio" {
+		t.Fatalf("AuthRefs = %#v, want scoped local harness compatibility secret", inst.Spec.AuthRefs)
+	}
+	var secret corev1.Secret
+	if err := srv.client.Get(req.Context(), types.NamespacedName{Name: inst.Spec.AuthRefs[0].Secret, Namespace: "default"}, &secret); err != nil {
+		t.Fatalf("get harness compatibility secret: %v", err)
+	}
+	if got := string(secret.Data["OPENAI_API_KEY"]); got != "local-no-key" {
+		t.Errorf("OPENAI_API_KEY = %q, want compatibility value", got)
+	}
+	if got := secret.Labels["sympozium.ai/credential-kind"]; got != "harness-local-compatibility" {
+		t.Errorf("credential-kind label = %q", got)
+	}
+}
+
+func TestCreateInstance_KeylessBuiltInAgentDoesNotCreateCompatibilitySecret(t *testing.T) {
+	srv, _ := newInstanceTestServer(t)
+	body, _ := json.Marshal(CreateInstanceRequest{
+		Name:     "builtin-local",
+		Provider: "lm-studio",
+		Model:    "qwen-local",
+		BaseURL:  "http://models.local/v1",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents?namespace=default", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.buildMux(nil, nil).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var inst sympoziumv1alpha1.Agent
+	if err := srv.client.Get(req.Context(), types.NamespacedName{Name: "builtin-local", Namespace: "default"}, &inst); err != nil {
+		t.Fatal(err)
+	}
+	if len(inst.Spec.AuthRefs) != 0 {
+		t.Fatalf("AuthRefs = %#v, built-in keyless Agent must not receive harness compatibility credentials", inst.Spec.AuthRefs)
+	}
+	var secret corev1.Secret
+	err := srv.client.Get(req.Context(), types.NamespacedName{Name: "builtin-local-harness-local-key", Namespace: "default"}, &secret)
+	if err == nil {
+		t.Fatal("built-in Agent unexpectedly created a harness compatibility Secret")
+	}
 }
 
 func TestPatchAgent_RuntimeRef(t *testing.T) {

--- a/web/src/pages/topology.tsx
+++ b/web/src/pages/topology.tsx
@@ -704,8 +704,17 @@ function buildTopology(
   const LOCAL_PROVIDERS = new Set(["lm-studio", "ollama", "llama-server", "vllm", "unsloth"]);
 
   for (const ens of ensembles) {
+    const inferred = ens.spec.baseURL ? inferProvider(ens.spec.baseURL) : null;
+    if (inferred && LOCAL_PROVIDERS.has(inferred)) {
+      ensProviders.set(inferred, PROVIDER_LABELS[inferred] || inferred);
+      ensProviderMap.set(ens.metadata.name, inferred);
+    }
     for (const ref of ens.spec.authRefs || []) {
-      if (ref.provider) {
+      // A compatibility credential may retain provider=custom even though the
+      // endpoint is a discovered local runtime. The endpoint is authoritative
+      // for topology classification; credentials describe authentication,
+      // not where inference executes.
+      if (ref.provider && !ensProviderMap.has(ens.metadata.name)) {
         ensProviders.set(ref.provider, PROVIDER_LABELS[ref.provider] || ref.provider);
         ensProviderMap.set(ens.metadata.name, ref.provider);
       }
@@ -715,10 +724,10 @@ function buildTopology(
         (m) => m.status?.endpoint && ens.spec.baseURL?.includes(m.status.endpoint.replace("/v1", "")),
       );
       if (!isModelEndpoint) {
-        const inferred = inferProvider(ens.spec.baseURL);
-        if (inferred) {
-          ensProviders.set(inferred, PROVIDER_LABELS[inferred] || inferred);
-          ensProviderMap.set(ens.metadata.name, inferred);
+        const fallbackProvider = inferProvider(ens.spec.baseURL);
+        if (fallbackProvider) {
+          ensProviders.set(fallbackProvider, PROVIDER_LABELS[fallbackProvider] || fallbackProvider);
+          ensProviderMap.set(ens.metadata.name, fallbackProvider);
         }
       }
     }
@@ -739,8 +748,11 @@ function buildTopology(
       agentModelMap.set(agent.metadata.name, matchedModel.metadata.name);
       continue;
     }
-    let prov = (agent.spec.authRefs || []).find((r) => r.provider)?.provider;
-    if (!prov && baseURL) prov = inferProvider(baseURL) || undefined;
+    const inferred = baseURL ? inferProvider(baseURL) : null;
+    let prov = inferred && LOCAL_PROVIDERS.has(inferred)
+      ? inferred
+      : (agent.spec.authRefs || []).find((r) => r.provider)?.provider;
+    if (!prov) prov = inferred || undefined;
     if (prov) {
       ensProviders.set(prov, PROVIDER_LABELS[prov] || prov);
       agentProviderMap.set(agent.metadata.name, prov);


### PR DESCRIPTION
## Summary

- automatically create a scoped `OPENAI_API_KEY=local-no-key` compatibility Secret for harness-backed Agents using an explicit keyless model endpoint
- label the Secret as harness-local compatibility state
- preserve existing behavior for built-in keyless Agents and harnesses with real credentials
- make topology classify `/proxy/llama-cpp/` endpoints as local `llama-server` even when compatibility credential metadata says `custom`

## Why

Pi and Hermes adapters require an OpenAI-compatible API-key field even when LocalAI/llama.cpp/LM Studio/Ollama do not validate credentials. Separately, credential provider metadata was overriding the actual endpoint in topology, incorrectly drawing local inference as Custom API.

## Tests

- harness-backed keyless Agent receives the compatibility Secret and AuthRef
- built-in keyless Agent receives no compatibility Secret or AuthRef
- live Framework Hermes validation succeeded against Qwen/LocalAI