### PR TITLE
feat(sessionkey): stable per-conversation session keys

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/sympozium-ai/sympozium/internal/collector"
 	"github.com/sympozium-ai/sympozium/internal/controller"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
+	"github.com/sympozium-ai/sympozium/internal/sessionkey"
 )
 
 const systemNamespace = "sympozium-system"
@@ -1089,7 +1090,7 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 		req.AgentID = "primary"
 	}
 	if req.SessionKey == "" {
-		req.SessionKey = fmt.Sprintf("session-%d", time.Now().UnixNano())
+		req.SessionKey = sessionkey.ForAPIServerDefault()
 	}
 	if req.Timeout == "" {
 		req.Timeout = "5m"

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/sessionkey"
 )
 
 const sympoziumInstanceFinalizer = "sympozium.ai/finalizer"
@@ -978,7 +979,7 @@ func (r *AgentReconciler) ensureWebEndpointAgentRun(ctx context.Context, instanc
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:   instance.Name,
 			AgentID:    "web-endpoint",
-			SessionKey: "web-endpoint",
+			SessionKey: sessionkey.ForWebEndpoint(instance.Name),
 			Task:       sympoziumv1alpha1.NewStringTask("Serve HTTP requests for this instance"),
 			Mode:       "server",
 			Model: sympoziumv1alpha1.ModelSpec{

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
@@ -22,6 +21,7 @@ import (
 	channelpkg "github.com/sympozium-ai/sympozium/internal/channel"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
 	"github.com/sympozium-ai/sympozium/internal/ipc"
+	"github.com/sympozium-ai/sympozium/internal/sessionkey"
 )
 
 var routerTracer = otel.Tracer("sympozium.ai/channel-router")
@@ -288,7 +288,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:   msg.InstanceName,
 			AgentID:    "primary",
-			SessionKey: fmt.Sprintf("channel-%s-%s-%d", msg.Channel, msg.ChatID, time.Now().UnixNano()),
+			SessionKey: sessionkey.ForChannel(msg.Channel, msg.ChatID, msg.ThreadID),
 			Task:       sympoziumv1alpha1.NewStringTask(msg.Text),
 			Model: sympoziumv1alpha1.ModelSpec{
 				Provider:                 provider,

--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/sessionkey"
 	"github.com/sympozium-ai/sympozium/internal/toolpolicy"
 )
 
@@ -268,9 +269,10 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			},
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
-			AgentRef: schedule.Spec.AgentRef,
-			Task:     sympoziumv1alpha1.NewStringTask(task),
-			AgentID:  fmt.Sprintf("schedule-%s", schedule.Name),
+			AgentRef:   schedule.Spec.AgentRef,
+			Task:       sympoziumv1alpha1.NewStringTask(task),
+			AgentID:    fmt.Sprintf("schedule-%s", schedule.Name),
+			SessionKey: sessionkey.ForSchedule(schedule.Name),
 			Model: sympoziumv1alpha1.ModelSpec{
 				Provider: resolveProvider(instance),
 				Model:    instance.Spec.Agents.Default.Model,

--- a/internal/orchestrator/spawner.go
+++ b/internal/orchestrator/spawner.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/sessionkey"
 	"github.com/sympozium-ai/sympozium/internal/toolpolicy"
 )
 
@@ -130,7 +131,7 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 	)
 
 	runName := buildSubagentRunName(req.ParentRunName, req.CurrentDepth+1, req.ChildIndex, req.BatchID)
-	sessionKey := fmt.Sprintf("%s:sub:%s", req.ParentSessionKey, runName)
+	sessionKey := sessionkey.ForSub(req.ParentSessionKey, runName)
 
 	span.SetAttributes(attribute.String("run.name", runName))
 	log.Info("Spawning sub-agent", "runName", runName)

