### PR TITLE
Prove production Sympozium-to-Celln execution on real KVM

### DIFF
--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -95,6 +95,14 @@ immutable output reference, not that mutable text, as an artifact identity.
 
 This does not add whole-agent, sidecar, shared-memory or ensemble execution.
 
+Deleting a dispatched AgentRun requests authenticated remote cancellation.
+The controller retains its finalizer while Celln returns `202 Cancelling` or
+cannot be reached; acknowledgement is not proof of teardown. Its deadline
+backstop also cancels remotely and waits for a terminal record before failing
+the run. Terminal status set by another controller does not bypass this cleanup.
+This relies on the configured dispatcher's execution registry; it is not
+distributed failover or recovery of a lost registry after a dispatcher crash.
+
 ## Enabling / Disabling Celln
 
 ```bash

--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -53,16 +53,16 @@ Operators must configure both ends deliberately.
 ```
 AgentRun (backend: celln)
   │
-  ├─ Controller POSTs {id, task, timeout} to CELLN_ROUTER_URL
+  ├─ Controller POSTs a celln.dev/v1alpha1 ExecutionRequest to CELLN_ROUTER_URL
   │   (celln-router.celln-system.svc.cluster.local:8787)
   │
   ├─ Router (one pod per KVM node) forwards to the host-level
   │   celln dispatcher — a systemd service on that node, installed
   │   by the celln-installer DaemonSet
   │
-  └─ Dispatcher asks its configured AI provider to write a program,
-     attests and seals it into a real KVM cell, runs it, and returns
-     the bounded output. status.cellnActionId tracks the poll.
+  └─ Dispatcher verifies the pinned program (or forges one for task-only
+     requests), seals a KVM cell from a warm mote, runs it, and returns
+     a receipt plus bounded display output. status.cellnActionId tracks the poll.
 ```
 
 The installer and router only schedule onto nodes labeled `celln.dev/kvm: "true"` — Celln needs `/dev/kvm` and is not a container-level isolation mechanism, so it can't run on arbitrary nodes the way the `job` backend can.
@@ -112,14 +112,14 @@ sympozium install --enable-hermetic-workloads
 ```
 
 ```yaml
-# values.yaml — the master switch, false by default
+# values.yaml — explicitly disable the chart's default-enabled integration
 celln:
   enabled: false
 ```
 
-When `false` (the default), no `celln-system` namespace, installer, or router is deployed, and the controller/apiserver aren't given a router URL — zero footprint.
+When `false`, no `celln-system` namespace, installer, or router is deployed, and the controller/apiserver aren't given a router URL or credential mount.
 
-**Disabling it does not remove `"celln"` as a valid `backend` value on the CRD.** A run submitted with `backend: celln` while disabled will still be admitted; the controller will attempt to reach the router at the default in-cluster DNS name, fail to resolve it, and the run transitions to `Failed` with a router-unreachable error. If you disable Celln after enabling it, communicate that to whoever authors `AgentRun`s or agent defaults that set `backend: celln` — or watch for the live banner on the Runs page, which flags exactly this case.
+**Disabling it does not remove `"celln"` as a valid `backend` value on the CRD.** A run submitted while disabled is still schema-valid but refuses when the controller lacks the required transport configuration. There is no fallback to a Job. Communicate configuration changes to authors of Celln-backed runs.
 
 ## Enabling Celln: the AI provider requirement
 
@@ -153,6 +153,15 @@ If none of the above is true on a given KVM node, that node's dispatcher is stil
 | Everything configured | Run dispatches, executes in a real sealed cell, and returns a bounded result. |
 
 ## See Also
