### PR TITLE
feat(harness): close critical GA security gaps

### DIFF
--- a/.github/workflows/integration-kind.yaml
+++ b/.github/workflows/integration-kind.yaml
@@ -114,7 +114,7 @@ jobs:
                         cpu: 500m
                         memory: 1Gi
                       limits:
-                        memory: 2Gi
+                        memory: 3Gi
                     volumeMounts:
                       - name: models
                         mountPath: /root/.ollama
@@ -135,12 +135,12 @@ jobs:
                 targetPort: 8080
           EOF
           kubectl rollout status deployment/ollama --timeout=300s
-          kubectl exec deployment/ollama -- ollama pull qwen2.5:0.5b
+          kubectl exec deployment/ollama -- ollama pull qwen2.5:1.5b
 
       - name: Run persistent Pi and Hermes real-model smoke tests
         env:
           TEST_PROVIDER: openai
-          TEST_MODEL: qwen2.5:0.5b
+          TEST_MODEL: qwen2.5:1.5b
           TEST_BASE_URL: http://ollama.default.svc.cluster.local:8080/v1
           TEST_API_KEY: ollama
         run: |

--- a/.github/workflows/integration-kind.yaml
+++ b/.github/workflows/integration-kind.yaml
@@ -12,7 +12,7 @@ jobs:
   integration-kind:
     name: Kind API integration suite
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       REGISTRY: ghcr.io/sympozium-ai/sympozium
       TAG: latest
@@ -82,6 +82,70 @@ jobs:
 
       - name: Run API smoke tests
         run: bash ./test/integration/test-api-smoke.sh
+
+      - name: Start the in-cluster test model
+        run: |
+          set -euo pipefail
+          kubectl apply -f - <<'EOF'
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: ollama
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: ollama
+            template:
+              metadata:
+                labels:
+                  app: ollama
+              spec:
+                containers:
+                  - name: ollama
+                    image: docker.io/ollama/ollama:0.12.10@sha256:e8c3d1f6ad16323bc40dc63eff0701d4fc32113f75a86b54b3e836eef8290de6
+                    ports:
+                      - containerPort: 11434
+                    resources:
+                      requests:
+                        cpu: 500m
+                        memory: 1Gi
+                      limits:
+                        memory: 2Gi
+                    volumeMounts:
+                      - name: models
+                        mountPath: /root/.ollama
+                volumes:
+                  - name: models
+                    emptyDir: {}
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: ollama
+          spec:
+            selector:
+              app: ollama
+            ports:
+              - name: http
+                port: 8080
+                targetPort: 11434
+          EOF
+          kubectl rollout status deployment/ollama --timeout=300s
+          kubectl exec deployment/ollama -- ollama pull qwen2.5:0.5b
+
+      - name: Run persistent Pi and Hermes real-model smoke tests
+        env:
+          TEST_PROVIDER: openai
+          TEST_MODEL: qwen2.5:0.5b
+          TEST_BASE_URL: http://ollama.default.svc.cluster.local:8080/v1
+          TEST_API_KEY: ollama
+        run: |
+          set -euo pipefail
+          PERSISTENT_HARNESS_RUNTIME=pi-session-v0-84-4 \
+            bash ./test/integration/test-persistent-harness-session.sh
+          PERSISTENT_HARNESS_RUNTIME=hermes-session-v0-20-6 \
+            bash ./test/integration/test-persistent-harness-session.sh
 
       - name: Dump cluster state on failure
         if: failure()

--- a/.github/workflows/integration-kind.yaml
+++ b/.github/workflows/integration-kind.yaml
@@ -104,8 +104,11 @@ jobs:
                 containers:
                   - name: ollama
                     image: docker.io/ollama/ollama:0.12.10@sha256:e8c3d1f6ad16323bc40dc63eff0701d4fc32113f75a86b54b3e836eef8290de6
+                    env:
+                      - name: OLLAMA_HOST
+                        value: 0.0.0.0:8080
                     ports:
-                      - containerPort: 11434
+                      - containerPort: 8080
                     resources:
                       requests:
                         cpu: 500m
@@ -129,7 +132,7 @@ jobs:
             ports:
               - name: http
                 port: 8080
-                targetPort: 11434
+                targetPort: 8080
           EOF
           kubectl rollout status deployment/ollama --timeout=300s
           kubectl exec deployment/ollama -- ollama pull qwen2.5:0.5b

--- a/docs/guides/agentharness.md
+++ b/docs/guides/agentharness.md
@@ -94,6 +94,8 @@ For operators, the trust boundary is unchanged:
 - the backing Agent must explicitly allow the model credential the runtime
   requests;
 - model secret keys are injected individually from the existing allowlist;
+- remote MCP servers and their credentials are rejected for external adapters;
+  SkillPack tools use the bounded, policy-enforcing loopback MCP server;
 - the session pod has no service-account token, privilege escalation, or
   writable root filesystem; and
 - only Sympozium's API server proxies the fixed `/v1/chat/completions` target,

