### PR TITLE
fix(celln): restrict router ingress to controller namespace and pods (M0)

### DIFF
--- a/charts/sympozium/templates/celln-network-policy.yaml
+++ b/charts/sympozium/templates/celln-network-policy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.celln.enabled }}
+# Mandatory for this privileged execution ingress, independently of the
+# optional policies for ordinary agent pods. Requires an enforcing CNI.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: celln-router-ingress
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: celln-router
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Namespace AND pod selector must remain in the same peer. Separate
+        # peers would allow every pod in the control-plane namespace, or a
+        # tenant pod that merely copied the controller label.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "sympozium.namespace" . | quote }}
+          podSelector:
+            matchLabels:
+              control-plane: controller-manager
+      ports:
+        - protocol: TCP
+          port: 8788
+{{- end }}

--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -105,6 +105,33 @@ distributed failover or recovery of a lost registry after a dispatcher crash.
 
 ## Enabling / Disabling Celln
 
+### M0 rollout warning and network boundary
+
+The chart's `celln-router-ingress` NetworkPolicy selects router pods in
+`celln-system` and permits only TCP 8788 from controller pods **in the configured
+control-plane namespace**. The namespace and pod selectors are intersected;
+copying a controller label in another namespace does not grant access. This
+policy remains enabled with Celln even if the general `networkPolicies.enabled`
+option is false. It requires a NetworkPolicy-enforcing CNI and is not an
+authentication mechanism. Host-network traffic and administrator-added additive
+policies require separate operator review.
+
+The API server is intentionally not granted execution access. Its current
+TCP-only capability probe may report unavailable under this restriction;
+authenticated, least-privilege readiness is tracked in M0 rather than granting
+the API server access to an otherwise unauthenticated execution endpoint.
+
+This policy alone does not resolve [#331](https://github.com/sympozium-ai/sympozium/issues/331).
+The companion Celln router change requires `--client-token-file` for inbound
+authentication, separate from the outbound dispatcher's `--token-file`, and
+adds cancellation forwarding. The chart's existing image versions, router
+command, token distribution and TLS path still need a coordinated M0 update.
+Do not replace the host binary independently: the old router command cannot
+start the new fail-closed CLI. Do not treat the default installation as a proven
+multi-tenant execution path or work around missing TLS by silently enabling
+insecure HTTP. See [epic #426](https://github.com/sympozium-ai/sympozium/issues/426)
+for remaining deployment, replica ownership and two-node acceptance work.
+
 ```bash
 sympozium install --enable-hermetic-workloads
 # or: make install ENABLE_HERMETIC_WORKLOADS=true

--- a/internal/controller/celln_network_policy_test.go
+++ b/internal/controller/celln_network_policy_test.go
@@ -1,0 +1,123 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os/exec"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// Render the actual chart, then check Kubernetes selector semantics. This is
+// not a substitute for the M0 cross-namespace test on a policy-enforcing CNI.
+func TestCellnNetworkPolicy(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm required for chart rendering")
+	}
+	for _, tc := range []struct {
+		name, namespace, settings string
+		enabled                   bool
+	}{
+		{"default", "sympozium-system", "celln.enabled=true", true},
+		{"custom-namespace", "custom-control", "celln.enabled=true,namespace=custom-control", true},
+		{"ordinary-policies-disabled", "sympozium-system", "celln.enabled=true,networkPolicies.enabled=false", true},
+		{"celln-disabled", "sympozium-system", "celln.enabled=false", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := exec.Command("helm", "template", "m0", "../../charts/sympozium", "--set", tc.settings).CombinedOutput()
+			if err != nil {
+				t.Fatalf("helm template: %v\n%s", err, out)
+			}
+			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(out), 4096)
+			var policy *networkingv1.NetworkPolicy
+			var controller appsv1.Deployment
+			for {
+				var raw json.RawMessage
+				if err := decoder.Decode(&raw); err == io.EOF {
+					break
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				if len(bytes.TrimSpace(raw)) == 0 {
+					continue // Helm may emit comment-only YAML documents.
+				}
+				var meta struct {
+					Kind     string
+					Metadata struct{ Name string }
+				}
+				if err := json.Unmarshal(raw, &meta); err != nil {
+					t.Fatal(err)
+				}
+				if meta.Kind == "NetworkPolicy" && meta.Metadata.Name == "celln-router-ingress" {
+					if policy != nil {
+						t.Fatal("duplicate ingress policy")
+					}
+					policy = &networkingv1.NetworkPolicy{}
+					if err := json.Unmarshal(raw, policy); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if meta.Kind == "Deployment" && meta.Metadata.Name == "sympozium-controller-manager" {
+					if err := json.Unmarshal(raw, &controller); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if !tc.enabled {
+				if policy != nil {
+					t.Fatal("Celln disabled but policy rendered")
+				}
+				return
+			}
+			if policy == nil {
+				t.Fatal("Celln router is missing its ingress policy")
+			}
+			if policy.Namespace != "celln-system" || policy.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"] != "celln-router" {
+				t.Fatal("policy does not target router")
+			}
+			if len(policy.Spec.PolicyTypes) != 1 || policy.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+				t.Fatal("ingress isolation missing")
+			}
+			if len(policy.Spec.Ingress) != 1 || len(policy.Spec.Ingress[0].From) != 1 {
+				t.Fatal("unexpected additional ingress grants")
+			}
+			rule := policy.Spec.Ingress[0]
+			if len(rule.Ports) != 1 || rule.Ports[0].Port.IntVal != 8788 || rule.Ports[0].Protocol == nil || *rule.Ports[0].Protocol != "TCP" {
+				t.Fatal("must grant only router TCP port")
+			}
+			peer := rule.From[0]
+			if peer.NamespaceSelector == nil || peer.PodSelector == nil || peer.IPBlock != nil {
+				t.Fatal("namespace and pod selectors must be intersected")
+			}
+			nsSelector, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			podSelector, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			allowed := func(ns string, podLabels map[string]string) bool {
+				return nsSelector.Matches(labels.Set{"kubernetes.io/metadata.name": ns}) && podSelector.Matches(labels.Set(podLabels))
+			}
+			if controller.Namespace != tc.namespace || !allowed(controller.Namespace, controller.Spec.Template.Labels) {
+				t.Fatal("actual controller pod cannot reach router")
+			}
+			if allowed("tenant", controller.Spec.Template.Labels) {
+				t.Fatal("tenant copying controller labels is allowed")
+			}
+			if allowed(tc.namespace, map[string]string{"sympozium.ai/role": "agent"}) {
+				t.Fatal("ordinary control-plane namespace pod is allowed")
+			}
+			if allowed("tenant", nil) {
+				t.Fatal("unrelated tenant is allowed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## M0 first increment

Part of #426; partial mitigation for #331, not closure.

- Add mandatory Celln router ingress NetworkPolicy in `celln-system`, independent of the optional general agent policies.
- Allow only TCP 8788 from the actual controller pod selector AND configured control-plane namespace; copied labels in a tenant namespace do not qualify.
- Render the real Helm chart in tests and check selector semantics for defaults, custom namespace, general policies disabled, and Celln disabled.
- Document that this needs an enforcing CNI and does not substitute for inbound authentication. The API server is deliberately not given execution access; its current TCP-only capability probe may report unavailable until M0's least-privilege readiness path lands.

## Validation

- `go test -race ./internal/controller ./api/v1alpha1 -count=1` passed, including the four Helm render/selector cases.
- `helm lint charts/sympozium` passed.
- No cluster changes and no cross-namespace CNI enforcement proof claimed; that remains in M0's deployed E2E gate.

## Dependencies and limits

Companion Celln PR adds distinct inbound credentials and cancellation forwarding. The existing chart command/image versions, credential distribution and TLS topology still require a coordinated update. This draft is a reviewable first increment, not the completed M0 deployment. #331 and #426 stay open.
