### PR TITLE
chore(harness): single-source Pi/Hermes example adapter versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ regenerates `config/crd/bases/` **and** syncs both chart copies
 drift (`make helm-sync-check`). Never hand-edit generated CRD YAML or
 `zz_generated.deepcopy.go`.
 
+## Updating the Pi/Hermes example adapter versions
+`charts/sympozium/values.yaml`'s `harnessExamples` block is the only file to
+edit for an adapter's name, image digest, or default enablement — the
+`--reuse-values` fallback dict in `charts/sympozium/templates/harness-examples.yaml`
+is generated from it. Run **`make helm-sync`** after editing it; `make
+helm-sync-check` (CI) fails if the two have drifted. Never hand-edit the block
+between the `sync-harness-defaults:begin`/`:end` markers.
+
 ## Naming — these renames recur as bugs
 - The CRD kind is **`Agent`** (formerly `SympoziumInstance` — do not use).
 - AgentRun/Schedule reference an agent via **`agentRef`** + **`agentId`** (not `instanceRef`/`agentID`).

--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,7 @@ db-migrate: ## Run database migrations
 
 ##@ Helm
 
-helm-sync: ## Sync CRDs and appVersion into the Helm charts
+helm-sync: ## Sync CRDs, appVersion, and generated defaults into the Helm charts
 	@echo "Syncing CRDs to charts/sympozium/crds/..."
 	@mkdir -p charts/sympozium/crds
 	cp config/crd/bases/*.yaml charts/sympozium/crds/
@@ -463,9 +463,11 @@ helm-sync: ## Sync CRDs and appVersion into the Helm charts
 	@mkdir -p charts/sympozium-crds/templates
 	@rm -f charts/sympozium-crds/templates/sympozium.ai_*.yaml
 	cp config/crd/bases/*.yaml charts/sympozium-crds/templates/
+	@echo "Syncing harness-examples.yaml reuse-values fallback from values.yaml..."
+	go run hack/sync-harness-defaults.go
 	@echo "Done."
 
-helm-sync-check: ## Check that Helm chart CRDs are in sync (CI use)
+helm-sync-check: ## Check that Helm charts are in sync (CI use)
 	@diff -qr config/crd/bases/ charts/sympozium/crds/ > /dev/null 2>&1 \
 		|| (echo "ERROR: Helm chart CRDs are out of sync. Run 'make helm-sync'" && exit 1)
 	@tmp=$$(mktemp -d); \
@@ -476,7 +478,17 @@ helm-sync-check: ## Check that Helm chart CRDs are in sync (CI use)
 		&& (echo "ERROR: sympozium-crds chart templates are out of sync. Run 'make helm-sync'" && rm -rf $$tmp && exit 1) \
 		|| true; \
 	rm -rf $$tmp
-	@echo "Helm chart CRDs are in sync."
+	@tmp=$$(mktemp); \
+	cp charts/sympozium/templates/harness-examples.yaml $$tmp; \
+	go run hack/sync-harness-defaults.go > /dev/null; \
+	if ! diff -q $$tmp charts/sympozium/templates/harness-examples.yaml > /dev/null; then \
+		echo "ERROR: harness-examples.yaml reuse-values fallback is out of sync with values.yaml. Run 'make helm-sync'"; \
+		cp $$tmp charts/sympozium/templates/harness-examples.yaml; \
+		rm -f $$tmp; \
+		exit 1; \
+	fi; \
+	rm -f $$tmp
+	@echo "Helm charts are in sync."
 
 helm-lint: ## Lint the Helm charts
 	helm lint charts/sympozium/

--- a/charts/sympozium/templates/harness-examples.yaml
+++ b/charts/sympozium/templates/harness-examples.yaml
@@ -1,8 +1,15 @@
 {{- /*
 Existing Helm releases upgraded with --reuse-values do not contain this new
-value block. Keep defaults here as well as values.yaml so those upgrades gain
-the catalog instead of failing on a nil map.
+value block. Keep a full fallback default here so those upgrades still gain
+the catalog, and so a partially-stale reused values object (missing only a
+newer adapter key) still falls back per-field instead of erroring.
+
+This block is generated from charts/sympozium/values.yaml's harnessExamples
+section — values.yaml is the only file to edit for an adapter name/image/
+enabled change. Run `make helm-sync` after editing it, and `make
+helm-sync-check` (part of CI) fails if this block has drifted.
 */}}