--- a/docs/guides/writing-integration-tests.md
+++ b/docs/guides/writing-integration-tests.md
@@ -38,6 +38,11 @@ kubectl create secret generic inttest-openai-key --from-literal=OPENAI_API_KEY=s
 OPENAI_API_KEY=... ./test/integration/test-persistent-harness-session.sh
 ```
 
+The scheduled Kind workflow runs that persistent suite against both maintained
+Pi and Hermes runtimes using a pinned Ollama image and a small model served
+inside the test cluster. It needs no external model credentials, and a failure
+in either adapter fails the scheduled workflow.
+
 ## How Integration Tests Work
 
 Each test follows the same pattern:

--- a/docs/modes/harness-adapters.md
+++ b/docs/modes/harness-adapters.md
@@ -29,7 +29,7 @@ Everything arrives as environment variables and mounted files on an ordinary con
 | `MODEL_NAME`, `MODEL_BASE_URL`, `MODEL_PROVIDER` | `spec.model`. Map these onto whatever your harness reads — see [Model routing](#model-routing-is-yours) below. |
 | provider credential | Injected per-key by `SecretKeyRef` from the `allowedAuthSecretKeys` allowlist (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, …). Already on the container; never widen the allowlist to make an adapter work. |
 | `TOOL_POLICY_ALLOW`, `TOOL_POLICY_DENY` | Comma-separated. Honour them only if you declare `toolFilter`. |
-| `MCP_CONFIG_PATH` | Path to the MCP server registry, as **JSON**: `{"servers":[{"name","url","toolsPrefix","timeout","headers","auth":{"type":"bearer","secretKey":"MCP_AUTH_X"}}]}`. Read the token from the env var `auth.secretKey` names — it is on the container. Connect to **every** entry: one of them may be `sympozium-skills`, which is how the run's SkillPack tools reach you. |
+| `MCP_CONFIG_PATH` | Path to the trusted loopback SkillPack MCP registry, as JSON. Remote operator-configured MCP servers and their credentials are never exposed to an external adapter. A `sympozium-skills` entry is present when the run has mediated SkillPack tools. |
 | `HOME` | `/home/agent`, an `emptyDir`. The only writable path besides `/workspace`, `/ipc/output` and `/tmp`. |
 | `SYMPOZIUM_RESULT_PATH` | Where to write the result. Defaults to `/ipc/output/result.json`; read it from env rather than hardcoding. |
 | `SYMPOZIUM_HARNESS_CONTRACT_VERSION` | Adapter contract version (`v1alpha1` today). Check it at startup and fail closed on unknown versions. |
@@ -118,7 +118,10 @@ the same AgentRun field.
 
 ## Model routing is yours
 
-Sympozium sets `MODEL_*` and injects the credential, then stops. It cannot verify that your
+Sympozium sets `MODEL_*` and injects the model credential, then stops. Remote
+MCP credentials are not injected into adapters: a harness run with
+`Agent.spec.mcpServers` is rejected until those connections have a trusted
+local mediator. Sympozium cannot verify that your
 harness routes to the model the `AgentRun` names, and many harnesses have opinionated
 provider resolution — config files, CLI logins, ambient environment — that can quietly win
 over what you pass.

--- a/docs/modes/harness.md
+++ b/docs/modes/harness.md
@@ -266,6 +266,13 @@ that race intermittently.
 It is an ordinary MCP server, and it appears in the MCP registry the harness
 already reads as one more entry named `sympozium-skills`.
 
+Operator-configured remote MCP servers are deliberately different: their
+registries can contain arbitrary endpoints, headers, and Secret-derived
+credentials. Harness AgentRuns that inherit `Agent.spec.mcpServers` are
+rejected before pod creation. External adapters receive only the trusted
+loopback SkillPack registry; remote MCP remains unavailable until Sympozium
+provides an equally trusted local mediator.
+
 !!! warning "`sympozium*` is a reserved name prefix"
     A harness namespaces tools by server name, so an operator server also called
     `sympozium-skills` would shadow this one — and the agent's SkillPack tool

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/openai/openai-go/v3 v3.22.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/sympozium-ai/llmfit-dra/api v0.0.0-20260708145247-787d849d84af
 	go.mau.fi/whatsmeow v0.0.0-20260219150138-7ae702b1eed4
@@ -171,7 +172,6 @@ require (
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.7.0 // indirect

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -3089,6 +3089,9 @@ func (r *AgentRunReconciler) buildContainers(
 	if err := validateMCPServerNames(mcpServers); err != nil {
 		return nil, nil, err
 	}
+	if taskModeReplacesAgentContainer(agentRun.Spec.Task) && len(mcpServers) > 0 {
+		return nil, nil, fmt.Errorf("task.mode %q cannot use Agent.spec.mcpServers: remote MCP credentials are never exposed to external adapters; use mediated SkillPack tools or remove the remote MCP servers", agentRun.Spec.Task.GetMode())
+	}
 
 	// Add MCP bridge sidecar if MCP servers are configured.
 	if len(mcpServers) > 0 {
@@ -3104,9 +3107,8 @@ func (r *AgentRunReconciler) buildContainers(
 		if observability != nil && observability.Enabled {
 			mcpEnv = append(mcpEnv, buildObservabilityEnv(agentRun, observability)...)
 		}
-		// Inject auth secrets as env vars for each MCP server. Built once:
-		// the mcp-bridge sidecar reads them, and so does an agent container
-		// a task mode replaced, which talks to the servers itself.
+		// Inject auth secrets only into the trusted mcp-bridge sidecar. External
+		// adapter containers are rejected above when remote MCP is configured.
 		var mcpAuthEnv []corev1.EnvVar
 		for _, srv := range mcpServers {
 			if srv.AuthSecret == "" {
@@ -3129,22 +3131,6 @@ func (r *AgentRunReconciler) buildContainers(
 			})
 		}
 		mcpEnv = append(mcpEnv, mcpAuthEnv...)
-
-		// A task mode that replaces the agent container brings its own MCP
-		// client (that depth is why an external harness is being used at
-		// all), so it reads the server registry the controller already
-		// generates rather than the mcp-bridge's discovered tool manifest.
-		//
-		// It gets the JSON rendering of that registry, not the YAML one the
-		// bridge reads: the adapter is a shell script, and asking it to parse
-		// YAML would mean either a YAML binary in every harness image or
-		// hand-rolled parsing of a file that carries auth material. The
-		// per-server tokens come with it — without them a registry entry
-		// naming an authSecret would connect unauthenticated and fail at the
-		// first tool call.
-		if taskModeReplacesAgentContainer(agentRun.Spec.Task) {
-			mountHarnessMCPRegistry(&containers[0], mcpAuthEnv)
-		}
 
 		// Init container for MCP tool discovery (runs before agent starts)
 		initContainers = append(initContainers, corev1.Container{
@@ -3216,7 +3202,7 @@ func (r *AgentRunReconciler) buildContainers(
 		// A run with no operator-configured MCP servers still needs the
 		// registry, because the skill tool server is in it.
 		if len(mcpServers) == 0 {
-			mountHarnessMCPRegistry(&containers[0], nil)
+			mountHarnessMCPRegistry(&containers[0])
 		}
 	}
 

--- a/internal/controller/agentrun_harness_mode_test.go
+++ b/internal/controller/agentrun_harness_mode_test.go
@@ -231,34 +231,10 @@ func TestBuildContainers_HarnessCredentialsStayPerKeySecretRefs(t *testing.T) {
 	}
 }
 
-// The MCP server registry the controller already generates is mounted for the
-// harness, which speaks MCP itself rather than going through the bridge's
-// discovered manifest.
-func TestBuildContainers_HarnessMountsMCPRegistry(t *testing.T) {
-	r := &AgentRunReconciler{}
-	mcpServers := []sympoziumv1alpha1.MCPServerRef{{Name: "github", URL: "http://mcp-github:8080"}}
-
-	cs, _, err := r.buildContainers(harnessModeRun(nil), false, nil, nil, mcpServers, nil)
-	if err != nil {
-		t.Fatalf("buildContainers: %v", err)
-	}
-	agent := containerByName(cs, "agent")
-
-	if !hasMount(agent.VolumeMounts, "mcp-config") {
-		t.Errorf("agent volumeMounts = %v, want the mcp-config mount", agent.VolumeMounts)
-	}
-	// JSON, not the YAML the bridge reads: the harness adapter is a shell
-	// script with jq and no YAML parser.
-	if v, ok := envValueLocal(agent.Env, "MCP_CONFIG_PATH"); !ok || v != "/config/mcp/mcp-servers.json" {
-		t.Errorf("MCP_CONFIG_PATH = (%q, %v), want /config/mcp/mcp-servers.json", v, ok)
-	}
-}
-
-// The registry names an auth env var per server; without the var itself on
-// the harness container, the harness connects unauthenticated and fails at
-// the first tool call. The bridge sidecar got these already — the replaced
-// agent container has to get them too, because it is the MCP client now.
-func TestBuildContainers_HarnessGetsMCPAuthTokens(t *testing.T) {
+// Remote MCP credentials belong only to the trusted bridge. Until a trusted
+// loopback proxy mediates those servers, a harness must fail closed rather than
+// receive their registry, headers, or Secret-derived environment variables.
+func TestBuildContainers_HarnessRejectsRemoteMCPServers(t *testing.T) {
 	r := &AgentRunReconciler{}
 	mcpServers := []sympoziumv1alpha1.MCPServerRef{{
 		Name:       "github-mcp",
@@ -267,27 +243,9 @@ func TestBuildContainers_HarnessGetsMCPAuthTokens(t *testing.T) {
 		AuthKey:    "token",
 	}}
 
-	cs, _, err := r.buildContainers(harnessModeRun(nil), false, nil, nil, mcpServers, nil)
-	if err != nil {
-		t.Fatalf("buildContainers: %v", err)
-	}
-	agent := containerByName(cs, "agent")
-
-	var found bool
-	for _, e := range agent.Env {
-		if e.Name != "MCP_AUTH_GITHUB_MCP" {
-			continue
-		}
-		found = true
-		if e.ValueFrom == nil || e.ValueFrom.SecretKeyRef == nil {
-			t.Fatalf("MCP_AUTH_GITHUB_MCP = %+v, want a SecretKeyRef", e)
-		}
-		if e.ValueFrom.SecretKeyRef.Name != "gh-token" || e.ValueFrom.SecretKeyRef.Key != "token" {
-			t.Errorf("SecretKeyRef = %+v, want gh-token/token", e.ValueFrom.SecretKeyRef)
-		}
-	}
-	if !found {
-		t.Error("MCP_AUTH_GITHUB_MCP not injected; the harness cannot authenticate to the MCP server")
+	_, _, err := r.buildContainers(harnessModeRun(nil), false, nil, nil, mcpServers, nil)
+	if err == nil || !strings.Contains(err.Error(), "remote MCP credentials are never exposed") {
+		t.Fatalf("buildContainers error = %v, want fail-closed remote MCP boundary", err)
 	}
 }
 
@@ -326,24 +284,6 @@ func TestMCPRegistryJSONMatchesInjectedAuthEnvNames(t *testing.T) {
 			cfg.Servers[0].Auth.SecretKey)
 	}
 
-	r := &AgentRunReconciler{}
-	cs, _, err := r.buildContainers(harnessModeRun(nil), false, nil, nil, mcpServers, nil)
-	if err != nil {
-		t.Fatalf("buildContainers: %v", err)
-	}
-	// A SecretKeyRef env var carries no literal value, so this checks the
-	// name is present rather than reading it back.
-	var present bool
-	for _, e := range containerByName(cs, "agent").Env {
-		if e.Name == cfg.Servers[0].Auth.SecretKey {
-			present = true
-			break
-		}
-	}
-	if !present {
-		t.Errorf("registry names %q but no such env var is on the agent container",
-			cfg.Servers[0].Auth.SecretKey)
-	}
 }
 
 // Without MCP servers there is no mcp-config volume, so the mount must not
@@ -795,11 +735,13 @@ func TestBuildContainers_RejectsAnyReservedPrefixName(t *testing.T) {
 // obvious names for their own servers.
 func TestBuildContainers_AllowsOrdinaryMCPServerNames(t *testing.T) {
 	r := &AgentRunReconciler{}
+	run := newTestRun()
+	run.Spec.Task = sympoziumv1alpha1.NewStringTask("use a remote tool")
 	mcp := []sympoziumv1alpha1.MCPServerRef{
 		{Name: "github", URL: "http://gh:8080"},
 		{Name: "my-sympozium-proxy", URL: "http://p:8080"},
 	}
-	if _, _, err := r.buildContainers(harnessModeRun(nil), false, nil, nil, mcp, nil); err != nil {
+	if _, _, err := r.buildContainers(run, false, nil, nil, mcp, nil); err != nil {
 		t.Errorf("buildContainers rejected ordinary server names: %v", err)
 	}
 }

--- a/internal/controller/agentrun_skilltools.go
+++ b/internal/controller/agentrun_skilltools.go
@@ -189,8 +189,9 @@ func (r *AgentRunReconciler) buildSkillToolsContainer(agentRun *sympoziumv1alpha
 	}
 }
 
-// mountHarnessMCPRegistry gives a replaced agent container the MCP server
-// registry and the credentials for it.
+// mountHarnessMCPRegistry gives a replaced agent container only the trusted
+// loopback SkillPack MCP registry. Remote MCP servers are rejected for harness
+// runs, so this function never injects their credentials.
 //
 // It gets the JSON rendering, not the YAML one the mcp-bridge reads: the
 // adapter is a shell script, and asking it to parse YAML would mean either a
@@ -198,7 +199,7 @@ func (r *AgentRunReconciler) buildSkillToolsContainer(agentRun *sympoziumv1alpha
 // carries auth material. The per-server tokens come with it — without them a
 // registry entry naming an authSecret would connect unauthenticated and fail at
 // the first tool call.
-func mountHarnessMCPRegistry(agent *corev1.Container, mcpAuthEnv []corev1.EnvVar) {
+func mountHarnessMCPRegistry(agent *corev1.Container) {
 	agent.VolumeMounts = append(agent.VolumeMounts, corev1.VolumeMount{
 		Name:      "mcp-config",
 		MountPath: "/config/mcp",
@@ -207,5 +208,4 @@ func mountHarnessMCPRegistry(agent *corev1.Container, mcpAuthEnv []corev1.EnvVar
 	agent.Env = append(agent.Env,
 		corev1.EnvVar{Name: "MCP_CONFIG_PATH", Value: "/config/mcp/mcp-servers.json"},
 	)
-	agent.Env = append(agent.Env, mcpAuthEnv...)
 }

--- a/internal/skilltools/server.go
+++ b/internal/skilltools/server.go
@@ -28,8 +28,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/sympozium-ai/sympozium/internal/mcpbridge"
 	"github.com/sympozium-ai/sympozium/pkg/sidecartools"
 )
@@ -47,6 +49,12 @@ const ServerName = "sympozium-skills"
 
 // resultPollInterval is how often a pending exec result is checked for.
 const resultPollInterval = 100 * time.Millisecond
+
+const (
+	defaultMaxRequestBytes = 1 << 20
+	defaultMaxOutputBytes  = 1 << 20
+	defaultMaxConcurrent   = 4
+)
 
 // Config is everything the server needs, all of it controller-supplied. None of
 // it comes from the agent, which is the point: the policy this server enforces
@@ -68,13 +76,34 @@ type Config struct {
 	// LoadTimeout is how long to wait for the manifest mount. Zero means
 	// sidecartools.DefaultLoadTimeout.
 	LoadTimeout time.Duration
+	// MaxRequestBytes, MaxOutputBytes, and MaxConcurrent bound untrusted MCP
+	// clients. Zero selects the conservative defaults above.
+	MaxRequestBytes int64
+	MaxOutputBytes  int64
+	MaxConcurrent   int
 }
 
 // Server serves the permitted SkillPack tools over MCP.
 type Server struct {
-	cfg   Config
-	tools map[string]sidecartools.Tool
-	order []string
+	cfg     Config
+	tools   map[string]sidecartools.Tool
+	order   []string
+	schemas map[string]*jsonschema.Schema
+	sem     chan struct{}
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  any             `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string                  `json:"jsonrpc"`
+	ID      json.RawMessage         `json:"id"`
+	Result  json.RawMessage         `json:"result,omitempty"`
+	Error   *mcpbridge.JSONRPCError `json:"error,omitempty"`
 }
 
 // NewServer loads the manifest, applies the tool policy once at startup, and
