### PR TITLE
Authenticate Celln controller dispatch and polling

### DIFF
--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -127,6 +127,12 @@ spec:
             {{- if .Values.celln.enabled }}
             - name: CELLN_ROUTER_URL
               value: {{ .Values.celln.routerUrl | quote }}
+            - name: CELLN_ALLOW_INSECURE_HTTP
+              value: {{ .Values.celln.allowInsecureHttp | quote }}
+            {{- if .Values.celln.tokenSecret }}
+            - name: CELLN_TOKEN_FILE
+              value: /etc/sympozium/celln/token
+            {{- end }}
             {{- end }}
             {{- if .Values.pricing.enabled }}
             - name: SYMPOZIUM_PRICING_CONFIGMAP
@@ -157,6 +163,21 @@ spec:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- if and .Values.celln.enabled .Values.celln.tokenSecret }}
+          volumeMounts:
+            - name: celln-token
+              mountPath: /etc/sympozium/celln
+              readOnly: true
+          {{- end }}
+      {{- if and .Values.celln.enabled .Values.celln.tokenSecret }}
+      volumes:
+        - name: celln-token
+          secret:
+            secretName: {{ .Values.celln.tokenSecret | quote }}
+            items:
+              - key: token
+                path: token
+      {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -449,6 +449,13 @@ celln:
   enabled: true
   # -- URL of the celln-router Service. The controller POSTs here.
   routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
+  # -- Existing Secret in the controller namespace, key `token`, containing
+  # the dispatcher's bearer credential (at least 24 bytes). No token is generated
+  # or inferred from model credentials. Missing configuration refuses dispatch.
+  tokenSecret: ""
+  # -- Explicitly permit a plaintext non-loopback router URL. Prefer an HTTPS
+  # endpoint; cluster networking alone does not encrypt the bearer credential.
+  allowInsecureHttp: false
   # -- API key for your chosen LLM provider. Set ONE of these.
   # The key file is mounted at /etc/celln/agent-key on the host dispatcher.
   # If none are set, the dispatcher will use auto-discovery (ollama) or

--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -31,6 +31,25 @@ spec:
 
 ## How It Works
 
+### Dispatcher authentication
+
+The controller requires `CELLN_TOKEN_FILE`, an operator-provisioned file
+containing the Celln bearer credential (at least 24 bytes). This is distinct
+from model-provider credentials and is never read from AgentRun task text.
+The file is re-read for each POST/GET so mounted Secret rotation takes effect.
+Redirects are refused rather than forwarding credentials or changing methods.
+
+With Helm, create the Secret in the **controller namespace** with key `token`
+and set `celln.tokenSecret` to its name. The token must match the selected
+dispatcher/router's configured credential. Prefer an HTTPS `celln.routerUrl`;
+non-loopback plaintext requires explicit `celln.allowInsecureHttp: true` (or
+`CELLN_ALLOW_INSECURE_HTTP=true` outside Helm). This opt-in does not encrypt
+traffic. Missing or invalid credentials refuse dispatch without backend fallback.
+
+These settings configure the controller client; they do not distribute a
+credential to host dispatchers or make legacy installer images compatible.
+Operators must configure both ends deliberately.
+
 ```
 AgentRun (backend: celln)
   │

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -87,8 +87,6 @@ func cellnActionID(agentRun *sympoziumv1alpha1.AgentRun) string {
 	return agentRun.Name + "-" + string(agentRun.UID)
 }
 
-var cellnHTTPClient = &http.Client{Timeout: 30 * time.Second}
-
 // executionRequest mirrors celln.dev/v1alpha1's ExecutionRequest, forge
 // variant only. Field names/JSON tags must match crates/celln-spec exactly.
 type executionRequest struct {
@@ -161,7 +159,6 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 ) (ctrl.Result, error) {
 	log.Info("Dispatching AgentRun to Celln backend")
 
-	routerURL := cellnRouterURL()
 	task := agentRun.Spec.Task.GetPrompt()
 	if task == "" {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln backend requires a string-form task")
@@ -193,8 +190,7 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Celln: marshal execution request: %v", err))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		routerURL+"/v1/executions", bytes.NewReader(body))
+	req, err := cellnRequest(ctx, http.MethodPost, "/v1/executions", bytes.NewReader(body))
 	if err != nil {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Celln: build request: %v", err))
 	}
@@ -202,7 +198,7 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 
 	resp, err := cellnHTTPClient.Do(req)
 	if err != nil {
-		log.Error(err, "Celln router unreachable", "url", routerURL)
+		log.Error(err, "Celln router unreachable")
 		// Return a nil error so controller-runtime honors RequeueAfter as a
 		// fixed 10s retry cadence, rather than routing through its own
 		// rate-limited workqueue backoff (which ignores Result when err != nil
@@ -241,7 +237,6 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 	log logr.Logger,
 	agentRun *sympoziumv1alpha1.AgentRun,
 ) (ctrl.Result, error) {
-	routerURL := cellnRouterURL()
 	actionID := agentRun.Status.CellnActionID
 	if actionID == "" {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln execution ID missing from status")
@@ -263,15 +258,14 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		routerURL+"/v1/executions/"+actionID, nil)
+	req, err := cellnRequest(ctx, http.MethodGet, "/v1/executions/"+actionID, nil)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	resp, err := cellnHTTPClient.Do(req)
 	if err != nil {
-		log.Error(err, "Celln router unreachable during poll", "url", routerURL)
+		log.Error(err, "Celln router unreachable during poll")
 		// nil error so controller-runtime honors RequeueAfter as a fixed 10s
 		// retry cadence instead of its own workqueue backoff (see the
 		// matching comment in reconcilePendingCelln).

--- a/internal/controller/agentrun_celln_test.go
+++ b/internal/controller/agentrun_celln_test.go
@@ -20,7 +20,9 @@ import (
 
 // newTestCellnRun builds a minimal AgentRun suitable for driving
 // reconcilePendingCelln / reconcileRunningCelln directly.
-func newTestCellnRun(name string, uid types.UID) *sympoziumv1alpha1.AgentRun {
+func newTestCellnRun(t *testing.T, name string, uid types.UID) *sympoziumv1alpha1.AgentRun {
+	t.Helper()
+	configureCellnToken(t)
 	return &sympoziumv1alpha1.AgentRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -44,7 +46,7 @@ func TestReconcilePendingCelln_ActionIDUniquePerUID(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)
 
-	runA := newTestCellnRun("dup-name", types.UID("uid-aaaa"))
+	runA := newTestCellnRun(t, "dup-name", types.UID("uid-aaaa"))
 	rA := newAgentRunTestReconciler(t, runA)
 	if _, err := rA.reconcilePendingCelln(context.Background(), logr.Discard(), runA); err != nil {
 		t.Fatalf("reconcilePendingCelln (run A): %v", err)
@@ -54,7 +56,7 @@ func TestReconcilePendingCelln_ActionIDUniquePerUID(t *testing.T) {
 		t.Fatalf("get stored run A: %v", err)
 	}
 
-	runB := newTestCellnRun("dup-name", types.UID("uid-bbbb"))
+	runB := newTestCellnRun(t, "dup-name", types.UID("uid-bbbb"))
 	rB := newAgentRunTestReconciler(t, runB)
 	if _, err := rB.reconcilePendingCelln(context.Background(), logr.Discard(), runB); err != nil {
 		t.Fatalf("reconcilePendingCelln (run B): %v", err)
@@ -88,7 +90,7 @@ func TestReconcileRunningCelln_DeadlineExceeded_FailsRun(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)
 
-	run := newTestCellnRun("wedged-run", types.UID("uid-cccc"))
+	run := newTestCellnRun(t, "wedged-run", types.UID("uid-cccc"))
 	run.Spec.Timeout = &metav1.Duration{Duration: 10 * time.Second}
 	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
 	run.Status.CellnActionID = "wedged-run-uid-cccc"
@@ -123,7 +125,7 @@ func TestReconcilePendingCelln_RouterUnreachable_RequeuesWithoutError(t *testing
 	// without any real network I/O, so this fails fast and deterministically.
 	t.Setenv("CELLN_ROUTER_URL", "http://127.0.0.1:1")
 
-	run := newTestCellnRun("unreachable-run", types.UID("uid-dddd"))
+	run := newTestCellnRun(t, "unreachable-run", types.UID("uid-dddd"))
 	r := newAgentRunTestReconciler(t, run)
 
 	result, err := r.reconcilePendingCelln(context.Background(), logr.Discard(), run)
@@ -138,7 +140,7 @@ func TestReconcilePendingCelln_RouterUnreachable_RequeuesWithoutError(t *testing
 func TestReconcileRunningCelln_RouterUnreachable_RequeuesWithoutError(t *testing.T) {
 	t.Setenv("CELLN_ROUTER_URL", "http://127.0.0.1:1")
 
-	run := newTestCellnRun("unreachable-poll-run", types.UID("uid-eeee"))
+	run := newTestCellnRun(t, "unreachable-poll-run", types.UID("uid-eeee"))
 	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
 	run.Status.CellnActionID = "unreachable-poll-run-uid-eeee"
 	started := metav1.NewTime(time.Now())
@@ -169,7 +171,7 @@ func TestReconcilePendingCelln_PostsAWellFormedForgeExecutionRequest(t *testing.
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)
 
-	run := newTestCellnRun("well-formed", types.UID("uid-ffff"))
+	run := newTestCellnRun(t, "well-formed", types.UID("uid-ffff"))
 	run.Spec.Task = sympoziumv1alpha1.NewStringTask("write a haiku generator")
 	run.Spec.Timeout = &metav1.Duration{Duration: 45 * time.Second}
 
@@ -222,7 +224,7 @@ func TestReconcileRunningCelln_SucceededSetsResultFromExecutionRecordOutput(t *t
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)
 
-	run := newTestCellnRun("succeeded-run", types.UID("uid-9999"))
+	run := newTestCellnRun(t, "succeeded-run", types.UID("uid-9999"))
 	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
 	run.Status.CellnActionID = "succeeded-run-uid-9999"
 	started := metav1.NewTime(time.Now())

--- a/internal/controller/celln_transport.go
+++ b/internal/controller/celln_transport.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Credentials belong to controller deployment configuration, never AgentRun
+// task text. Read the mounted file for every call so rotation takes effect.
+func cellnRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	base, err := url.Parse(cellnRouterURL())
+	if err != nil || base.Host == "" || base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+		return nil, fmt.Errorf("Celln: invalid router URL")
+	}
+	loopback := base.Hostname() == "localhost"
+	if ip := net.ParseIP(base.Hostname()); ip != nil {
+		loopback = ip.IsLoopback()
+	}
+	if base.Scheme != "https" && !(base.Scheme == "http" && (loopback || os.Getenv("CELLN_ALLOW_INSECURE_HTTP") == "true")) {
+		return nil, fmt.Errorf("Celln: router requires HTTPS; plaintext non-loopback requires CELLN_ALLOW_INSECURE_HTTP=true")
+	}
+	filename := os.Getenv("CELLN_TOKEN_FILE")
+	if filename == "" {
+		return nil, fmt.Errorf("Celln: CELLN_TOKEN_FILE must name an operator-provisioned credential")
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("Celln: cannot read dispatcher credential")
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, 4097))
+	token := strings.TrimSpace(string(data))
+	if err != nil || len(data) > 4096 || len(token) < 24 || strings.ContainsAny(token, "\r\n\t ") {
+		return nil, fmt.Errorf("Celln: invalid dispatcher credential")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(base.String(), "/")+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("Celln: cannot build dispatcher request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// Never follow redirects with a credential or reinterpret a redirected POST as
+// GET. A moved service needs an explicit operator configuration update.
+var cellnHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}

--- a/internal/controller/celln_transport_test.go
+++ b/internal/controller/celln_transport_test.go
@@ -1,0 +1,90 @@
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testCellnToken = "isolated-test-credential-at-least-24-bytes"
+
+func configureCellnToken(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte(testCellnToken), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CELLN_TOKEN_FILE", path)
+	return path
+}
+
+func TestCellnTransportAuthenticationAndRotation(t *testing.T) {
+	path := configureCellnToken(t)
+	t.Setenv("CELLN_ROUTER_URL", "http://127.0.0.1:8787")
+	for _, token := range []string{testCellnToken, testCellnToken + "-rotated"} {
+		if err := os.WriteFile(path, []byte(token+"\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		for _, method := range []string{http.MethodPost, http.MethodGet} {
+			req, err := cellnRequest(context.Background(), method, "/v1/executions", nil)
+			if err != nil || req.Header.Get("Authorization") != "Bearer "+token {
+				t.Fatalf("credential missing or stale: %v", err)
+			}
+		}
+	}
+}
+
+func TestCellnTransportRefusesUnsafeConfiguration(t *testing.T) {
+	path := configureCellnToken(t)
+	t.Setenv("CELLN_ALLOW_INSECURE_HTTP", "")
+	for _, u := range []string{"http://example.com", "https://user:password@example.com", "file:///tmp/socket", "https://example.com?token=secret"} {
+		t.Setenv("CELLN_ROUTER_URL", u)
+		if _, err := cellnRequest(context.Background(), "GET", "/v1/node", nil); err == nil {
+			t.Fatalf("accepted unsafe URL %s", u)
+		}
+	}
+	t.Setenv("CELLN_ROUTER_URL", "https://example.com")
+	for _, token := range []string{"", "short", testCellnToken + "\r\nInjected: yes", strings.Repeat("x", 4097)} {
+		if err := os.WriteFile(path, []byte(token), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cellnRequest(context.Background(), "GET", "/v1/node", nil); err == nil {
+			t.Fatal("accepted invalid credential")
+		}
+	}
+	t.Setenv("CELLN_TOKEN_FILE", "")
+	if _, err := cellnRequest(context.Background(), "GET", "/v1/node", nil); err == nil {
+		t.Fatal("accepted missing credential configuration")
+	}
+}
+
+func TestCellnTransportDoesNotFollowRedirects(t *testing.T) {
+	configureCellnToken(t)
+	called := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer target.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+testCellnToken {
+			t.Error("missing authentication")
+		}
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+	t.Setenv("CELLN_ROUTER_URL", source.URL)
+	req, err := cellnRequest(context.Background(), "POST", "/v1/executions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := cellnHTTPClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if called || resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatal("followed redirect")
+	}
+}


### PR DESCRIPTION
## Summary

Advances https://github.com/sympozium-ai/celln/issues/2. The Celln dispatcher requires authentication, but the controller previously sent no bearer token.

- Require an operator-mounted CELLN_TOKEN_FILE; re-read for rotation and bound/validate its contents without logging credentials.
- Authenticate both dispatch and polling; refuse redirects and unsafe URLs. HTTPS is required outside loopback unless explicitly opting into plaintext.
- Add Helm existing-Secret wiring and transport guidance, without distributing credentials to hosts or claiming legacy image compatibility.

## Verification

- `go test ./internal/controller -run Celln -count=1`
- `go test -race ./internal/controller -run Celln -count=1`
- Helm controller template rendered with existing Secret and explicit plaintext opt-in.
- `git diff --check`

Pinned static requests, complete receipt validation/persistence, remote cancellation, and the fresh real-controller acceptance run follow separately. No existing cluster or user's original worktree was changed.
