### PR TITLE
Wait for Celln teardown before deadline and deletion completion

### DIFF
--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -95,6 +95,14 @@ immutable output reference, not that mutable text, as an artifact identity.
 
 This does not add whole-agent, sidecar, shared-memory or ensemble execution.
 
+Deleting a dispatched AgentRun requests authenticated remote cancellation.
+The controller retains its finalizer while Celln returns `202 Cancelling` or
+cannot be reached; acknowledgement is not proof of teardown. Its deadline
+backstop also cancels remotely and waits for a terminal record before failing
+the run. Terminal status set by another controller does not bypass this cleanup.
+This relies on the configured dispatcher's execution registry; it is not
+distributed failover or recovery of a lost registry after a dispatcher crash.
+
 ## Enabling / Disabling Celln
 
 ```bash

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -310,6 +310,14 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 		deadline := cellnEffectiveTimeout(agentRun) + cellnDeadlineSlack
 		if elapsed := time.Since(agentRun.Status.StartedAt.Time); elapsed > deadline {
 			log.Info("Celln backend deadline exceeded", "elapsed", elapsed, "deadline", deadline)
+			done, err := r.cancelCelln(ctx, agentRun)
+			if err != nil {
+				log.Error(err, "Celln deadline cleanup pending")
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			}
+			if !done {
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
 			return ctrl.Result{}, r.failRun(ctx, agentRun,
 				fmt.Sprintf("Celln backend deadline exceeded: no terminal status after %s (deadline %s)", elapsed.Round(time.Second), deadline))
 		}

--- a/internal/controller/agentrun_celln_test.go
+++ b/internal/controller/agentrun_celln_test.go
@@ -85,7 +85,10 @@ func TestReconcilePendingCelln_ActionIDUniquePerUID(t *testing.T) {
 
 func TestReconcileRunningCelln_DeadlineExceeded_FailsRun(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(executionRecord{RequestID: "whatever", Phase: "Running"})
+		if r.Method != "POST" || r.URL.Path != "/v1/executions/wedged-run-uid-cccc/cancel" {
+			t.Error("deadline did not cancel remotely")
+		}
+		_ = json.NewEncoder(w).Encode(executionRecord{RequestID: "wedged-run-uid-cccc", Phase: "Cancelled"})
 	}))
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1110,6 +1110,15 @@ func (r *AgentRunReconciler) checkAgentContainer(ctx context.Context, log logr.L
 // Instead of deleting immediately, it keeps up to RunHistoryLimit completed
 // runs per instance and prunes only the oldest ones beyond that threshold.
 func (r *AgentRunReconciler) reconcileCompleted(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (ctrl.Result, error) {
+	if agentRun.Status.CellnActionID != "" && controllerutil.ContainsFinalizer(agentRun, agentRunFinalizer) {
+		done, err := r.cancelCelln(ctx, agentRun)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		if !done {
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		}
+	}
 	// Clean up cluster-scoped RBAC created for skill sidecars.
 	r.cleanupSkillRBAC(ctx, log, agentRun)
 
@@ -1885,6 +1894,16 @@ func (r *AgentRunReconciler) pruneOldRuns(ctx context.Context, log logr.Logger, 
 // reconcileDelete handles AgentRun deletion.
 func (r *AgentRunReconciler) reconcileDelete(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (ctrl.Result, error) {
 	log.Info("Reconciling AgentRun deletion")
+	if agentRun.Status.CellnActionID != "" {
+		done, err := r.cancelCelln(ctx, agentRun)
+		if err != nil {
+			log.Error(err, "Celln deletion cleanup pending")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		if !done {
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		}
+	}
 
 	// Clean up cluster-scoped RBAC resources created for skill sidecars.
 	r.cleanupSkillRBAC(ctx, log, agentRun)

--- a/internal/controller/celln_cancel.go
+++ b/internal/controller/celln_cancel.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// Acknowledging cancellation is not teardown. Keep reconciling (and retain
+// the Kubernetes finalizer) until Celln reports a terminal execution. This
+// also cancels work when another controller marks an AgentRun failed.
+func (r *AgentRunReconciler) cancelCelln(ctx context.Context, run *sympoziumv1alpha1.AgentRun) (bool, error) {
+	id := run.Status.CellnActionID
+	if id == "" {
+		return true, nil
+	}
+	if id != cellnActionID(run) {
+		return false, fmt.Errorf("Celln: cancellation identity mismatch")
+	}
+	req, err := cellnRequest(ctx, http.MethodPost, "/v1/executions/"+id+"/cancel", nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := cellnHTTPClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusAccepted {
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("Celln: cancellation refused (HTTP %d)", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 262145))
+	if err != nil || len(body) > 262144 {
+		return false, fmt.Errorf("Celln: invalid cancellation response size")
+	}
+	var record executionRecord
+	d := json.NewDecoder(bytes.NewReader(body))
+	d.DisallowUnknownFields()
+	if d.Decode(&record) != nil || d.Decode(new(any)) != io.EOF || record.RequestID != id || !slices.Contains([]string{"Succeeded", "Failed", "Refused", "Cancelled"}, record.Phase) {
+		return false, fmt.Errorf("Celln: cancellation has no correlated terminal record")
+	}
+	if record.Receipt != nil {
+		if err := validateCellnReceipt(run, record); err != nil {
+			return false, err
+		}
+		encoded, _ := json.Marshal(record.Receipt)
+		if err := r.updateStatusWithRetry(ctx, run, func(ar *sympoziumv1alpha1.AgentRun) { ar.Status.CellnReceipt = string(encoded) }); err != nil {
+			return false, err
+		}
+	} else if record.Phase == "Succeeded" {
+		return false, fmt.Errorf("Celln: success without receipt during cancellation")
+	}
+	return true, nil
+}

--- a/internal/controller/celln_cancel_test.go
+++ b/internal/controller/celln_cancel_test.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestCellnCancellationWaitsForTeardown(t *testing.T) {
+	run := newTestCellnRun(t, "cancel", "uid")
+	run.Status.CellnActionID = cellnActionID(run)
+	run.Finalizers = []string{agentRunFinalizer}
+	status := http.StatusAccepted
+	phase := "Cancelling"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != "POST" || req.URL.Path != "/v1/executions/"+cellnActionID(run)+"/cancel" || req.Header.Get("Authorization") != "Bearer "+testCellnToken {
+			t.Error("incorrect cancellation request")
+		}
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(executionRecord{RequestID: cellnActionID(run), Phase: phase})
+	}))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+	r := newAgentRunTestReconciler(t, run)
+	for _, code := range []int{http.StatusAccepted, http.StatusUnauthorized, http.StatusServiceUnavailable} {
+		status = code
+		result, err := r.reconcileDelete(context.Background(), logr.Discard(), run)
+		if err != nil || result.RequeueAfter == 0 {
+			t.Fatalf("cleanup did not retry HTTP %d: %+v %v", code, result, err)
+		}
+		var stored sympoziumv1alpha1.AgentRun
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &stored); err != nil {
+			t.Fatal(err)
+		}
+		if !controllerutil.ContainsFinalizer(&stored, agentRunFinalizer) {
+			t.Fatal("removed finalizer before remote teardown")
+		}
+	}
+	status = http.StatusOK
+	if done, err := r.cancelCelln(context.Background(), run); done || err == nil {
+		t.Fatal("accepted nonterminal 200")
+	}
+	phase = "Cancelled"
+	if done, err := r.cancelCelln(context.Background(), run); !done || err != nil {
+		t.Fatalf("terminal cancellation: %v %v", done, err)
+	}
+	phase = "Succeeded"
+	if done, err := r.cancelCelln(context.Background(), run); done || err == nil {
+		t.Fatal("accepted success without receipt")
+	}
+}
+
+func TestCellnDeadlineDoesNotFinishWhileCleanupPending(t *testing.T) {
+	run := newTestCellnRun(t, "deadline-pending", "uid")
+	run.Status.CellnActionID = cellnActionID(run)
+	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
+	started := metav1.NewTime(time.Now().Add(-time.Hour))
+	run.Status.StartedAt = &started
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusAccepted) }))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+	r := newAgentRunTestReconciler(t, run)
+	result, err := r.reconcileRunningCelln(context.Background(), logr.Discard(), run)
+	if err != nil || result.RequeueAfter == 0 {
+		t.Fatalf("did not wait: %+v %v", result, err)
+	}
+	var stored sympoziumv1alpha1.AgentRun
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status.Phase != sympoziumv1alpha1.AgentRunPhaseRunning {
+		t.Fatal("reported completion before teardown")
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #422. Advances https://github.com/sympozium-ai/celln/issues/2.

Request authenticated remote cancellation on AgentRun deletion, controller deadline, and finalization after externally set terminal status. Keep the finalizer/requeue while cancellation is merely acknowledged (202) or the service cannot be reached. Require a correlated terminal record and validate/persist any receipt before treating cleanup as complete.

## Verification

- `go test -race ./internal/controller ./api/v1alpha1`
- Tests cover deadline-triggered remote cancellation, pending teardown, retained finalizers on 202/401/503, nonterminal 200, and missing success receipts.
- `git diff --check`

This is one-dispatcher lifecycle coordination, not recovery of a lost execution registry or distributed failover. Fresh real-controller/KVM acceptance follows.