+{{/* sync-harness-defaults:begin */}}
 {{- $defaults := dict
   "enabled" true
   "policy" (dict "name" "harness-examples")
@@ -23,6 +30,7 @@ the catalog instead of failing on a nil map.
     "name" "hermes-session-v0-20-6"
     "image" "ghcr.io/sympozium-ai/harness-adapters/hermes@sha256:70c643b287b4a74583c7fedafd60e853579a36380a652a3d39ab0ae8c86e2d3b")
 }}
+{{/* sync-harness-defaults:end */}}
 {{- $examples := mergeOverwrite $defaults (default (dict) .Values.harnessExamples) }}
 {{- if $examples.enabled }}
 {{- if not (or $examples.pi.enabled $examples.piSession.enabled $examples.hermes.enabled $examples.hermesSession.enabled) }}

--- a/hack/sync-harness-defaults.go
+++ b/hack/sync-harness-defaults.go
@@ -1,0 +1,125 @@
+//go:build ignore
+
+// sync-harness-defaults regenerates the reuse-values fallback dict in
+// charts/sympozium/templates/harness-examples.yaml from the harnessExamples
+// section of charts/sympozium/values.yaml, which is the only file an operator
+// edits to change an example adapter's name, image, or default enablement.
+//
+// The fallback exists because a Helm release upgraded with --reuse-values can
+// carry an older, partially-stale values object that is missing this block
+// (or one of its adapter keys) entirely; the template still needs a literal
+// default to merge over. Keeping that literal in sync by hand is exactly the
+// kind of drift that caused a live runtime to be hand-patched outside Helm
+// (see git history around the hermes-session-v0-20-6 AgentRuntime), so it is
+// generated instead.
+//
+// Run via `make helm-sync`. `make helm-sync-check` (part of CI) fails the
+// build if this file's generated block does not match what's committed.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	valuesPath   = "charts/sympozium/values.yaml"
+	templatePath = "charts/sympozium/templates/harness-examples.yaml"
+	beginMarker  = "{{/* sync-harness-defaults:begin */}}\n"
+	endMarker    = "{{/* sync-harness-defaults:end */}}\n"
+)
+
+type adapter struct {
+	Enabled bool   `json:"enabled"`
+	Name    string `json:"name"`
+	Image   string `json:"image"`
+}
+
+type harnessExamples struct {
+	Enabled bool `json:"enabled"`
+	Policy  struct {
+		Name string `json:"name"`
+	} `json:"policy"`
+	Pi            adapter `json:"pi"`
+	PiSession     adapter `json:"piSession"`
+	Hermes        adapter `json:"hermes"`
+	HermesSession adapter `json:"hermesSession"`
+}
+
+type values struct {
+	HarnessExamples harnessExamples `json:"harnessExamples"`
+}
+
+func main() {
+	raw, err := os.ReadFile(valuesPath)
+	if err != nil {
+		fatalf("read %s: %v", valuesPath, err)
+	}
+	var v values
+	if err := yaml.Unmarshal(raw, &v); err != nil {
+		fatalf("parse %s: %v", valuesPath, err)
+	}
+
+	block := renderBlock(v.HarnessExamples)
+
+	template, err := os.ReadFile(templatePath)
+	if err != nil {
+		fatalf("read %s: %v", templatePath, err)
+	}
+	updated, err := replaceBetweenMarkers(string(template), block)
+	if err != nil {
+		fatalf("%s: %v", templatePath, err)
+	}
+	if err := os.WriteFile(templatePath, []byte(updated), 0o644); err != nil {
+		fatalf("write %s: %v", templatePath, err)
+	}
+}
+
+func renderBlock(h harnessExamples) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, `{{- $defaults := dict`)
+	fmt.Fprintf(&b, "  %q %t\n", "enabled", h.Enabled)
+	fmt.Fprintf(&b, "  %q (dict %q %q)\n", "policy", "name", h.Policy.Name)
+	renderAdapter(&b, "pi", h.Pi)
+	renderAdapter(&b, "piSession", h.PiSession)
+	renderAdapter(&b, "hermes", h.Hermes)
+	renderAdapter(&b, "hermesSession", h.HermesSession, true)
+	fmt.Fprintln(&b, `}}`)
+	return b.String()
+}
+
+func renderAdapter(b *strings.Builder, key string, a adapter, last ...bool) {
+	fmt.Fprintf(b, "  %q (dict\n", key)
+	fmt.Fprintf(b, "    %q %t\n", "enabled", a.Enabled)
+	fmt.Fprintf(b, "    %q %q\n", "name", a.Name)
+	close := ")"
+	fmt.Fprintf(b, "    %q %q%s\n", "image", a.Image, close)
+}
+
+func replaceBetweenMarkers(content, block string) (string, error) {
+	beginIdx := strings.Index(content, beginMarker)
+	if beginIdx == -1 {
+		return "", fmt.Errorf("missing %q marker", strings.TrimSpace(beginMarker))
+	}
+	bodyStart := beginIdx + len(beginMarker)
+	endIdx := strings.Index(content[bodyStart:], endMarker)
+	if endIdx == -1 {
+		return "", fmt.Errorf("missing %q marker", strings.TrimSpace(endMarker))
+	}
+	endIdx += bodyStart
+
+	var out bytes.Buffer
+	out.WriteString(content[:bodyStart])
+	out.WriteString(block)
+	out.WriteString(content[endIdx:])
+	return out.String(), nil
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "sync-harness-defaults: "+format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

`charts/sympozium/values.yaml`'s `harnessExamples` block and the reuse-values fallback dict in `templates/harness-examples.yaml` carried the same four adapter name/image/enabled triples by hand. That's the exact class of drift that led to a live `hermes-session-v0-20-6` AgentRuntime being hand-patched outside Helm during the persistent-harness rollout (#392), rather than through a `values.yaml` change and a normal release.

`values.yaml` is now the only file to edit for a Pi/Hermes adapter name, image digest, or default-enabled change.

- `hack/sync-harness-defaults.go` regenerates the reuse-values fallback dict in `templates/harness-examples.yaml` between explicit markers, reading `values.yaml`'s `harnessExamples` section.
- `make helm-sync` runs it. `make helm-sync-check` (the same CI gate that already catches CRD chart-copy drift) now also fails if this block has drifted from `values.yaml`.
- `CLAUDE.md` documents the rule next to the existing CRD-sync instructions.

I first tried having the template read `values.yaml` directly at render time via `.Files.Get`, since that would need no generator at all. Helm deliberately excludes `values.yaml` from `.Files`, and that attempt silently rendered zero resources for the reuse-values fallback path instead of erroring. Caught it by testing that exact scenario before it landed anywhere, and reverted in favor of the generator approach, which mirrors how this repo already handles CRDs.

While writing the check I also found a bug in my own first draft: an `exit 1` nested inside a subshell wasn't propagating to the Make recipe, so the check printed an error but still reported success (exit 0). Fixed and verified the check now genuinely fails `make` on drift.

## Validation

- Regenerating from the current `values.yaml` reproduces the committed template byte-for-byte.
- `make helm-sync-check` fails when `values.yaml` is edited without running `make helm-sync`, and passes once it's run.
- Both reuse-values fallback shapes still render correctly: the whole `harnessExamples` key absent, and a partial override missing just one adapter key (verified the deep-merge per-field fallback is preserved, not just the top-level case).
- `helm lint charts/sympozium`, `go build ./...`, `go vet ./...`, `gofmt` all clean.

## Note

While debugging, I noticed the CRD chart-template drift check just above this one in `helm-sync-check` has the same swallowed-`exit 1` pattern my first draft had, so it likely doesn't fail CI on drift either. Left it alone as out of scope for this PR, flagging it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHCLvEDSPNHvu1jb4TyQqL