+
+For a repeatable static-program proof, use Celln's `make conformance-kvm` with
+`CELLN_SYMPOZIUM_PROOF` pointing to this repository's
+`test/integration/test-celln-real-controller.sh` and `CELLN_KIND_BIN` pointing to
+Kind. The script uses a fresh Podman-backed Kind cluster and isolated kubeconfig,
+builds the production controller, and records actual AgentRun status plus Celln
+receipts/audits. It never uses the existing Kubernetes context and needs no model
+credential. The controller and KVM dispatcher run on the host; Kind supplies the
+real Kubernetes API, not nested hardware isolation.
 
 - [Celln repository](https://github.com/sympozium-ai/celln) — the execution runtime itself: the cell/tool-lending model, hardware isolation guarantees, and `scripts/setup-host.sh` (what the installer DaemonSet runs on each node).
 - [Custom Resources](custom-resources.md) — the `AgentRun.spec.backend` field.

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -310,6 +310,14 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 		deadline := cellnEffectiveTimeout(agentRun) + cellnDeadlineSlack
 		if elapsed := time.Since(agentRun.Status.StartedAt.Time); elapsed > deadline {
 			log.Info("Celln backend deadline exceeded", "elapsed", elapsed, "deadline", deadline)
+			done, err := r.cancelCelln(ctx, agentRun)
+			if err != nil {
+				log.Error(err, "Celln deadline cleanup pending")
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			}
+			if !done {
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
 			return ctrl.Result{}, r.failRun(ctx, agentRun,
 				fmt.Sprintf("Celln backend deadline exceeded: no terminal status after %s (deadline %s)", elapsed.Round(time.Second), deadline))
 		}

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -154,13 +154,13 @@ type executionReceipt struct {
 	CompletedAt string            `json:"completedAt"`
 	CellID      string            `json:"cellId"`
 	Resolved    executionResolved `json:"resolved"`
-	Output      *executionOutput  `json:"output,omitempty"`
+	Output      *executionOutput  `json:"output"`
 }
 
 type executionResolved struct {
-	Mote   *string  `json:"mote,omitempty"`
-	Tools  []string `json:"tools,omitempty"`
-	Inputs []string `json:"inputs,omitempty"`
+	Mote   *string  `json:"mote"`
+	Tools  []string `json:"tools"`
+	Inputs []string `json:"inputs"`
 }
 
 type executionOutput struct {

--- a/internal/controller/agentrun_celln_test.go
+++ b/internal/controller/agentrun_celln_test.go
@@ -85,7 +85,10 @@ func TestReconcilePendingCelln_ActionIDUniquePerUID(t *testing.T) {
 
 func TestReconcileRunningCelln_DeadlineExceeded_FailsRun(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(executionRecord{RequestID: "whatever", Phase: "Running"})
+		if r.Method != "POST" || r.URL.Path != "/v1/executions/wedged-run-uid-cccc/cancel" {
+			t.Error("deadline did not cancel remotely")
+		}
+		_ = json.NewEncoder(w).Encode(executionRecord{RequestID: "wedged-run-uid-cccc", Phase: "Cancelled"})
 	}))
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -694,7 +694,7 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 	// inside the agent-runner. Fail fast with a clear status.error so the
 	// operator sees why the run never started instead of a runtime crash.
 	// PR #302 review (issuecomment 5033007953) — second smaller ask.
-	if agentRun.Spec.Task == nil {
+	if agentRun.Spec.Task == nil && !(agentRun.Spec.Backend == "celln" && agentRun.Spec.Celln != nil) {
 		return ctrl.Result{}, r.failRun(ctx, agentRun,
 			"spec.task is required and must not be empty; provide a string prompt (Path A) or a {mode, tool, parameters} object (Path B)")
 	}

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1110,6 +1110,15 @@ func (r *AgentRunReconciler) checkAgentContainer(ctx context.Context, log logr.L
 // Instead of deleting immediately, it keeps up to RunHistoryLimit completed
 // runs per instance and prunes only the oldest ones beyond that threshold.
 func (r *AgentRunReconciler) reconcileCompleted(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (ctrl.Result, error) {
+	if agentRun.Status.CellnActionID != "" && controllerutil.ContainsFinalizer(agentRun, agentRunFinalizer) {
+		done, err := r.cancelCelln(ctx, agentRun)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		if !done {
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		}
+	}
 	// Clean up cluster-scoped RBAC created for skill sidecars.
 	r.cleanupSkillRBAC(ctx, log, agentRun)
 
@@ -1885,6 +1894,16 @@ func (r *AgentRunReconciler) pruneOldRuns(ctx context.Context, log logr.Logger, 
 // reconcileDelete handles AgentRun deletion.
 func (r *AgentRunReconciler) reconcileDelete(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (ctrl.Result, error) {
 	log.Info("Reconciling AgentRun deletion")
+	if agentRun.Status.CellnActionID != "" {
+		done, err := r.cancelCelln(ctx, agentRun)
+		if err != nil {
+			log.Error(err, "Celln deletion cleanup pending")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		if !done {
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		}
+	}
 
 	// Clean up cluster-scoped RBAC resources created for skill sidecars.
 	r.cleanupSkillRBAC(ctx, log, agentRun)

--- a/internal/controller/celln_cancel.go
+++ b/internal/controller/celln_cancel.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// Acknowledging cancellation is not teardown. Keep reconciling (and retain
+// the Kubernetes finalizer) until Celln reports a terminal execution. This
+// also cancels work when another controller marks an AgentRun failed.
+func (r *AgentRunReconciler) cancelCelln(ctx context.Context, run *sympoziumv1alpha1.AgentRun) (bool, error) {
+	id := run.Status.CellnActionID
+	if id == "" {
+		return true, nil
+	}
+	if id != cellnActionID(run) {
+		return false, fmt.Errorf("Celln: cancellation identity mismatch")
+	}
+	req, err := cellnRequest(ctx, http.MethodPost, "/v1/executions/"+id+"/cancel", nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := cellnHTTPClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusAccepted {
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("Celln: cancellation refused (HTTP %d)", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 262145))
+	if err != nil || len(body) > 262144 {
+		return false, fmt.Errorf("Celln: invalid cancellation response size")
+	}
+	var record executionRecord
+	d := json.NewDecoder(bytes.NewReader(body))
+	d.DisallowUnknownFields()
+	if d.Decode(&record) != nil || d.Decode(new(any)) != io.EOF || record.RequestID != id || !slices.Contains([]string{"Succeeded", "Failed", "Refused", "Cancelled"}, record.Phase) {
+		return false, fmt.Errorf("Celln: cancellation has no correlated terminal record")
+	}
+	if record.Receipt != nil {
+		if err := validateCellnReceipt(run, record); err != nil {
+			return false, err
+		}
+		encoded, _ := json.Marshal(record.Receipt)
+		if err := r.updateStatusWithRetry(ctx, run, func(ar *sympoziumv1alpha1.AgentRun) { ar.Status.CellnReceipt = string(encoded) }); err != nil {
+			return false, err
+		}
+	} else if record.Phase == "Succeeded" {
+		return false, fmt.Errorf("Celln: success without receipt during cancellation")
+	}
+	return true, nil
+}

--- a/internal/controller/celln_cancel_test.go
+++ b/internal/controller/celln_cancel_test.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestCellnCancellationWaitsForTeardown(t *testing.T) {
+	run := newTestCellnRun(t, "cancel", "uid")
+	run.Status.CellnActionID = cellnActionID(run)
+	run.Finalizers = []string{agentRunFinalizer}
+	status := http.StatusAccepted
+	phase := "Cancelling"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != "POST" || req.URL.Path != "/v1/executions/"+cellnActionID(run)+"/cancel" || req.Header.Get("Authorization") != "Bearer "+testCellnToken {
+			t.Error("incorrect cancellation request")
+		}
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(executionRecord{RequestID: cellnActionID(run), Phase: phase})
+	}))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+	r := newAgentRunTestReconciler(t, run)
+	for _, code := range []int{http.StatusAccepted, http.StatusUnauthorized, http.StatusServiceUnavailable} {
+		status = code
+		result, err := r.reconcileDelete(context.Background(), logr.Discard(), run)
+		if err != nil || result.RequeueAfter == 0 {
+			t.Fatalf("cleanup did not retry HTTP %d: %+v %v", code, result, err)
+		}
+		var stored sympoziumv1alpha1.AgentRun
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &stored); err != nil {
+			t.Fatal(err)
+		}
+		if !controllerutil.ContainsFinalizer(&stored, agentRunFinalizer) {
+			t.Fatal("removed finalizer before remote teardown")
+		}
+	}
+	status = http.StatusOK
+	if done, err := r.cancelCelln(context.Background(), run); done || err == nil {
+		t.Fatal("accepted nonterminal 200")
+	}
+	phase = "Cancelled"
+	if done, err := r.cancelCelln(context.Background(), run); !done || err != nil {
+		t.Fatalf("terminal cancellation: %v %v", done, err)
+	}
+	phase = "Succeeded"
+	if done, err := r.cancelCelln(context.Background(), run); done || err == nil {
+		t.Fatal("accepted success without receipt")
+	}
+}
+
+func TestCellnDeadlineDoesNotFinishWhileCleanupPending(t *testing.T) {
+	run := newTestCellnRun(t, "deadline-pending", "uid")
+	run.Status.CellnActionID = cellnActionID(run)
+	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
+	started := metav1.NewTime(time.Now().Add(-time.Hour))
+	run.Status.StartedAt = &started
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusAccepted) }))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+	r := newAgentRunTestReconciler(t, run)
+	result, err := r.reconcileRunningCelln(context.Background(), logr.Discard(), run)
+	if err != nil || result.RequeueAfter == 0 {
+		t.Fatalf("did not wait: %+v %v", result, err)
+	}
+	var stored sympoziumv1alpha1.AgentRun
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status.Phase != sympoziumv1alpha1.AgentRunPhaseRunning {
+		t.Fatal("reported completion before teardown")
+	}
+}

--- a/internal/controller/celln_validation_test.go
+++ b/internal/controller/celln_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -13,6 +14,28 @@ import (
 )
 
 const testCellnHash = "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestCellnReceiptPreservesNullAndEmptyFields(t *testing.T) {
+	wire := `{"apiVersion":"celln.dev/v1alpha1","requestId":"id","phase":"succeeded","node":"node","cellId":"cell","resolved":{"mote":null,"tools":[],"inputs":[]},"output":null,"startedAt":"2026-09-06T00:00:00Z","completedAt":"2026-09-06T00:00:01Z"}`
+	var receipt executionReceipt
+	if err := json.Unmarshal([]byte(wire), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var before, after any
+	if err := json.Unmarshal([]byte(wire), &before); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &after); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("receipt contract changed during persistence: %s", encoded)
+	}
+}
 
 func testFrozenCellnRequest(run *sympoziumv1alpha1.AgentRun) executionRequest {
 	return executionRequest{APIVersion: "celln.dev/v1alpha1", ID: cellnActionID(run), Workload: executionWorkload{ID: run.Spec.AgentRef, Caller: "test"}, Forge: &executionForge{Task: "original"}, Capabilities: executionCapability{Workspace: "none", TimeoutMs: 90000, MemoryBytes: cellnMemoryBytes, OutputBytes: cellnOutputBytes}, Execution: executionPolicy{Lane: "agent", RequireHardwareIsolation: true}}
@@ -27,6 +50,7 @@ func TestCellnPinnedRequestAndFrozenRetry(t *testing.T) {
 		Invocation:   sympoziumv1alpha1.CellnInvocation{Alias: "/tool", Args: []string{"original"}},
 		Capabilities: sympoziumv1alpha1.CellnCapabilities{Workspace: "read-only", MemoryBytes: cellnMemoryBytes, OutputBytes: cellnOutputBytes}, Lane: "tool",
 	}
+	run.Spec.Task = nil
 	var requests []executionRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer "+testCellnToken {
@@ -41,8 +65,11 @@ func TestCellnPinnedRequestAndFrozenRetry(t *testing.T) {
 	}))
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)
-	r := newAgentRunTestReconciler(t, run)
-	if _, err := r.reconcilePendingCelln(context.Background(), logr.Discard(), run); err != nil {
+	agent := parityAgent()
+	agent.Name = run.Spec.AgentRef
+	agent.Namespace = run.Namespace
+	r := newAgentRunTestReconciler(t, run, agent)
+	if _, err := r.reconcilePending(context.Background(), logr.Discard(), run); err != nil {
 		t.Fatal(err)
 	}
 	var stored sympoziumv1alpha1.AgentRun

--- a/test/integration/test-celln-real-controller.sh
+++ b/test/integration/test-celln-real-controller.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Invoked explicitly by Celln's real-KVM fixture. Never uses the user's cluster.
+set -euo pipefail
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+: "${CELLN_ROUTER_URL:?isolated fixture URL required}"
+: "${CELLN_TOKEN_FILE:?isolated fixture credential required}"
+: "${CELLN_PROOF_REQUEST:?pinned fixture request required}"
+: "${CELLN_PROOF_EVIDENCE:?evidence directory required}"
+: "${CELLN_PROOF_ROOT:?isolated dispatcher root required}"
+: "${CELLN_PROOF_BINARY:?actual Celln binary required}"
+kind_bin=${CELLN_KIND_BIN:-kind}
+for tool in go jq rg kubectl curl podman timeout; do command -v "$tool" >/dev/null; done
+[[ -x "$kind_bin" ]] || command -v "$kind_bin" >/dev/null
+[[ "$CELLN_ROUTER_URL" == http://127.0.0.1:* ]]
+work=$(mktemp -d /tmp/sympozium-celln-proof.XXXXXX)
+export KUBECONFIG="$work/kubeconfig"
+export KIND_EXPERIMENTAL_PROVIDER=podman
+cluster="celln-controller-proof-$$"
+controller_pid=""
+owned=false
+cleanup() {
+  if [[ -n "$controller_pid" ]]; then kill "$controller_pid" 2>/dev/null || true; wait "$controller_pid" 2>/dev/null || true; fi
+  if [[ "$owned" == true ]]; then "$kind_bin" delete cluster --name "$cluster"; fi
+  case "$work" in /tmp/sympozium-celln-proof.*) rm -r -- "$work" ;; esac
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+mkdir -p "$CELLN_PROOF_EVIDENCE"
+evidence=$(cd "$CELLN_PROOF_EVIDENCE" && pwd)
+if "$kind_bin" get clusters | rg -Fx "$cluster"; then echo "refusing existing cluster" >&2; exit 1; fi
+owned=true
+"$kind_bin" create cluster --name "$cluster" --wait 120s
+kubectl create -f "$repo/config/crd/bases"
+kubectl wait --for=condition=Established --timeout=60s crd --all
+kubectl create namespace celln-proof
+jq -n '{apiVersion:"sympozium.ai/v1alpha1",kind:"Agent",metadata:{name:"reference",namespace:"celln-proof"},spec:{agents:{default:{model:"unused"}},memory:{enabled:false}}}' | kubectl create -f -
+(cd "$repo" && go build -o "$work/controller" ./cmd/controller)
+env -u OTEL_EXPORTER_OTLP_ENDPOINT -u SYMPOZIUM_PRICING_CONFIGMAP \
+  NATS_URL="" AGENT_SANDBOX_ENABLED=false "$work/controller" \
+  --metrics-bind-address=0 --health-probe-bind-address=0 --max-run-history=100 \
+  >"$evidence/controller.log" 2>&1 &
+controller_pid=$!
+
+node() { curl --fail --silent --show-error --max-time 10 -H "Authorization: Bearer $(<"$CELLN_TOKEN_FILE")" "$CELLN_ROUTER_URL$1"; }
+create_run() {
+  local name=$1 mode=$2 timeout_value=$3
+  jq --arg name "$name" --arg mode "$mode" --arg timeout "$timeout_value" '
+    {apiVersion:"sympozium.ai/v1alpha1",kind:"AgentRun",metadata:{name:$name,namespace:"celln-proof"},spec:{
+      agentRef:"reference",agentId:"reference",sessionKey:$name,model:{provider:"openai",model:"unused",authSecretRef:""},backend:"celln",timeout:$timeout,
+      celln:{mote:.mote,tools:.tools,inputs:.inputs,invocation:{alias:.invocation.alias,args:[$mode]},lane:"tool",capabilities:(.capabilities|del(.timeoutMs))}}}
+    | if $mode == "inputs" then .spec.celln.invocation.args += ["first-input"] else . end
+    | if ($mode|startswith("workspace-")) then .spec.celln.inputs=[] | .spec.celln.capabilities.workspace=($mode|ltrimstr("workspace-")) | .spec.celln.invocation.args=["workspace",.spec.celln.capabilities.workspace] else . end
+    | if $mode == "unsupported" then .spec.celln.tools[0].closure={hash:.spec.celln.mote.hash} else . end
+    | if $mode == "unapproved-input" then .spec.celln.inputs[0].hash=("blake3:"+("b"*64)) else . end
+  ' "$CELLN_PROOF_REQUEST" >"$evidence/$name-request.json"
+  kubectl create -f "$evidence/$name-request.json"
+}
+terminal() {
+  local name=$1 phase=$2
+  local deadline=$((SECONDS+60))
+  while (( SECONDS < deadline )); do
+    kill -0 "$controller_pid"
+    kubectl get agentrun "$name" -n celln-proof -o json >"$evidence/$name-status.json"
+    if jq -e '.status.phase == "Succeeded" or .status.phase == "Failed"' "$evidence/$name-status.json" >/dev/null; then break; fi
+    sleep 1
+  done
+  jq -e --arg phase "$phase" '.status.phase == $phase' "$evidence/$name-status.json" >/dev/null || { jq '.status' "$evidence/$name-status.json"; tail -60 "$evidence/controller.log"; return 1; }
+}
+collect() {
+  local name=$1
+  local id
+  id=$(jq -r '.status.cellnActionId' "$evidence/$name-status.json")
+  node "/v1/executions/$id" >"$evidence/$name-result.json"
+  node "/v1/executions/$id/audit" >"$evidence/$name-audit.json"
+  jq -e --slurpfile status "$evidence/$name-status.json" '
+    .requestId == $status[0].status.cellnActionId and .receipt == ($status[0].status.cellnReceipt|fromjson)
+    and .caller == ("sympozium:celln-proof/"+$status[0].metadata.name)
+    and .execution.cellId == .receipt.cellId and .execution.pilot.lane == "tool"
+    and any(.events[]; .phase == "Dissolved")
+  ' "$evidence/$name-audit.json" >/dev/null
+  node /v1/node >"$evidence/$name-node.json"
+  jq -e '.node.live_cells == 0 and .node.memory_bytes == 268435456 and .node.egress_slots == 1' "$evidence/$name-node.json" >/dev/null
+}
+for mode in silent failed spoof inputs workspace-none workspace-read-only workspace-read-write; do
+  create_run "proof-$mode" "$mode" 15s
+  phase=Succeeded
+  if [[ "$mode" == failed || "$mode" == spoof ]]; then phase=Failed; fi
+  terminal "proof-$mode" "$phase"
+  collect "proof-$mode"
+done
+jq -e '.execution.exitCode == 0 and .receipt.output == null' "$evidence/proof-silent-audit.json" >/dev/null
+jq -e '.execution.exitCode == 7' "$evidence/proof-failed-audit.json" >/dev/null
+jq -e '.execution.exitCode == 9' "$evidence/proof-spoof-audit.json" >/dev/null
+jq -e --slurpfile ref "$CELLN_PROOF_REQUEST" '.receipt.resolved.inputs == [$ref[0].inputs[0].hash]' "$evidence/proof-inputs-audit.json" >/dev/null
+for mode in unsupported unapproved-input; do
+  create_run "proof-$mode" "$mode" 15s
+  terminal "proof-$mode" Failed
+  jq -e '.status.cellnReceipt == null or .status.cellnReceipt == ""' "$evidence/proof-$mode-status.json" >/dev/null
+done
+create_run proof-timeout timeout 1s
+terminal proof-timeout Failed
+collect proof-timeout
+jq -e '.execution.watchdogStopped == true' "$evidence/proof-timeout-audit.json" >/dev/null
+create_run proof-cancel timeout 30s
+deadline=$((SECONDS+30))
+while (( SECONDS < deadline )); do
+  kubectl get agentrun proof-cancel -n celln-proof -o json >"$evidence/proof-cancel-status.json"
+  id=$(jq -r '.status.cellnActionId // ""' "$evidence/proof-cancel-status.json")
+  # Audit execution details arrive when the worker returns. The live cell
+  # registry, unlike an HTTP reservation, proves a cell was actually forked.
+  "$CELLN_PROOF_BINARY" --root "$CELLN_PROOF_ROOT" --json ps >"$evidence/proof-cancel-before.json"
+  if [[ -n "$id" ]] && jq -se 'length == 1 and .[0].status == "running" and .[0].description == "reference"' "$evidence/proof-cancel-before.json" >/dev/null; then break; fi
+  sleep 1
+done
+jq -se 'length == 1 and .[0].status == "running"' "$evidence/proof-cancel-before.json" >/dev/null
+sleep 0.3
+kubectl delete agentrun proof-cancel -n celln-proof --wait=false
+kubectl wait --for=delete agentrun/proof-cancel -n celln-proof --timeout=30s
+node "/v1/executions/$id/audit" >"$evidence/proof-cancel-audit.json"
+jq -e --slurpfile before "$evidence/proof-cancel-before.json" '.receipt.phase == "cancelled" and .receipt.cellId == $before[0].id and .receipt.output.bytes > 0 and any(.events[]; .phase == "Dissolved")' "$evidence/proof-cancel-audit.json" >/dev/null
+node /v1/node >"$evidence/final-node.json"
+jq -e '.node.live_cells == 0 and .node.memory_bytes == 268435456' "$evidence/final-node.json" >/dev/null
+kubectl get jobs -n celln-proof -o json >"$evidence/jobs.json"
+jq -e '.items|length == 0' "$evidence/jobs.json" >/dev/null
+jq -n --arg revision "$(git -C "$repo" rev-parse HEAD)" --argjson dirty "$(if [[ -z "$(git -C "$repo" status --porcelain)" ]]; then echo false; else echo true; fi)" \
+  --arg controllerSha256 "$(sha256sum "$work/controller" | cut -d' ' -f1)" --arg kind "$("$kind_bin" version)" \
+  '{suite:"sympozium-real-controller-celln-kvm",status:"passed",revision:$revision,dirty:$dirty,controllerSha256:$controllerSha256,kind:$kind,
+  cases:["silent","failed","spoof","inputs","workspace-none","workspace-read-only","workspace-read-write","unsupported","unapproved-input","timeout","delete-cancel"]}' >"$evidence/summary.json"
+echo "PASS: production Sympozium controller → Kubernetes AgentRun → authenticated Celln → KVM receipt; evidence $evidence"


### PR DESCRIPTION
## Summary

Completes the implementation/proof path for https://github.com/sympozium-ai/celln/issues/2. Includes #423 as an ancestry dependency; merge it first.

- Add an explicitly invoked isolated Kind/Podman proof running the production controller binary against real Kubernetes CRDs and AgentRuns, while Celln executes on real host KVM.
- Cover silent success, nonzero failure, output-marker spoofing, immutable inputs, all workspace modes, unsupported closure/unapproved input, timeout, and deletion-driven cancellation of the exact live cell.
- Retain request/status/receipt/audit, reservation and no-Job-fallback evidence plus revision/binary metadata. Never use the existing cluster/kubeconfig.
- Fix two integration findings: allow a pinned request with no model task; preserve receipt null/empty fields during status persistence. Add ordinary-host regressions for both.

## Verification

- `go test -race ./internal/controller ./api/v1alpha1` passed.
- Full real-controller/KVM proof passed all 11 cases. Initial evidence: Celln `target/dispatch-conformance/1788702349148555697-1156057/sympozium/` (dirty implementation run, not clean-revision evidence).
- Cluster removed; user context unchanged. Clean-revision and final merged-stack runs are required before epic completion.

Celln's companion test hook is on branch `test/issue-2-sympozium-proof`; use its documented `CELLN_SYMPOZIUM_PROOF` opt-in. No model account is needed; the controller/dispatcher run on the host and Kind supplies the actual Kubernetes API.