--- a/internal/sessionkey/sessionkey.go
+++ b/internal/sessionkey/sessionkey.go
@@ -1,0 +1,104 @@
+// Package sessionkey builds canonical AgentRun session keys and short
+// deterministic hashes derived from them.
+//
+// AgentRun.spec.sessionKey is free-form and remains so — nothing in this
+// package is enforced by webhook or CRD validation. Callers that create
+// AgentRuns from a known source (channel message, schedule, web proxy
+// request, sub-agent spawn) SHOULD use the constructors here so that
+// session keys are stable per logical conversation and consistent across
+// the codebase. Hash is used to derive bounded-length identifiers (PVC
+// names, label values) from an arbitrary session key.
+package sessionkey
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// Hash returns a 16-character hex digest of key (first 8 bytes of SHA-256).
+// Suitable for use as a DNS-1123 label component when the original key may
+// be too long, contain disallowed characters, or vary in format. Collision
+// space is 2^64 — adequate for per-agent/per-namespace identifier suffixes.
+func Hash(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:8])
+}
+
+// ForChannel returns the session key for an inbound channel message. When
+// threadID is non-empty the session is scoped to the thread; otherwise it
+// is scoped to the chat/channel as a whole. This is the threading-off
+// semantic: the whole channel becomes one continuous session.
+func ForChannel(channelType, chatID, threadID string) string {
+	if threadID != "" {
+		return ForChannelThread(channelType, chatID, threadID)
+	}
+	return ForChannelChat(channelType, chatID)
+}
+
+// ForChannelThread returns the session key for a threaded conversation
+// within a channel (e.g. a Slack thread anchored at threadTS).
+func ForChannelThread(channelType, chatID, threadID string) string {
+	return fmt.Sprintf("chan:%s:%s:%s", channelType, chatID, threadID)
+}
+
+// ForChannelChat returns the session key for an entire chat/channel/DM
+// when no threading is in use.
+func ForChannelChat(channelType, chatID string) string {
+	return fmt.Sprintf("chan:%s:%s", channelType, chatID)
+}
+
+// ForSchedule returns the session key shared across all runs of a single
+// Schedule. Heartbeat/recurring runs see the same memory slice, so the
+// agent can build state over time ("last time I noticed X…").
+func ForSchedule(scheduleName string) string {
+	return fmt.Sprintf("sched:%s", scheduleName)
+}
+
+// ForScheduleRun returns a session key unique to one run of a Schedule.
+// Use when each invocation should be isolated (fire-and-forget sweeps
+// that must not accumulate state).
+func ForScheduleRun(scheduleName, runName string) string {
+	return fmt.Sprintf("sched:%s:run:%s", scheduleName, runName)
+}
+
+// ForWebProxy returns the session key for an OpenAI-compatible request
+// served by the web proxy. requestHash is the proxy's idempotency hash;
+// retries of the same logical request share a session.
+func ForWebProxy(instance, requestHash string) string {
+	return fmt.Sprintf("web:%s:%s", instance, requestHash)
+}
+
+// ForMCP returns the session key for an MCP SSE connection.
+func ForMCP(instance, sessionID string) string {
+	return fmt.Sprintf("mcp:%s:%s", instance, sessionID)
+}
+
+// ForWebEndpoint returns the session key for the long-lived server-mode
+// AgentRun that backs an Agent's web-endpoint skill. Per-instance so two
+// Agents using the same skill do not share memory.
+func ForWebEndpoint(instance string) string {
+	return fmt.Sprintf("web-endpoint:%s", instance)
+}
+
+// ForSub returns the session key for a sub-agent spawned by a parent
+// AgentRun. The format preserves the parent key as a prefix so subtree
+// traversal by string match is straightforward.
+func ForSub(parentSessionKey, childRunName string) string {
+	return fmt.Sprintf("%s:sub:%s", parentSessionKey, childRunName)
+}
+
+// ForAPIServerDefault returns a session key for ad-hoc API server runs
+// where the caller did not supply one. Uses crypto/rand so concurrent
+// requests cannot collide.
+func ForAPIServerDefault() string {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// rand.Read on a healthy system does not fail; if it does, fall
+		// back to a fixed prefix — the caller will still get a unique
+		// key via GenerateName on the AgentRun itself.
+		return "adhoc:nonce-unavailable"
+	}
+	return "adhoc:" + hex.EncodeToString(buf[:])
+}

