### PR TITLE
fix(helm): suspend postgres MCP server by default

### DIFF
--- a/charts/sympozium/files/mcp-servers/postgres.yaml
+++ b/charts/sympozium/files/mcp-servers/postgres.yaml
@@ -8,6 +8,8 @@ metadata:
     sympozium.ai/catalog: "true"
 spec:
   transportType: stdio
+  # DATABASE_URI is operator-provided; do not start the server until it is configured.
+  suspended: true
   toolsPrefix: pg
   timeout: 60
   toolsDeny:

--- a/internal/helmchart/helmchart_test.go
+++ b/internal/helmchart/helmchart_test.go
@@ -1,0 +1,63 @@
+package helmchart
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/engine"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func TestDefaultPostgresMCPServerStartsSuspended(t *testing.T) {
+	ch, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	values, err := chartutil.ToRenderValues(ch, map[string]any{}, chartutil.ReleaseOptions{
+		Name:      "sympozium",
+		Namespace: "test-system",
+		IsInstall: true,
+	}, chartutil.DefaultCapabilities)
+	if err != nil {
+		t.Fatalf("ToRenderValues() error = %v", err)
+	}
+
+	rendered, err := engine.Render(ch, values)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	manifest, ok := rendered["sympozium/templates/default-mcp-servers.yaml"]
+	if !ok {
+		t.Fatal("default MCP server manifest was not rendered")
+	}
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+	for {
+		var object struct {
+			Kind     string `json:"kind"`
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Suspended bool `json:"suspended"`
+			} `json:"spec"`
+		}
+		if err := decoder.Decode(&object); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("decode rendered manifest: %v", err)
+		}
+		if object.Kind == "MCPServer" && object.Metadata.Name == "postgres" {
+			if !object.Spec.Suspended {
+				t.Fatal("default postgres MCPServer must be suspended until DATABASE_URI is configured")
+			}
+			return
+		}
+	}
+
+	t.Fatal("rendered chart does not contain the default postgres MCPServer")
+}


### PR DESCRIPTION
## Summary

- suspend the default PostgreSQL MCPServer until its operator-provided `DATABASE_URI` is configured
- add a regression test that loads and renders the embedded Helm chart and verifies the PostgreSQL MCPServer is suspended

After configuring the `mcp-postgres-token` secret, operators can explicitly set `spec.suspended` to `false` to start the server.

## Testing

- `make fmt`
- `make vet`
- `make test`
- `go build ./...`
- `helm lint charts/sympozium/`
- rendered `templates/default-mcp-servers.yaml` and verified `postgres.spec.suspended: true`

## AI assistance

This contribution was developed with AI assistance. The final diff was independently reviewed and all listed checks were run locally.

Fixes #397