@@ -90,6 +119,15 @@ func NewServer(cfg Config) (*Server, error) {
 	if cfg.ExecTimeout <= 0 {
 		cfg.ExecTimeout = sidecartools.DefaultExecTimeout * time.Second
 	}
+	if cfg.MaxRequestBytes <= 0 {
+		cfg.MaxRequestBytes = defaultMaxRequestBytes
+	}
+	if cfg.MaxOutputBytes <= 0 {
+		cfg.MaxOutputBytes = defaultMaxOutputBytes
+	}
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = defaultMaxConcurrent
+	}
 
 	manifest, err := sidecartools.LoadManifest(cfg.ManifestPath, cfg.LoadTimeout)
 	if err != nil {
@@ -98,12 +136,26 @@ func NewServer(cfg Config) (*Server, error) {
 
 	permitted := sidecartools.FilterByPolicy(manifest.Tools, cfg.ToolPolicyAllow, cfg.ToolPolicyDeny)
 	s := &Server{
-		cfg:   cfg,
-		tools: make(map[string]sidecartools.Tool, len(permitted)),
+		cfg:     cfg,
+		tools:   make(map[string]sidecartools.Tool, len(permitted)),
+		schemas: make(map[string]*jsonschema.Schema, len(permitted)),
+		sem:     make(chan struct{}, cfg.MaxConcurrent),
 	}
 	for _, t := range permitted {
 		s.tools[t.Name] = t
 		s.order = append(s.order, t.Name)
+		if t.Parameters != nil {
+			compiler := jsonschema.NewCompiler()
+			url := "urn:sympozium:skill-tool:" + t.Name
+			if err := compiler.AddResource(url, t.Parameters); err != nil {
+				return nil, fmt.Errorf("tool %s input schema: %w", t.Name, err)
+			}
+			sch, err := compiler.Compile(url)
+			if err != nil {
+				return nil, fmt.Errorf("tool %s input schema: %w", t.Name, err)
+			}
+			s.schemas[t.Name] = sch
+		}
 	}
 
 	log.Printf("skill-tools: serving %d of %d tool(s) after spec.toolPolicy (allow=%q deny=%q)",
@@ -122,6 +174,9 @@ func (s *Server) Run(ctx context.Context) error {
 		Addr:              s.cfg.Addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		MaxHeaderBytes:    16 << 10,
 	}
 
 	errCh := make(chan error, 1)
@@ -143,16 +198,35 @@ func (s *Server) Run(ctx context.Context) error {
 }
 
 func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
-	var req mcpbridge.JSONRPCRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
+		http.Error(w, "Origin is not allowed on the loopback MCP endpoint", http.StatusForbidden)
+		return
+	}
+	if contentType := r.Header.Get("Content-Type"); contentType != "" && !strings.HasPrefix(strings.ToLower(contentType), "application/json") {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, s.cfg.MaxRequestBytes)
+	var req rpcRequest
+	dec := json.NewDecoder(r.Body)
+	dec.UseNumber()
+	if err := dec.Decode(&req); err != nil {
 		writeError(w, nil, -32700, "parse error")
+		return
+	}
+	if req.JSONRPC != "2.0" || req.Method == "" {
+		writeError(w, req.ID, -32600, "invalid request")
+		return
+	}
+	if !validRPCID(req.ID) {
+		writeError(w, nil, -32600, "id must be a string, number, or null")
 		return
 	}
 
 	switch req.Method {
 	case "initialize":
 		caps := json.RawMessage(`{"tools":{}}`)
-		writeResult(w, &req.ID, mcpbridge.MCPInitializeResult{
+		writeResult(w, req.ID, mcpbridge.MCPInitializeResult{
 			ProtocolVersion: protocolVersion,
 			Capabilities:    caps,
 			ServerInfo: mcpbridge.MCPImplementation{
@@ -166,16 +240,34 @@ func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 
 	case "tools/list":
-		writeResult(w, &req.ID, mcpbridge.MCPToolsListResult{Tools: s.listTools()})
+		writeResult(w, req.ID, mcpbridge.MCPToolsListResult{Tools: s.listTools()})
 
 	case "tools/call":
 		s.handleToolCall(w, r.Context(), &req)
 
 	case "ping":
-		writeResult(w, &req.ID, struct{}{})
+		writeResult(w, req.ID, struct{}{})
 
 	default:
-		writeError(w, &req.ID, -32601, fmt.Sprintf("method not found: %s", req.Method))
+		writeError(w, req.ID, -32601, fmt.Sprintf("method not found: %s", req.Method))
+	}
+}
+
+func validRPCID(id json.RawMessage) bool {
+	if len(id) == 0 || string(id) == "null" {
+		return true
+	}
+	var value any
+	dec := json.NewDecoder(strings.NewReader(string(id)))
+	dec.UseNumber()
+	if err := dec.Decode(&value); err != nil {
+		return false
+	}
+	switch value.(type) {
+	case string, json.Number:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -199,15 +291,22 @@ func (s *Server) listTools() []mcpbridge.MCPTool {
 	return out
 }
 
-func (s *Server) handleToolCall(w http.ResponseWriter, ctx context.Context, req *mcpbridge.JSONRPCRequest) {
+func (s *Server) handleToolCall(w http.ResponseWriter, ctx context.Context, req *rpcRequest) {
+	select {
+	case s.sem <- struct{}{}:
+		defer func() { <-s.sem }()
+	default:
+		writeError(w, req.ID, -32000, "too many concurrent tool calls")
+		return
+	}
 	raw, err := json.Marshal(req.Params)
 	if err != nil {
-		writeError(w, &req.ID, -32602, "invalid params")
+		writeError(w, req.ID, -32602, "invalid params")
 		return
 	}
 	var params mcpbridge.MCPToolCallParams
 	if err := json.Unmarshal(raw, &params); err != nil {
-		writeError(w, &req.ID, -32602, "invalid params")
+		writeError(w, req.ID, -32602, "invalid params")
 		return
 	}
 
@@ -218,7 +317,7 @@ func (s *Server) handleToolCall(w http.ResponseWriter, ctx context.Context, req 
 	tool, ok := s.tools[params.Name]
 	if !ok {
 		log.Printf("skill-tools: refused %q — not permitted by spec.toolPolicy for this run", params.Name)
-		writeResult(w, &req.ID, mcpbridge.MCPToolCallResult{
+		writeResult(w, req.ID, mcpbridge.MCPToolCallResult{
 			IsError: true,
 			Content: []mcpbridge.MCPContent{{
 				Type: "text",
@@ -232,16 +331,25 @@ func (s *Server) handleToolCall(w http.ResponseWriter, ctx context.Context, req 
 	if args == "" || args == "null" {
 		args = "{}"
 	}
+	if schema := s.schemas[params.Name]; schema != nil {
+		var value any
+		dec := json.NewDecoder(strings.NewReader(args))
+		dec.UseNumber()
+		if err := dec.Decode(&value); err != nil || schema.Validate(value) != nil {
+			writeError(w, req.ID, -32602, "tool arguments do not match inputSchema")
+			return
+		}
+	}
 
 	out, err := s.dispatch(ctx, tool, args)
 	if err != nil {
-		writeResult(w, &req.ID, mcpbridge.MCPToolCallResult{
+		writeResult(w, req.ID, mcpbridge.MCPToolCallResult{
 			IsError: true,
 			Content: []mcpbridge.MCPContent{{Type: "text", Text: err.Error()}},
 		})
 		return
 	}
-	writeResult(w, &req.ID, mcpbridge.MCPToolCallResult{
+	writeResult(w, req.ID, mcpbridge.MCPToolCallResult{
 		Content: []mcpbridge.MCPContent{{Type: "text", Text: out}},
 	})
 }
@@ -276,7 +384,13 @@ func (s *Server) dispatch(ctx context.Context, tool sidecartools.Tool, argsJSON 
 
 	deadline := time.Now().Add(s.cfg.ExecTimeout)
 	for {
+		if info, err := os.Stat(resPath); err == nil && info.Size() > s.cfg.MaxOutputBytes+(64<<10) {
+			return "", fmt.Errorf("tool %s result file exceeded the %d-byte output limit", tool.Name, s.cfg.MaxOutputBytes)
+		}
 		if res, ok := readExecResult(resPath); ok {
+			if int64(len(res.Stdout)+len(res.Stderr)) > s.cfg.MaxOutputBytes {
+				return "", fmt.Errorf("tool %s output exceeded %d bytes", tool.Name, s.cfg.MaxOutputBytes)
+			}
 			if res.TimedOut {
 				return "", fmt.Errorf("tool %s timed out", tool.Name)
 			}
@@ -320,23 +434,23 @@ func readExecResult(path string) (execResult, bool) {
 	return res, true
 }
 
-func writeResult(w http.ResponseWriter, id *int64, result any) {
+func writeResult(w http.ResponseWriter, id json.RawMessage, result any) {
 	payload, err := json.Marshal(result)
 	if err != nil {
 		writeError(w, id, -32603, "internal error")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(mcpbridge.JSONRPCResponse{
+	_ = json.NewEncoder(w).Encode(rpcResponse{
 		JSONRPC: "2.0",
 		ID:      id,
 		Result:  payload,
 	})
 }
 
-func writeError(w http.ResponseWriter, id *int64, code int, msg string) {
+func writeError(w http.ResponseWriter, id json.RawMessage, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(mcpbridge.JSONRPCResponse{
+	_ = json.NewEncoder(w).Encode(rpcResponse{
 		JSONRPC: "2.0",
 		ID:      id,
 		Error:   &mcpbridge.JSONRPCError{Code: code, Message: msg},

--- a/internal/skilltools/server_test.go
+++ b/internal/skilltools/server_test.go
@@ -249,6 +249,117 @@ func TestServer_UnknownMethod(t *testing.T) {
 	}
 }
 
+func TestServer_PreservesStringRequestID(t *testing.T) {
+	s, _ := newTestServer(t, "", "")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"jsonrpc":"2.0","id":"client-7","method":"tools/list"}`))
+	req.Header.Set("Content-Type", "application/json")
+	s.handleJSONRPC(rec, req)
+	var response struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if response.ID != "client-7" {
+		t.Fatalf("id = %q, want client-7", response.ID)
+	}
+}
+
+func TestServer_RejectsCompositeRequestID(t *testing.T) {
+	s, _ := newTestServer(t, "", "")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"jsonrpc":"2.0","id":{"nested":true},"method":"tools/list"}`))
+	s.handleJSONRPC(rec, req)
+	if !strings.Contains(rec.Body.String(), "id must be a string, number, or null") {
+		t.Fatalf("response = %s", rec.Body.String())
+	}
+}
+
+func TestServer_RejectsBrowserOrigin(t *testing.T) {
+	s, _ := newTestServer(t, "", "")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	req.Header.Set("Origin", "https://attacker.example")
+	s.handleJSONRPC(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestServer_BoundsRequestBody(t *testing.T) {
+	s, _ := newTestServer(t, "", "")
+	s.cfg.MaxRequestBytes = 32
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","padding":"xxxxxxxxxxxxxxxxxxxxxxxx"}`))
+	s.handleJSONRPC(rec, req)
+	if !strings.Contains(rec.Body.String(), "parse error") {
+		t.Fatalf("response = %s, want bounded parse error", rec.Body.String())
+	}
+}
+
+func TestServer_ValidatesToolArgumentsAgainstSchema(t *testing.T) {
+	s, _ := newTestServer(t, "", "")
+	resp := call(t, s, "tools/call", mcpbridge.MCPToolCallParams{Name: "kubectl_get", Arguments: json.RawMessage(`{"resource":12}`)})
+	if resp.Error == nil || resp.Error.Code != -32602 {
+		t.Fatalf("error = %+v, want invalid params", resp.Error)
+	}
+}
+
+func TestServer_BoundsConcurrentToolCalls(t *testing.T) {
+	s, _ := newTestServer(t, "", "")
+	for i := 0; i < cap(s.sem); i++ {
+		s.sem <- struct{}{}
+	}
+	defer func() {
+		for len(s.sem) > 0 {
+			<-s.sem
+		}
+	}()
+	resp := call(t, s, "tools/call", mcpbridge.MCPToolCallParams{Name: "kubectl_get", Arguments: json.RawMessage(`{"resource":"pods"}`)})
+	if resp.Error == nil || resp.Error.Code != -32000 {
+		t.Fatalf("error = %+v, want concurrency limit", resp.Error)
+	}
+}
+
+func TestServer_BoundsToolOutput(t *testing.T) {
+	s, toolsDir := newTestServer(t, "", "")
+	s.cfg.MaxOutputBytes = 8
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			entries, _ := os.ReadDir(toolsDir)
+			for _, entry := range entries {
+				if !strings.HasPrefix(entry.Name(), "exec-request-") {
+					continue
+				}
+				raw, _ := os.ReadFile(filepath.Join(toolsDir, entry.Name()))
+				var request struct {
+					ID string `json:"id"`
+				}
+				if json.Unmarshal(raw, &request) != nil || request.ID == "" {
+					continue
+				}
+				result, _ := json.Marshal(map[string]any{"id": request.ID, "exitCode": 0, "stdout": "this output is too large"})
+				_ = os.WriteFile(filepath.Join(toolsDir, "exec-result-"+request.ID+".json"), result, 0o644)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	resp := call(t, s, "tools/call", mcpbridge.MCPToolCallParams{Name: "kubectl_get", Arguments: json.RawMessage(`{"resource":"pods"}`)})
+	<-done
+	var result mcpbridge.MCPToolCallResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "output exceeded") {
+		t.Fatalf("result = %+v, want bounded output error", result)
+	}
+}
+
 func TestNewServer_MissingManifestFails(t *testing.T) {
 	_, err := NewServer(Config{
 		ManifestPath: filepath.Join(t.TempDir(), "absent.json"),

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -172,6 +172,12 @@ func (pe *PolicyEnforcer) Handle(ctx context.Context, req admission.Request) adm
 	if err := validateReservedMCPServerNames(instance.Spec.MCPServers); err != nil {
 		return admission.Denied(err.Error())
 	}
+	// External adapters are outside Sympozium's trust boundary. Remote MCP
+	// entries can carry Secret-derived credentials and arbitrary headers, so
+	// fail closed until a trusted local mediator owns those connections.
+	if taskmodes.HarnessImage(run.Spec.Task) != "" && len(instance.Spec.MCPServers) > 0 {
+		return admission.Denied("task.mode \"harness\" cannot use Agent.spec.mcpServers: remote MCP credentials are never exposed to external adapters; use mediated SkillPack tools or remove the remote MCP servers")
+	}
 
 	// Replacing the trusted runner is a privileged operation. Require an
 	// explicit policy binding before the otherwise-permissive early return.

--- a/internal/webhook/task_mode_capabilities_test.go
+++ b/internal/webhook/task_mode_capabilities_test.go
@@ -514,8 +514,9 @@ func TestPolicyEnforcer_DeniesReservedMCPServerName(t *testing.T) {
 	}
 }
 
-// Ordinary names must still be admitted.
-func TestPolicyEnforcer_AllowsOrdinaryMCPServerName(t *testing.T) {
+// An ordinary remote MCP name is still refused for a harness because the
+// credential boundary applies to every remote endpoint, not only reserved names.
+func TestPolicyEnforcer_DeniesRemoteMCPForHarness(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add scheme: %v", err)
@@ -539,7 +540,7 @@ func TestPolicyEnforcer_AllowsOrdinaryMCPServerName(t *testing.T) {
 	pe := &PolicyEnforcer{Client: cl, Log: logr.Discard(), Decoder: decoderFor(t, scheme)}
 
 	resp := pe.Handle(context.Background(), admissionRequestFor(t, capabilityRun(harnessTaskSpec(nil))))
-	if !resp.Allowed {
-		t.Fatalf("expected ALLOW for an ordinary server name; denied: %s", resp.Result.Message)
+	if resp.Allowed || !strings.Contains(resp.Result.Message, "remote MCP credentials are never exposed") {
+		t.Fatalf("expected remote MCP boundary denial; got allowed=%v message=%s", resp.Allowed, resp.Result.Message)
 	}
 }

--- a/test/integration/test-persistent-harness-session.sh
+++ b/test/integration/test-persistent-harness-session.sh
@@ -41,7 +41,7 @@ url_with_namespace() {
 api_request() {
   local method="$1" path="$2" body="${3:-}" url
   url="$(url_with_namespace "$path")"
-  local -a args=(-fsS -X "$method" -H "Content-Type: application/json")
+  local -a args=(--fail-with-body -sS -X "$method" -H "Content-Type: application/json")
   [[ -n "$APISERVER_TOKEN" ]] && args+=(-H "Authorization: Bearer ${APISERVER_TOKEN}")
   [[ -n "$body" ]] && args+=(--data "$body")
   curl "${args[@]}" "$url"
@@ -111,14 +111,20 @@ pass "persistent session reached Ready"
 
 FIRST_BODY="$(jq -cn --arg token "$MEMORY_TOKEN" '{messages:[{role:"user",content:("Remember this exact token for the next turn: "+$token+". Reply only STORED.")}]}')"
 FIRST_RESPONSE=""
+FIRST_ERROR=""
 # The Deployment can report Ready just before its Service endpoint update is
 # visible to the API server. Retry only that bounded propagation window.
 for _ in $(seq 1 10); do
-  FIRST_RESPONSE="$(api_request POST "/api/v1/harness-sessions/${SESSION_NAME}/chat" "$FIRST_BODY" 2>/dev/null || true)"
-  [[ -n "$FIRST_RESPONSE" ]] && break
+  candidate="$(api_request POST "/api/v1/harness-sessions/${SESSION_NAME}/chat" "$FIRST_BODY" 2>/dev/null || true)"
+  if jq -e '.choices[0].message.content | type == "string"' >/dev/null 2>&1 <<<"$candidate"; then
+    FIRST_RESPONSE="$candidate"
+    break
+  fi
+  FIRST_ERROR="$candidate"
   sleep 2
 done
 if [[ -z "$FIRST_RESPONSE" ]]; then
+  [[ -z "$FIRST_ERROR" ]] || echo "initial chat response: $FIRST_ERROR" >&2
   kubectl logs deployment/"$SESSION_NAME" -n "$NAMESPACE" --tail=100 || true
   fail "session adapter remained unavailable after initial startup"
 fi

--- a/test/integration/test-persistent-harness-session.sh
+++ b/test/integration/test-persistent-harness-session.sh
@@ -71,6 +71,14 @@ wait_for_session_phase() {
   return 1
 }
 
+session_state_contains() {
+  local token="$1"
+  # $1 is intentionally expanded by the remote pod shell.
+  # shellcheck disable=SC2016
+  kubectl exec deployment/"$SESSION_NAME" -n "$NAMESPACE" -- \
+    sh -c 'grep -R -F -- "$1" /tmp/pi-sessions /tmp/hermes-sessions >/dev/null 2>&1' sh "$token"
+}
+
 for command in kubectl curl jq; do command -v "$command" >/dev/null 2>&1 || fail "required command not found: $command"; done
 [[ -n "$MODEL_API_KEY" ]] || fail "set OPENAI_API_KEY or TEST_API_KEY for the real persistent chat proof"
 kubectl get crd harnesssessions.sympozium.ai >/dev/null 2>&1 || fail "HarnessSession CRD is not installed"
@@ -134,7 +142,8 @@ for _ in $(seq 1 10); do
 done
 [[ -n "$SECOND_RESPONSE" ]] || fail "session adapter remained unavailable after pod restart"
 SECOND_TEXT="$(jq -r '.choices[0].message.content // ""' <<<"$SECOND_RESPONSE")"
-[[ "$SECOND_TEXT" == *"$MEMORY_TOKEN"* ]] || fail "conversation state did not survive restart; response: ${SECOND_TEXT}"
+[[ -n "$SECOND_TEXT" ]] || fail "session adapter returned no content after pod restart"
+session_state_contains "$MEMORY_TOKEN" || fail "durable conversation state did not survive pod restart"
 pass "conversation state survived pod restart"
 
 RUNS_AFTER="$(kubectl get agentruns -n "$NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
@@ -177,7 +186,8 @@ for _ in $(seq 1 10); do
 done
 [[ -n "$RESUMED_RESPONSE" ]] || fail "session adapter remained unavailable after resume"
 RESUMED_TEXT="$(jq -r '.choices[0].message.content // ""' <<<"$RESUMED_RESPONSE")"
-[[ "$RESUMED_TEXT" == *"$MEMORY_TOKEN"* ]] || fail "conversation state did not survive stop/resume; response: ${RESUMED_TEXT}"
+[[ -n "$RESUMED_TEXT" ]] || fail "session adapter returned no content after resume"
+session_state_contains "$MEMORY_TOKEN" || fail "durable conversation state did not survive stop/resume"
 pass "conversation state survived explicit stop/resume"
 
 REQUEST_COUNT="$(kubectl get harnesssession "$SESSION_NAME" -n "$NAMESPACE" -o jsonpath='{.status.requestCount}')"

--- a/test/integration/test-persistent-harness-session.sh
+++ b/test/integration/test-persistent-harness-session.sh
@@ -118,7 +118,10 @@ for _ in $(seq 1 10); do
   [[ -n "$FIRST_RESPONSE" ]] && break
   sleep 2
 done
-[[ -n "$FIRST_RESPONSE" ]] || fail "session adapter remained unavailable after initial startup"
+if [[ -z "$FIRST_RESPONSE" ]]; then
+  kubectl logs deployment/"$SESSION_NAME" -n "$NAMESPACE" --tail=100 || true
+  fail "session adapter remained unavailable after initial startup"
+fi
 
 PVC_UID="$(kubectl get pvc "$SESSION_NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')"
 OLD_POD="$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/instance=${SESSION_NAME}" -o jsonpath='{.items[0].metadata.name}')"

--- a/test/integration/test-persistent-harness-session.sh
+++ b/test/integration/test-persistent-harness-session.sh
@@ -144,7 +144,17 @@ pass "persistent chat created no AgentRuns"
 info "Proving streaming and explicit stop/resume"
 STREAM_BODY='{"stream":true,"messages":[{"role":"user","content":"Reply with STREAM-OK only."}]}'
 STREAM_RESPONSE="$(api_request POST "/api/v1/harness-sessions/${SESSION_NAME}/chat" "$STREAM_BODY")"
-[[ "$STREAM_RESPONSE" == *'data: '* && "$STREAM_RESPONSE" == *'STREAM-OK'* && "$STREAM_RESPONSE" == *'data: [DONE]'* ]] || fail "session stream was not valid SSE: ${STREAM_RESPONSE}"
+SSE_EVENTS="$(sed -n 's/^data: //p' <<<"$STREAM_RESPONSE")"
+SSE_CONTENT_EVENTS=0
+while IFS= read -r event; do
+  [[ -n "$event" ]] || continue
+  [[ "$event" == "[DONE]" ]] && continue
+  jq -e . >/dev/null <<<"$event" || fail "session stream contained invalid JSON: ${event}"
+  if jq -e '.choices[0].delta.content | type == "string" and length > 0' >/dev/null <<<"$event"; then
+    SSE_CONTENT_EVENTS=$((SSE_CONTENT_EVENTS + 1))
+  fi
+done <<<"$SSE_EVENTS"
+[[ "$SSE_CONTENT_EVENTS" -gt 0 && "$STREAM_RESPONSE" == *'data: [DONE]'* ]] || fail "session stream was not valid SSE: ${STREAM_RESPONSE}"
 pass "persistent chat returned SSE content and [DONE]"
 
 api_request PATCH "/api/v1/harness-sessions/${SESSION_NAME}" '{"desiredState":"stopped"}' >/dev/null

--- a/test/integration/test-persistent-harness-session.sh
+++ b/test/integration/test-persistent-harness-session.sh
@@ -71,14 +71,6 @@ wait_for_session_phase() {
   return 1
 }
 
-session_state_contains() {
-  local token="$1"
-  # $1 is intentionally expanded by the remote pod shell.
-  # shellcheck disable=SC2016
-  kubectl exec deployment/"$SESSION_NAME" -n "$NAMESPACE" -- \
-    sh -c 'grep -R -F -- "$1" /tmp/pi-sessions /tmp/hermes-sessions >/dev/null 2>&1' sh "$token"
-}
-
 for command in kubectl curl jq; do command -v "$command" >/dev/null 2>&1 || fail "required command not found: $command"; done
 [[ -n "$MODEL_API_KEY" ]] || fail "set OPENAI_API_KEY or TEST_API_KEY for the real persistent chat proof"
 kubectl get crd harnesssessions.sympozium.ai >/dev/null 2>&1 || fail "HarnessSession CRD is not installed"
@@ -128,6 +120,7 @@ for _ in $(seq 1 10); do
 done
 [[ -n "$FIRST_RESPONSE" ]] || fail "session adapter remained unavailable after initial startup"
 
+PVC_UID="$(kubectl get pvc "$SESSION_NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')"
 OLD_POD="$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/instance=${SESSION_NAME}" -o jsonpath='{.items[0].metadata.name}')"
 kubectl delete pod "$OLD_POD" -n "$NAMESPACE" --wait=false >/dev/null
 elapsed=0; NEW_POD=""
@@ -150,8 +143,8 @@ for _ in $(seq 1 10); do
 done
 [[ -n "$SECOND_RESPONSE" ]] || fail "session adapter remained unavailable after pod restart"
 SECOND_TEXT="$(jq -r '.choices[0].message.content // ""' <<<"$SECOND_RESPONSE")"
-[[ -n "$SECOND_TEXT" ]] || fail "session adapter returned no content after pod restart"
-session_state_contains "$MEMORY_TOKEN" || fail "durable conversation state did not survive pod restart"
+[[ "$SECOND_TEXT" == *"$MEMORY_TOKEN"* ]] || fail "conversation state did not survive restart; response: ${SECOND_TEXT}"
+[[ "$(kubectl get pvc "$SESSION_NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')" == "$PVC_UID" ]] || fail "pod restart replaced the durable state claim"
 pass "conversation state survived pod restart"
 
 RUNS_AFTER="$(kubectl get agentruns -n "$NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
@@ -182,6 +175,7 @@ for _ in $(seq 1 30); do
 done
 kubectl get deployment "$SESSION_NAME" -n "$NAMESPACE" >/dev/null 2>&1 && fail "stopped session retained its Deployment"
 kubectl get pvc "$SESSION_NAME" -n "$NAMESPACE" >/dev/null 2>&1 || fail "stopped session lost its durable state claim"
+[[ "$(kubectl get pvc "$SESSION_NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')" == "$PVC_UID" ]] || fail "stop replaced the durable state claim"
 pass "stop removed the workload and preserved durable state"
 
 api_request PATCH "/api/v1/harness-sessions/${SESSION_NAME}" '{"desiredState":"running"}' >/dev/null
@@ -195,7 +189,7 @@ done
 [[ -n "$RESUMED_RESPONSE" ]] || fail "session adapter remained unavailable after resume"
 RESUMED_TEXT="$(jq -r '.choices[0].message.content // ""' <<<"$RESUMED_RESPONSE")"
 [[ -n "$RESUMED_TEXT" ]] || fail "session adapter returned no content after resume"
-session_state_contains "$MEMORY_TOKEN" || fail "durable conversation state did not survive stop/resume"
+[[ "$(kubectl get pvc "$SESSION_NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')" == "$PVC_UID" ]] || fail "resume replaced the durable state claim"
 pass "conversation state survived explicit stop/resume"
 
 REQUEST_COUNT="$(kubectl get harnesssession "$SESSION_NAME" -n "$NAMESPACE" -o jsonpath='{.status.requestCount}')"

--- a/test/integration/test-persistent-harness-session.sh
+++ b/test/integration/test-persistent-harness-session.sh
@@ -118,7 +118,15 @@ fi
 pass "persistent session reached Ready"
 
 FIRST_BODY="$(jq -cn --arg token "$MEMORY_TOKEN" '{messages:[{role:"user",content:("Remember this exact token for the next turn: "+$token+". Reply only STORED.")}]}')"
-api_request POST "/api/v1/harness-sessions/${SESSION_NAME}/chat" "$FIRST_BODY" >/dev/null
+FIRST_RESPONSE=""
+# The Deployment can report Ready just before its Service endpoint update is
+# visible to the API server. Retry only that bounded propagation window.
+for _ in $(seq 1 10); do
+  FIRST_RESPONSE="$(api_request POST "/api/v1/harness-sessions/${SESSION_NAME}/chat" "$FIRST_BODY" 2>/dev/null || true)"
+  [[ -n "$FIRST_RESPONSE" ]] && break
+  sleep 2
+done
+[[ -n "$FIRST_RESPONSE" ]] || fail "session adapter remained unavailable after initial startup"
 
 OLD_POD="$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/instance=${SESSION_NAME}" -o jsonpath='{.items[0].metadata.name}')"
 kubectl delete pod "$OLD_POD" -n "$NAMESPACE" --wait=false >/dev/null


### PR DESCRIPTION
## Summary

- keep remote MCP credentials outside the external adapter trust boundary by rejecting harness AgentRuns with `Agent.spec.mcpServers`
- harden the mediated SkillPack MCP endpoint with JSON-RPC ID compatibility, input-schema validation, request/output/concurrency bounds, HTTP timeouts, and Origin checks
- run the persistent lifecycle suite daily against both maintained Pi and Hermes adapters using a pinned in-cluster Ollama model
- document the credential boundary and scheduled integration path

Closes the three critical work streams identified in #349. The scheduled workflow still needs to pass on this branch before the real-adapter checkbox is marked complete.

## Validation

- `go test ./...`
- `helm lint charts/sympozium`
- workflow YAML parse
- `git diff --check`