--- a/internal/sessionkey/sessionkey_test.go
+++ b/internal/sessionkey/sessionkey_test.go
@@ -1,0 +1,117 @@
+package sessionkey
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHash(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "empty", in: ""},
+		{name: "short", in: "x"},
+		{name: "channel-key", in: "chan:slack:C123:1700000000.000200"},
+		{name: "long", in: strings.Repeat("a", 1024)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Hash(tt.in)
+			if len(got) != 16 {
+				t.Fatalf("Hash(%q) length = %d, want 16", tt.in, len(got))
+			}
+			// Determinism.
+			if again := Hash(tt.in); again != got {
+				t.Fatalf("Hash(%q) not deterministic: %q vs %q", tt.in, got, again)
+			}
+			// Hex only.
+			for _, r := range got {
+				if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+					t.Fatalf("Hash(%q) = %q contains non-hex rune %q", tt.in, got, r)
+				}
+			}
+		})
+	}
+
+	if Hash("a") == Hash("b") {
+		t.Fatal("Hash collision on trivial inputs")
+	}
+}
+
+func TestForChannel(t *testing.T) {
+	tests := []struct {
+		name     string
+		channel  string
+		chatID   string
+		threadID string
+		want     string
+	}{
+		{name: "threaded", channel: "slack", chatID: "C123", threadID: "1700000000.000200",
+			want: "chan:slack:C123:1700000000.000200"},
+		{name: "unthreaded", channel: "slack", chatID: "C123", threadID: "",
+			want: "chan:slack:C123"},
+		{name: "telegram-chat", channel: "telegram", chatID: "-100123", threadID: "",
+			want: "chan:telegram:-100123"},
+		{name: "telegram-topic", channel: "telegram", chatID: "-100123", threadID: "42",
+			want: "chan:telegram:-100123:42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ForChannel(tt.channel, tt.chatID, tt.threadID); got != tt.want {
+				t.Errorf("ForChannel = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForSchedule(t *testing.T) {
+	if got, want := ForSchedule("heartbeat"), "sched:heartbeat"; got != want {
+		t.Errorf("ForSchedule = %q, want %q", got, want)
+	}
+	if got, want := ForScheduleRun("heartbeat", "heartbeat-7"), "sched:heartbeat:run:heartbeat-7"; got != want {
+		t.Errorf("ForScheduleRun = %q, want %q", got, want)
+	}
+}
+
+func TestForWebProxy(t *testing.T) {
+	if got, want := ForWebProxy("inst", "abc123"), "web:inst:abc123"; got != want {
+		t.Errorf("ForWebProxy = %q, want %q", got, want)
+	}
+}
+
+func TestForMCP(t *testing.T) {
+	if got, want := ForMCP("inst", "mcp-99"), "mcp:inst:mcp-99"; got != want {
+		t.Errorf("ForMCP = %q, want %q", got, want)
+	}
+}
+
+func TestForWebEndpoint(t *testing.T) {
+	if got, want := ForWebEndpoint("inst-a"), "web-endpoint:inst-a"; got != want {
+		t.Errorf("ForWebEndpoint = %q, want %q", got, want)
+	}
+	if ForWebEndpoint("a") == ForWebEndpoint("b") {
+		t.Error("ForWebEndpoint must differ per instance")
+	}
+}
+
+func TestForSub(t *testing.T) {
+	parent := ForChannelThread("slack", "C1", "1700000000.0")
+	child := ForSub(parent, "sub-run-2")
+	if !strings.HasPrefix(child, parent+":sub:") {
+		t.Errorf("ForSub = %q, expected prefix %q", child, parent+":sub:")
+	}
+}
+
+func TestForAPIServerDefault(t *testing.T) {
+	a := ForAPIServerDefault()
+	b := ForAPIServerDefault()
+	if a == b {
+		t.Fatal("ForAPIServerDefault returned identical keys on consecutive calls")
+	}
+	if !strings.HasPrefix(a, "adhoc:") {
+		t.Errorf("ForAPIServerDefault = %q, expected adhoc: prefix", a)
+	}
+}

--- a/internal/webproxy/mcp.go
+++ b/internal/webproxy/mcp.go
@@ -13,6 +13,7 @@ import (
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
+	"github.com/sympozium-ai/sympozium/internal/sessionkey"
 )
 
 // JSONRPC types for MCP protocol.
@@ -240,7 +241,7 @@ func (p *Proxy) executeAgentTask(ctx context.Context, task string, session *mcpS
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:   inst.Name,
 			AgentID:    "primary",
-			SessionKey: fmt.Sprintf("mcp-%s-%d", inst.Name, time.Now().UnixNano()),
+			SessionKey: sessionkey.ForMCP(inst.Name, session.id),
 			Task:       sympoziumv1alpha1.NewStringTask(task),
 			Model: sympoziumv1alpha1.ModelSpec{
 				Provider:                 provider,

--- a/internal/webproxy/openai.go
+++ b/internal/webproxy/openai.go
@@ -18,6 +18,7 @@ import (
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
+	"github.com/sympozium-ai/sympozium/internal/sessionkey"
 )
 
 // ChatCompletionRequest is the OpenAI-compatible chat completions request.
@@ -192,7 +193,7 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:     inst.Name,
 			AgentID:      "primary",
-			SessionKey:   fmt.Sprintf("web-%s-%d", inst.Name, time.Now().UnixNano()),
+			SessionKey:   sessionkey.ForWebProxy(inst.Name, requestHash),
 			Task:         sympoziumv1alpha1.NewStringTask(task),
 			SystemPrompt: systemPrompt,
 			Model: sympoziumv1alpha1.ModelSpec{


### PR DESCRIPTION
Add an internal/sessionkey package that derives stable, structured session keys per run source, replacing nanosecond-unique keys:

- chan:<channel>:<chat>[:<thread>] for channel messages, so every message in one Slack thread (or channel, when threading is off) continues one session instead of starting cold
- sched:<name> for scheduled runs, so recurring runs accumulate memory
- web:<instance>:<request-hash> keyed on the proxy idempotency hash, so retries of the same logical request share a session
- mcp:<instance>:<session-id> tied to the actual SSE session
- per-instance web-endpoint keys (previously a literal shared by every Agent, letting instances leak memory to each other)
- adhoc:<random> via crypto/rand for API-server defaults (UnixNano could collide under concurrency)

Hash() gives a 16-char hex digest for DNS-1123-safe derived names and label values. AgentRun.spec.sessionKey stays free-form; nothing here is schema-enforced.