### PR TITLE
feat: add tolerations for agent pods

### DIFF
--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -437,6 +437,13 @@ type AgentConfig struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// Tolerations allow agent pods to schedule onto tainted nodes.
+	// Propagated to AgentRunSpec.Tolerations when runs are created.
+	// Use together with NodeSelector to pin agents to dedicated node
+	// pools (e.g. a GPU pool tainted with `nvidia.com/gpu=present:NoSchedule`).
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
 	// Lifecycle defines pre and post run hooks for agent runs.
 	// Propagated to AgentRunSpec.Lifecycle when runs are created.
 	// +optional

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -151,6 +151,12 @@ type AgentRunSpec struct {
 	// +kubebuilder:default=true
 	UseContext *bool `json:"useContext,omitempty"`
 
+	// Tolerations allow the agent pod to schedule onto tainted nodes.
+	// Typically inherited from Agent.Spec.Agents.Default.Tolerations by
+	// the controller, but may also be set directly on an AgentRun.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
 	// Volumes are additional pod volumes to attach to the agent pod.
 	// Typically populated from Agent.Spec.Volumes by the controller,
 	// but may also be set directly on an AgentRun. Useful for mounting

--- a/api/v1alpha1/ensemble_types.go
+++ b/api/v1alpha1/ensemble_types.go
@@ -270,6 +270,12 @@ type AgentConfigSpec struct {
 	// +optional
 	Lifecycle *LifecycleHooks `json:"lifecycle,omitempty"`
 
+	// Tolerations allow agent pods spawned for this agent configuration
+	// to schedule onto tainted nodes. Propagated to the generated
+	// Agent's AgentConfig.Tolerations.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
 	// ChannelAccessControl maps channel types to per-agent-configuration access control
 	// overrides. When set, these take priority over ensemble-level
 	// ChannelAccessControl for this agent configuration. Use AllowedChats with Discord

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -70,6 +70,13 @@ func (in *AgentConfig) DeepCopyInto(out *AgentConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Lifecycle != nil {
 		in, out := &in.Lifecycle, &out.Lifecycle
 		*out = new(LifecycleHooks)
@@ -218,6 +225,13 @@ func (in *AgentConfigSpec) DeepCopyInto(out *AgentConfigSpec) {
 		in, out := &in.Lifecycle, &out.Lifecycle
 		*out = new(LifecycleHooks)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.ChannelAccessControl != nil {
 		in, out := &in.ChannelAccessControl, &out.ChannelAccessControl
@@ -520,6 +534,13 @@ func (in *AgentRunSpec) DeepCopyInto(out *AgentRunSpec) {
 		in, out := &in.UseContext, &out.UseContext
 		*out = new(bool)
 		**out = **in
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -857,6 +857,49 @@ spec:
               timeout:
                 description: Timeout is the maximum duration for this agent run.
                 type: string
+              tolerations:
+                description: |-
+                  Tolerations allow the agent pod to schedule onto tainted nodes.
+                  Typically inherited from Agent.Spec.Agents.Default.Tolerations by
+                  the controller, but may also be set directly on an AgentRun.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               toolPolicy:
                 description: ToolPolicy defines which tools this agent is allowed
                   to use.

--- a/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
@@ -511,6 +511,50 @@ spec:
                         description: Thinking is the thinking mode (off, low, medium,
                           high).
                         type: string
+                      tolerations:
+                        description: |-
+                          Tolerations allow agent pods to schedule onto tainted nodes.
+                          Propagated to AgentRunSpec.Tolerations when runs are created.
+                          Use together with NodeSelector to pin agents to dedicated node
+                          pools (e.g. a GPU pool tainted with `nvidia.com/gpu=present:NoSchedule`).
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     required:
                     - model
                     type: object

--- a/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
@@ -699,6 +699,49 @@ spec:
                       description: SystemPrompt is the system prompt that defines
                         the agent's role and behaviour.
                       type: string
+                    tolerations:
+                      description: |-
+                        Tolerations allow agent pods spawned for this agent configuration
+                        to schedule onto tainted nodes. Propagated to the generated
+                        Agent's AgentConfig.Tolerations.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                     toolPolicy:
                       description: ToolPolicy defines which tools this agent config
                         is allowed to use.

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -857,6 +857,49 @@ spec:
               timeout:
                 description: Timeout is the maximum duration for this agent run.
                 type: string
+              tolerations:
+                description: |-
+                  Tolerations allow the agent pod to schedule onto tainted nodes.
+                  Typically inherited from Agent.Spec.Agents.Default.Tolerations by
+                  the controller, but may also be set directly on an AgentRun.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               toolPolicy:
                 description: ToolPolicy defines which tools this agent is allowed
                   to use.

--- a/charts/sympozium/crds/sympozium.ai_agents.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agents.yaml
@@ -511,6 +511,50 @@ spec:
                         description: Thinking is the thinking mode (off, low, medium,
                           high).
                         type: string
+                      tolerations:
+                        description: |-
+                          Tolerations allow agent pods to schedule onto tainted nodes.
+                          Propagated to AgentRunSpec.Tolerations when runs are created.
+                          Use together with NodeSelector to pin agents to dedicated node
+                          pools (e.g. a GPU pool tainted with `nvidia.com/gpu=present:NoSchedule`).
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     required:
                     - model
                     type: object

--- a/charts/sympozium/crds/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium/crds/sympozium.ai_ensembles.yaml
@@ -699,6 +699,49 @@ spec:
                       description: SystemPrompt is the system prompt that defines
                         the agent's role and behaviour.
                       type: string
+                    tolerations:
+                      description: |-
+                        Tolerations allow agent pods spawned for this agent configuration
+                        to schedule onto tainted nodes. Propagated to the generated
+                        Agent's AgentConfig.Tolerations.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                     toolPolicy:
                       description: ToolPolicy defines which tools this agent config
                         is allowed to use.

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -8710,6 +8710,7 @@ func tuiCreateRun(ns, instance, task string) (string, error) {
 			Skills:           inst.Spec.Skills,
 			Timeout:          &metav1.Duration{Duration: 10 * time.Minute},
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
+			Tolerations:      inst.Spec.Agents.Default.Tolerations,
 		},
 	}
 	if err := k8sClient.Create(ctx, run); err != nil {

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -857,6 +857,49 @@ spec:
               timeout:
                 description: Timeout is the maximum duration for this agent run.
                 type: string
+              tolerations:
+                description: |-
+                  Tolerations allow the agent pod to schedule onto tainted nodes.
+                  Typically inherited from Agent.Spec.Agents.Default.Tolerations by
+                  the controller, but may also be set directly on an AgentRun.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               toolPolicy:
                 description: ToolPolicy defines which tools this agent is allowed
                   to use.

--- a/config/crd/bases/sympozium.ai_agents.yaml
+++ b/config/crd/bases/sympozium.ai_agents.yaml
@@ -511,6 +511,50 @@ spec:
                         description: Thinking is the thinking mode (off, low, medium,
                           high).
                         type: string
+                      tolerations:
+                        description: |-
+                          Tolerations allow agent pods to schedule onto tainted nodes.
+                          Propagated to AgentRunSpec.Tolerations when runs are created.
+                          Use together with NodeSelector to pin agents to dedicated node
+                          pools (e.g. a GPU pool tainted with `nvidia.com/gpu=present:NoSchedule`).
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     required:
                     - model
                     type: object

--- a/config/crd/bases/sympozium.ai_ensembles.yaml
+++ b/config/crd/bases/sympozium.ai_ensembles.yaml
@@ -699,6 +699,49 @@ spec:
                       description: SystemPrompt is the system prompt that defines
                         the agent's role and behaviour.
                       type: string
+                    tolerations:
+                      description: |-
+                        Tolerations allow agent pods spawned for this agent configuration
+                        to schedule onto tainted nodes. Propagated to the generated
+                        Agent's AgentConfig.Tolerations.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                     toolPolicy:
                       description: ToolPolicy defines which tools this agent config
                         is allowed to use.

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -1222,6 +1222,7 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 			Skills:           inst.Spec.Skills,
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 			Lifecycle:        inst.Spec.Agents.Default.Lifecycle,
+			Tolerations:      inst.Spec.Agents.Default.Tolerations,
 			Env:              inst.Spec.Agents.Default.Env,
 			Timeout:          timeout,
 		},

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -1004,6 +1004,9 @@ func (r *AgentReconciler) ensureWebEndpointAgentRun(ctx context.Context, instanc
 	if len(instance.Spec.Agents.Default.NodeSelector) > 0 {
 		agentRun.Spec.Model.NodeSelector = instance.Spec.Agents.Default.NodeSelector
 	}
+	if len(instance.Spec.Agents.Default.Tolerations) > 0 {
+		agentRun.Spec.Tolerations = instance.Spec.Agents.Default.Tolerations
+	}
 
 	if err := controllerutil.SetControllerReference(instance, agentRun, r.Scheme); err != nil {
 		return fmt.Errorf("set owner reference: %w", err)

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1459,6 +1459,7 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 				SystemPrompt:     memorySystemPrompt(&targetInst),
 				Volumes:          targetInst.Spec.Volumes,
 				VolumeMounts:     targetInst.Spec.VolumeMounts,
+				Tolerations:      targetInst.Spec.Agents.Default.Tolerations,
 				Env:              targetInst.Spec.Agents.Default.Env,
 				Timeout:          sequentialRunTimeout(rel, &targetInst),
 				ToolPolicy:       toolpolicy.ForAgent(ctx, r.Client, &targetInst),
@@ -2196,6 +2197,7 @@ func (r *AgentRunReconciler) reconcilePendingServer(ctx context.Context, log log
 					AutomountServiceAccountToken: boolPtr(false),
 					ImagePullSecrets:             agentRun.Spec.ImagePullSecrets,
 					NodeSelector:                 agentRun.Spec.Model.NodeSelector,
+					Tolerations:                  agentRun.Spec.Tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:            "web-proxy",
@@ -2803,6 +2805,7 @@ func (r *AgentRunReconciler) buildAgentPodTemplate(
 			HostPID:                      hostPID,
 			DNSPolicy:                    dnsPolicy,
 			NodeSelector:                 agentRun.Spec.Model.NodeSelector,
+			Tolerations:                  agentRun.Spec.Tolerations,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot:   &runAsNonRoot,
 				RunAsUser:      &runAsUser,

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -1204,6 +1204,47 @@ func TestBuildJob_NoNodeSelector(t *testing.T) {
 	}
 }
 
+// ── Tolerations tests ───────────────────────────────────────────────────────
+
+func TestBuildJob_Tolerations(t *testing.T) {
+	r := &AgentRunReconciler{}
+	run := newTestRun()
+	run.Spec.Tolerations = []corev1.Toleration{
+		{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "present", Effect: corev1.TaintEffectNoSchedule},
+		{Key: "dedicated", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+	}
+
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+	tols := job.Spec.Template.Spec.Tolerations
+
+	if len(tols) != 2 {
+		t.Fatalf("Tolerations len = %d, want 2", len(tols))
+	}
+	if tols[0].Key != "nvidia.com/gpu" || tols[0].Value != "present" {
+		t.Errorf("Tolerations[0] = %+v, want nvidia.com/gpu=present", tols[0])
+	}
+	if tols[1].Key != "dedicated" || tols[1].Operator != corev1.TolerationOpExists {
+		t.Errorf("Tolerations[1] = %+v, want dedicated:Exists", tols[1])
+	}
+}
+
+func TestBuildJob_NoTolerations(t *testing.T) {
+	r := &AgentRunReconciler{}
+	run := newTestRun()
+	// No Tolerations set.
+
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+	if tols := job.Spec.Template.Spec.Tolerations; tols != nil {
+		t.Errorf("Tolerations should be nil when not set, got %v", tols)
+	}
+}
+
 // ── Lifecycle hook tests ────────────────────────────────────────────────────
 
 // newTestRunWithLifecycle returns a test AgentRun with lifecycle hooks configured.

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -303,6 +303,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 			Timeout:          inst.Spec.Agents.Default.ParseRunTimeout(),
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 			Lifecycle:        inst.Spec.Agents.Default.Lifecycle,
+			Tolerations:      inst.Spec.Agents.Default.Tolerations,
 			SystemPrompt:     memorySystemPrompt(inst),
 			Volumes:          inst.Spec.Volumes,
 			VolumeMounts:     inst.Spec.VolumeMounts,

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -593,6 +593,7 @@ func (r *EnsembleReconciler) buildAgent(
 					ProviderHeadersSecretRef: providerHeadersSecretRef,
 					AgentSandbox:             pack.Spec.AgentSandbox,
 					Lifecycle:                persona.Lifecycle,
+					Tolerations:              persona.Tolerations,
 					Subagents:                persona.Subagents,
 					Env:                      persona.Env,
 					RunTimeout:               persona.RunTimeout,

--- a/internal/controller/ensemble_parity_test.go
+++ b/internal/controller/ensemble_parity_test.go
@@ -378,6 +378,9 @@ func convergenceFixture() (*sympoziumv1alpha1.Ensemble, *sympoziumv1alpha1.Agent
 			},
 		},
 		Workspace: &sympoziumv1alpha1.WorkspaceSpec{PerSessionPVC: true, Size: "2Gi"},
+		Tolerations: []corev1.Toleration{{
+			Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "agents", Effect: corev1.TaintEffectNoSchedule,
+		}},
 	}
 	return pack, persona
 }

--- a/internal/controller/stimulus.go
+++ b/internal/controller/stimulus.go
@@ -81,6 +81,7 @@ func BuildStimulusRun(
 			ImagePullSecrets: targetInst.Spec.ImagePullSecrets,
 			Volumes:          targetInst.Spec.Volumes,
 			VolumeMounts:     targetInst.Spec.VolumeMounts,
+			Tolerations:      targetInst.Spec.Agents.Default.Tolerations,
 			Env:              targetInst.Spec.Agents.Default.Env,
 			Timeout:          targetInst.Spec.Agents.Default.ParseRunTimeout(),
 			ToolPolicy:       toolpolicy.ForAgent(ctx, c, targetInst),

--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -308,6 +308,9 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if len(instance.Spec.Agents.Default.NodeSelector) > 0 {
 		agentRun.Spec.Model.NodeSelector = instance.Spec.Agents.Default.NodeSelector
 	}
+	if len(instance.Spec.Agents.Default.Tolerations) > 0 {
+		agentRun.Spec.Tolerations = instance.Spec.Agents.Default.Tolerations
+	}
 	if len(instance.Spec.Agents.Default.ProviderHeaders) > 0 {
 		agentRun.Spec.Model.ProviderHeaders = instance.Spec.Agents.Default.ProviderHeaders
 	}

--- a/internal/orchestrator/spawner.go
+++ b/internal/orchestrator/spawner.go
@@ -167,10 +167,11 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 		},
 	}
 
-	// Look up the instance to propagate lifecycle hooks, env, and tool policy to sub-agents.
+	// Look up the instance to propagate lifecycle hooks, tolerations, env, and tool policy to sub-agents.
 	var inst sympoziumv1alpha1.Agent
 	if err := s.Client.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.InstanceName}, &inst); err == nil {
 		agentRun.Spec.Lifecycle = inst.Spec.Agents.Default.Lifecycle
+		agentRun.Spec.Tolerations = inst.Spec.Agents.Default.Tolerations
 		agentRun.Spec.Env = inst.Spec.Agents.Default.Env
 		if agentRun.Spec.Timeout == nil {
 			agentRun.Spec.Timeout = inst.Spec.Agents.Default.ParseRunTimeout()

--- a/internal/webproxy/mcp.go
+++ b/internal/webproxy/mcp.go
@@ -255,6 +255,7 @@ func (p *Proxy) executeAgentTask(ctx context.Context, task string, session *mcpS
 			Timeout:          inst.Spec.Agents.Default.ParseRunTimeout(),
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 			Lifecycle:        inst.Spec.Agents.Default.Lifecycle,
+			Tolerations:      inst.Spec.Agents.Default.Tolerations,
 			Env:              inst.Spec.Agents.Default.Env,
 		},
 	}

--- a/internal/webproxy/openai.go
+++ b/internal/webproxy/openai.go
@@ -209,6 +209,7 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			Timeout:          inst.Spec.Agents.Default.ParseRunTimeout(),
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 			Lifecycle:        inst.Spec.Agents.Default.Lifecycle,
+			Tolerations:      inst.Spec.Agents.Default.Tolerations,
 			Env:              inst.Spec.Agents.Default.Env,
 		},
 	}


### PR DESCRIPTION
This PR adds support for tolerations to `Agent` config, `AgentRun` spec, and `Ensemble` personas. This in turn allows us to reliably schedule AgentRun pods to dedicated node groups with taints.