### PR TITLE
feat: trusted Celln catalogue planning and operator composition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,6 +501,12 @@ helm-lint: ## Lint the Helm charts
 	helm lint charts/sympozium/
 	helm lint charts/sympozium-crds/
 
+.PHONY: test-celln-selection-live
+test-celln-selection-live: ## Verify catalogue grants against the explicit isolated API (no runs/model calls)
+	@test -n "$(CELLN_COMPOSITION_KUBECONFIG)" || (echo 'CELLN_COMPOSITION_KUBECONFIG required' >&2; exit 1)
+	@test -n "$(CELLN_COMPOSITION_FIXTURE)" || (echo 'CELLN_COMPOSITION_FIXTURE required' >&2; exit 1)
+	go test -race ./internal/cellnreview -run TestLiveCatalogueSelectionAndGrantIsolation -count=1 -v
+
 ##@ Clean
 
 clean: ## Remove build artifacts

--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -7,16 +7,26 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 // This is an operator review command, not a tenant-facing execution endpoint.
 // Selecting source flags here does not issue grants or attest to ownership.
 func newCellnSelectionPlanCmd() *cobra.Command {
+	return newCellnSelectionCmd(false)
+}
+
+func newCellnSelectionComposeCmd() *cobra.Command {
+	return newCellnSelectionCmd(true)
+}
+
+func newCellnSelectionCmd(compose bool) *cobra.Command {
 	var sourceNamespace, operatorSource, runtimeSource, agentSource string
 	var selected []string
 	var imageBytes int64
 	var runName string
+	var options cellnreview.ComposeOptions
 	cmd := &cobra.Command{Use: "plan AGENT", Args: cobra.ExactArgs(1), SilenceUsage: true,
 		Short: "Resolve live grants and emit a Celln composition plan without executing",
 		Long:  "Operator-only planning input. Read three independently configured grant ConfigMaps and live Agent/runtime/tool identities. Prints the resolved authority snapshot and exact compositor input; does not grant authority, certify readiness, write resources, compose images or execute. Tenant-facing callers must not accept these source flags from run requests.",
@@ -44,6 +54,13 @@ func newCellnSelectionPlanCmd() *cobra.Command {
 				if err := loader.Revalidate(cmd.Context(), *frozen); err != nil {
 					return err
 				}
+				if compose {
+					report, err := cellnreview.Compose(cmd.Context(), loader, *frozen, options)
+					if err != nil {
+						return err
+					}
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-composed-selection-v1", "frozen": frozen, "composition": report, "executionAuthorized": false})
+				}
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-selection-report-v1", "frozen": frozen, "artifactReadiness": "not_checked", "conformance": "not_checked", "executionAuthorized": false})
 			}
 			snapshot, err := loader.Resolve(cmd.Context(), types.NamespacedName{Namespace: namespace, Name: args[0]}, selection)
@@ -65,6 +82,18 @@ func newCellnSelectionPlanCmd() *cobra.Command {
 	cmd.Flags().StringVar(&runName, "run", "", "Bind and revalidate the plan against an existing same-namespace AgentRun (no dispatch)")
 	for _, name := range []string{"grant-namespace", "operator-grants", "runtime-grants", "agent-grants"} {
 		_ = cmd.MarkFlagRequired(name)
+	}
+	if compose {
+		cmd.Use = "compose AGENT"
+		cmd.Short = "Build a local signed Harness/tool composition from live reviewed grants"
+		cmd.Long = "Operator packaging only: verifies exact source publishers, executables and schemas, invokes the trusted Celln compositor, then revalidates the frozen run and approvals. Creates a new output directory; never admits, distributes, prewarms, grants model access or executes a cell. Failed post-build checks may leave diagnostic artifacts."
+		cmd.Flags().StringVar(&options.Binary, "celln-binary", "", "Absolute operator-selected Celln binary")
+		cmd.Flags().StringVar(&options.PolicyRoot, "policy-root", "", "Absolute trusted Celln policy/store root")
+		cmd.Flags().StringVar(&options.KeyFile, "key-file", "", "Absolute operator composer seed path (never read into Kubernetes)")
+		cmd.Flags().StringVar(&options.OutputDir, "output-dir", "", "Absolute new output directory; must not exist")
+		for _, name := range []string{"run", "celln-binary", "policy-root", "key-file", "output-dir"} {
+			_ = cmd.MarkFlagRequired(name)
+		}
 	}
 	return cmd
 }

--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// This is an operator review command, not a tenant-facing execution endpoint.
+// Selecting source flags here does not issue grants or attest to ownership.
+func newCellnSelectionPlanCmd() *cobra.Command {
+	var sourceNamespace, operatorSource, runtimeSource, agentSource string
+	var selected []string
+	var imageBytes int64
+	var runName string
+	cmd := &cobra.Command{Use: "plan AGENT", Args: cobra.ExactArgs(1), SilenceUsage: true,
+		Short: "Resolve live grants and emit a Celln composition plan without executing",
+		Long:  "Operator-only planning input. Read three independently configured grant ConfigMaps and live Agent/runtime/tool identities. Prints the resolved authority snapshot and exact compositor input; does not grant authority, certify readiness, write resources, compose images or execute. Tenant-facing callers must not accept these source flags from run requests.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			selection := make([]cellnauthority.Selection, 0, len(selected))
+			for _, ref := range selected {
+				name, revision, ok := strings.Cut(ref, "@")
+				if !ok || name == "" || revision == "" || strings.Contains(revision, "@") {
+					return fmt.Errorf("tool must be NAME@REVISION")
+				}
+				selection = append(selection, cellnauthority.Selection{Name: name, Revision: revision})
+			}
+			loader := cellnauthority.Loader{Reader: k8sClient,
+				OperatorSource: types.NamespacedName{Namespace: sourceNamespace, Name: operatorSource},
+				RuntimeSource:  types.NamespacedName{Namespace: sourceNamespace, Name: runtimeSource},
+				AgentSource:    types.NamespacedName{Namespace: sourceNamespace, Name: agentSource}}
+			if runName != "" {
+				frozen, err := loader.FreezeRun(cmd.Context(), types.NamespacedName{Namespace: namespace, Name: runName}, selection, imageBytes)
+				if err != nil {
+					return err
+				}
+				if frozen.Snapshot.Agent.Name != args[0] {
+					return fmt.Errorf("run belongs to a different Agent")
+				}
+				if err := loader.Revalidate(cmd.Context(), *frozen); err != nil {
+					return err
+				}
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-selection-report-v1", "frozen": frozen, "artifactReadiness": "not_checked", "conformance": "not_checked", "executionAuthorized": false})
+			}
+			snapshot, err := loader.Resolve(cmd.Context(), types.NamespacedName{Namespace: namespace, Name: args[0]}, selection)
+			if err != nil {
+				return err
+			}
+			plan, err := cellnauthority.Prepare(*snapshot, imageBytes)
+			if err != nil {
+				return err
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-selection-report-v1", "snapshot": snapshot, "prepared": plan, "artifactReadiness": "not_checked", "conformance": "not_checked", "executionAuthorized": false})
+		}}
+	cmd.Flags().StringVar(&sourceNamespace, "grant-namespace", "", "Operator-controlled namespace containing grant sources")
+	cmd.Flags().StringVar(&operatorSource, "operator-grants", "", "Operator grant ConfigMap name")
+	cmd.Flags().StringVar(&runtimeSource, "runtime-grants", "", "Runtime grant ConfigMap name")
+	cmd.Flags().StringVar(&agentSource, "agent-grants", "", "Agent grant ConfigMap name")
+	cmd.Flags().StringArrayVar(&selected, "tool", nil, "Explicit NAME@REVISION; repeat in desired order; omission selects no tools")
+	cmd.Flags().Int64Var(&imageBytes, "image-bytes", 33554432, "Composed image size, 32..512 MiB and 2 MiB aligned")
+	cmd.Flags().StringVar(&runName, "run", "", "Bind and revalidate the plan against an existing same-namespace AgentRun (no dispatch)")
+	for _, name := range []string{"grant-namespace", "operator-grants", "runtime-grants", "agent-grants"} {
+		_ = cmd.MarkFlagRequired(name)
+	}
+	return cmd
+}

--- a/cmd/sympozium/celln_selection_cmd_test.go
+++ b/cmd/sympozium/celln_selection_cmd_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSelectionPlanRequiresExplicitSourcesAndWellFormedSelections(t *testing.T) {
+	for _, args := range [][]string{
+		{"agent"},
+		{"agent", "--grant-namespace", "operator", "--operator-grants", "ops", "--runtime-grants", "runtime", "--agent-grants", "agent", "--tool", "bare-name"},
+		{"agent", "--grant-namespace", "operator", "--operator-grants", "ops", "--runtime-grants", "runtime", "--agent-grants", "agent", "--tool", "tool@v1@v2"},
+	} {
+		cmd := newCellnSelectionPlanCmd()
+		cmd.SetArgs(args)
+		var output bytes.Buffer
+		cmd.SetOut(&output)
+		cmd.SetErr(&output)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatalf("accepted %v", args)
+		}
+		if !strings.Contains(err.Error(), "required flag") && !strings.Contains(err.Error(), "NAME@REVISION") {
+			t.Fatalf("wrong refusal: %v", err)
+		}
+	}
+}

--- a/cmd/sympozium/celln_tool_cmd.go
+++ b/cmd/sympozium/celln_tool_cmd.go
@@ -47,5 +47,6 @@ func newCellnToolCmd() *cobra.Command {
 		_ = approve.MarkFlagRequired(flag)
 	}
 	cmd.AddCommand(approve)
+	cmd.AddCommand(newCellnSelectionPlanCmd())
 	return cmd
 }

--- a/cmd/sympozium/celln_tool_cmd.go
+++ b/cmd/sympozium/celln_tool_cmd.go
@@ -48,5 +48,6 @@ func newCellnToolCmd() *cobra.Command {
 	}
 	cmd.AddCommand(approve)
 	cmd.AddCommand(newCellnSelectionPlanCmd())
+	cmd.AddCommand(newCellnSelectionComposeCmd())
 	return cmd
 }

--- a/docs/evidence/celln-catalogue-composition-2026-09-07.json
+++ b/docs/evidence/celln-catalogue-composition-2026-09-07.json
@@ -1,0 +1,26 @@
+{
+  "status": "passed",
+  "scope": "Sympozium operator composition wrapper with real signed artifacts and Celln binary; fake Kubernetes client",
+  "sympoziumBase": "0695de5",
+  "sympoziumTestChangesUncommittedAtRun": true,
+  "cellnBase": "1f294a5a3f9a0cc7a8ff22db6693bafb144dc162",
+  "cellnFixtureChangesUncommittedAtRun": true,
+  "test": "TestComposeRealCellnArtifacts",
+  "runtimeExecutable": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47",
+  "sourceClosures": [
+    "blake3:0e3756714e0f22d9c3766ba70bf530698463be9fe37d216710cc673719798b2c",
+    "blake3:560217f05d95a421a8dae6654f97fb100774618621a461f9691f6bc2dc5e4e76",
+    "blake3:3bf63128b532805074426b837313485b56471713afe1b920dc7ffa870fbbf037"
+  ],
+  "composedClosure": "blake3:bb6d3e9159230e4809ae46d3c1b9cdf10704daf14473ee5b0ac39c01f43ec947",
+  "composedToolfs": "blake3:787c3c3ad2e7287520ce678c980cc5b95c4c16fff11d833eb88090cb446aacf7",
+  "imageBytes": 33554432,
+  "selectedTools": ["uppercase", "length"],
+  "checks": ["source publisher/executable/schema verification", "real compositor invocation", "local composed filesystem byte verification", "source revocation invalidates composed descriptor"],
+  "modelCalls": 0,
+  "kvmExecuted": false,
+  "liveKubernetesAPITested": false,
+  "artifactReadiness": "not_checked",
+  "conformance": "not_checked",
+  "limits": ["public fixture signing seed, not production credentials", "mote profile deliberately unprepared", "source filesystem provenance uses the existing JSON proof package", "does not qualify catalogue-backed dispatch or the UI/YAML user journey", "ext2 byte reproducibility not claimed"]
+}

--- a/docs/evidence/celln-live-catalogue-selection-2026-09-07.json
+++ b/docs/evidence/celln-live-catalogue-selection-2026-09-07.json
@@ -1,0 +1,25 @@
+{
+  "status": "passed",
+  "test": "TestLiveCatalogueSelectionAndGrantIsolation",
+  "scope": "live isolated Kubernetes API, catalogue selection and grant-source RBAC; not composition or execution",
+  "context": "kind-celln-deployed",
+  "sympoziumBase": "03a4b22",
+  "testChangesUncommittedAtRun": true,
+  "selectedTools": ["uppercase", "length"],
+  "checks": [
+    "real Agent, AgentRuntime and tool UIDs/generations/full-spec identities",
+    "three live grant sources bind the selected subjects",
+    "ordered plan contains runtime plus two signed source identities",
+    "tenant with own-namespace ConfigMap write permission cannot update operator grant",
+    "operator grant deletion refuses selection despite tenant-owned lookalike"
+  ],
+  "testNamespaces": ["celln-selection-tenant-b594j", "celln-selection-operator-tkdj5"],
+  "testNamespacesRemoved": true,
+  "agentRunsCreated": 0,
+  "modelCalls": 0,
+  "kvmExecuted": false,
+  "controllersPaused": false,
+  "frameworkTouched": false,
+  "artifactReadiness": "not_checked",
+  "conformance": "not_checked"
+}

--- a/docs/guides/celln-tool-authority.md
+++ b/docs/guides/celln-tool-authority.md
@@ -91,6 +91,41 @@ any future execution side effect; a saved report is not a durable approval.
 Controller persistence/dispatch integration and ambiguous-execution recovery
 are still required. Planning does not submit or mark the AgentRun as running.
 
+### Build the selected local composition
+
+`celln-tool compose` requires an existing run and the same explicit grant
+sources, plus operator-owned binary, policy/store, signing-key and new output
+paths. For example, replace `plan` above with `compose` and add:
+
+```sh
+  --run my-run \
+  --celln-binary /opt/celln/bin/celln \
+  --policy-root /var/lib/celln \
+  --key-file /secure/composer.seed \
+  --output-dir /var/tmp/new-harness-composition
+```
+
+This verifies each source's exact publisher, root entry point and executable
+using Celln's verifier, and verifies the selected schema bytes. Source
+descriptors must already be staged in `closures`, schema bytes in `tool-schemas`,
+and member blobs in `tools` under that operator root. It invokes Celln's
+compositor with bounded output and a 60-second subprocess deadline, without
+inheriting provider credentials. Each successful source check and the resulting
+composition must agree on the Celln trust-policy digest. Kubernetes approvals
+are revalidated immediately before and after the build.
+
+The output is a local signed composition, not an admitted or distributed image,
+a prewarmed mote, or a host model grant. No AgentRun status is changed. Refusal
+after a build can leave its explicitly named output directory for diagnosis;
+it must not be consumed as an authorized execution. Temporary plan files are
+removed on return. Controller execution still needs these checks connected to
+its own trusted configuration, persistence and readiness path.
+
+The Sympozium wrapper tests use a fake Kubernetes client and scripted verifier
+responses to check exact arguments, source binding, policy changes, withdrawal
+and cleanup. These tests do not replace the Celln compositor's real-image/KVM
+tests or establish a complete real catalogue-to-cell execution proof.
+
 Race-enabled tests use a Kubernetes fake client to exercise actual loader
 lookups, stale subjects, withdrawn grants, untrusted tenant lookalikes,
 source mutation, malformed documents and restrictive selections. They do not

--- a/docs/guides/celln-tool-authority.md
+++ b/docs/guides/celln-tool-authority.md
@@ -33,6 +33,69 @@ can execute 16 tool refs; exact signed composition is still required.
 
 ## Integration still required
 
+### Live grant-source loader (implementation in progress)
+
+`cellnauthority.Loader` reads the live Agent, its same-namespace `runtimeRef`,
+and explicitly selected tool names/revisions using an injected uncached
+Kubernetes API reader. Three distinct ConfigMap references are configured by
+the operator/controller, not supplied by a run: operator, runtime and Agent
+grant layers. Each `grants.json` document uses
+`sympozium.ai/celln-grants-v1`, declares its layer, binds both subjects by
+namespace/name/UID/generation/full-spec SHA256, and carries exact tool grants.
+The loader records source UID/resourceVersion/document digest, intersects
+all layers, then rereads subjects, tools and sources to refuse observed changes.
+An empty selection remains empty but still requires the configured subject
+approvals. It currently accepts JSON tool-lane selections only.
+
+The reader cannot prove ConfigMap ownership from labels: deployment RBAC must
+prevent tenant writes to these configured locations. Caller ownership of the
+Agent must also be authenticated separately. This loader is **not yet wired to
+API handlers or dispatch**, does not issue a host model grant, and does not turn
+runtime metadata into conformance or selection readiness. Its rereads are not
+an atomic Kubernetes transaction or an execution lease; fresh authorization
+and host enforcement remain mandatory before new work.
+
+The read-only operator command exposes this planning path:
+
+```sh
+sympozium --namespace tenant celln-tool plan my-agent \
+  --grant-namespace operator-system \
+  --operator-grants reviewed-operator-grants \
+  --runtime-grants reviewed-runtime-grants \
+  --agent-grants reviewed-agent-grants \
+  --tool uppercase-v1@v1 --tool length-v1@v1
+```
+
+The command emits a snapshot plus `prepared.composition`, the exact
+`celln.dev/composition-plan-v1` input for Celln's compositor. It also maps
+the approved selected schemas and limits to JSON Harness borrowed-tool
+descriptors. The runtime's full spec is retained and rechecked before
+preparation. Because tools share cell memory, the entire cell is capped by
+the strictest selected memory ceiling; there is no invented per-tool memory
+isolation. A ceiling too small to support the runtime must fail subsequent
+conformance, not be silently increased.
+
+This operator report explicitly says `executionAuthorized: false`,
+`artifactReadiness: not_checked` and `conformance: not_checked`. Choosing source
+flags does not establish their ownership or issue a host grant. A future
+tenant-facing API must select sources from trusted controller configuration,
+never forward these flags from user input. No objects or artifacts are written.
+
+Adding `--run RUN_NAME` binds the selection to an existing same-namespace
+Celln AgentRun. The output contains a versioned `frozen` record with the run
+UID/generation/full-spec identity, grant-source revisions, complete runtime
+spec, exact ordered tools and prepared artifacts. The loader revalidates that
+record before output. `Loader.Revalidate` refuses any observed change rather
+than returning a new plan or minting an execution ID. It must also run before
+any future execution side effect; a saved report is not a durable approval.
+Controller persistence/dispatch integration and ambiguous-execution recovery
+are still required. Planning does not submit or mark the AgentRun as running.
+
+Race-enabled tests use a Kubernetes fake client to exercise actual loader
+lookups, stale subjects, withdrawn grants, untrusted tenant lookalikes,
+source mutation, malformed documents and restrictive selections. They do not
+claim live API-server RBAC or catalogue-backed execution proof.
+
 These internal structs are not a tenant-facing authorization API. A future
 controller must independently authenticate and load each grant source, verify
 publisher/artifact/schema conformance and bind the runtime, policy and Agent

--- a/docs/guides/celln-tool-authority.md
+++ b/docs/guides/celln-tool-authority.md
@@ -126,6 +126,23 @@ responses to check exact arguments, source binding, policy changes, withdrawal
 and cleanup. These tests do not replace the Celln compositor's real-image/KVM
 tests or establish a complete real catalogue-to-cell execution proof.
 
+The opt-in `TestComposeRealCellnArtifacts` additionally passed against the
+actual Celln binary and signed native Harness/uppercase/length bytes. It built
+and verified a 32 MiB composition, then refused its descriptor after source
+withdrawal. [Recorded evidence](../evidence/celln-catalogue-composition-2026-09-07.json)
+explicitly distinguishes real artifacts from fake Kubernetes metadata: no
+model request or cell ran in this test.
+
+Prepare the fixture in the Celln checkout with the public-seed
+`prepare_composition_fixture` example, giving it a new directory and an existing
+native JSON proof package. Then run in the Sympozium checkout:
+
+```sh
+CELLN_COMPOSITION_FIXTURE=/absolute/path/to/generated/fixture \
+CELLN_COMPOSITION_BINARY=/absolute/path/to/celln \
+  go test -race ./internal/cellnreview -run TestComposeRealCellnArtifacts -count=1 -v
+```
+
 Race-enabled tests use a Kubernetes fake client to exercise actual loader
 lookups, stale subjects, withdrawn grants, untrusted tenant lookalikes,
 source mutation, malformed documents and restrictive selections. They do not

--- a/docs/guides/celln-tool-authority.md
+++ b/docs/guides/celln-tool-authority.md
@@ -143,6 +143,20 @@ CELLN_COMPOSITION_BINARY=/absolute/path/to/celln \
   go test -race ./internal/cellnreview -run TestComposeRealCellnArtifacts -count=1 -v
 ```
 
+The separate live-API selection/RBAC proof also passed on isolated
+`kind-celln-deployed`: real object identities resolved to the ordered runtime
+and two-tool plan; a tenant able to write its own ConfigMaps could not change
+the operator grant; removing that grant refused selection despite a tenant
+lookalike. [Evidence](../evidence/celln-live-catalogue-selection-2026-09-07.json)
+does not claim composition, model execution or readiness. The test creates no
+AgentRun, pauses no controllers, and removes its two generated namespaces.
+
+```sh
+CELLN_COMPOSITION_KUBECONFIG=/absolute/isolated/kubeconfig \
+CELLN_COMPOSITION_FIXTURE=/absolute/path/to/generated/fixture \
+  go test -race ./internal/cellnreview -run TestLiveCatalogueSelectionAndGrantIsolation -count=1 -v
+```
+
 Race-enabled tests use a Kubernetes fake client to exercise actual loader
 lookups, stale subjects, withdrawn grants, untrusted tenant lookalikes,
 source mutation, malformed documents and restrictive selections. They do not

--- a/internal/cellnauthority/frozen.go
+++ b/internal/cellnauthority/frozen.go
@@ -1,0 +1,91 @@
+package cellnauthority
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// FrozenSelection binds planning to an existing AgentRun. Persistence must
+// precede any execution side effect. This is not a grant, receipt or readiness
+// assertion; the caller must still verify artifacts and obtain host authority.
+type FrozenSelection struct {
+	APIVersion string            `json:"apiVersion"`
+	Run        Subject           `json:"run"`
+	Snapshot   SelectionSnapshot `json:"snapshot"`
+	Prepared   PreparedSelection `json:"prepared"`
+}
+
+func (l Loader) FreezeRun(ctx context.Context, runKey types.NamespacedName, selection []Selection, imageBytes int64) (*FrozenSelection, error) {
+	run, id, err := l.readRun(ctx, runKey)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := l.Resolve(ctx, types.NamespacedName{Namespace: run.Namespace, Name: run.Spec.AgentRef}, selection)
+	if err != nil {
+		return nil, err
+	}
+	prepared, err := Prepare(*snapshot, imageBytes)
+	if err != nil {
+		return nil, err
+	}
+	_, current, err := l.readRun(ctx, runKey)
+	if err != nil {
+		return nil, err
+	}
+	if current != id {
+		return nil, fmt.Errorf("run changed during resolution")
+	}
+	frozen := &FrozenSelection{APIVersion: "sympozium.ai/celln-frozen-selection-v1", Run: id, Snapshot: *snapshot, Prepared: *prepared}
+	bytes, err := json.Marshal(frozen)
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes) > 262144 {
+		return nil, fmt.Errorf("frozen selection exceeds 256 KiB")
+	}
+	return frozen, nil
+}
+
+// Revalidate never returns a replacement plan or execution ID. Any observed
+// subject, source or authority change refuses; the caller must reconcile an
+// ambiguous existing execution, not silently start a newly authorized attempt.
+func (l Loader) Revalidate(ctx context.Context, frozen FrozenSelection) error {
+	if frozen.APIVersion != "sympozium.ai/celln-frozen-selection-v1" || frozen.Run.Kind != "AgentRun" || len(frozen.Snapshot.Tools) > 16 {
+		return fmt.Errorf("invalid frozen selection")
+	}
+	selections := make([]Selection, 0, len(frozen.Snapshot.Tools))
+	for _, tool := range frozen.Snapshot.Tools {
+		selections = append(selections, Selection{Name: tool.Identity.Name, Revision: tool.Identity.Revision, Limits: tool.Limits.DeepCopy()})
+	}
+	current, err := l.FreezeRun(ctx, types.NamespacedName{Namespace: frozen.Run.Namespace, Name: frozen.Run.Name}, selections, frozen.Prepared.Composition.ImageBytes)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(*current, frozen) {
+		return fmt.Errorf("frozen selection or current approval changed")
+	}
+	return nil
+}
+
+func (l Loader) readRun(ctx context.Context, key types.NamespacedName) (*api.AgentRun, Subject, error) {
+	if l.Reader == nil || key.Namespace == "" || key.Name == "" {
+		return nil, Subject{}, fmt.Errorf("reader and run identity required")
+	}
+	var run api.AgentRun
+	if err := l.Reader.Get(ctx, key, &run); err != nil {
+		return nil, Subject{}, err
+	}
+	if run.Spec.Backend != "celln" || run.Spec.AgentRef == "" || !run.Spec.Task.IsString() {
+		return nil, Subject{}, fmt.Errorf("catalogue planning requires a Celln string-task AgentRun")
+	}
+	id, err := IdentifySubject("AgentRun", run.ObjectMeta, run.Spec)
+	if err != nil {
+		return nil, Subject{}, err
+	}
+	return &run, id, nil
+}

--- a/internal/cellnauthority/frozen_test.go
+++ b/internal/cellnauthority/frozen_test.go
@@ -1,0 +1,106 @@
+package cellnauthority
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func frozenFixture(t *testing.T) (Loader, client.Client, *FrozenSelection) {
+	t.Helper()
+	l, c, _, selection := loaderFixture(t)
+	var run api.AgentRun
+	if err := json.Unmarshal([]byte(`{"metadata":{"namespace":"tenant","name":"run","uid":"run-uid","generation":1},"spec":{"agentRef":"agent","backend":"celln","task":"use the lent tool"}}`), &run); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(context.Background(), &run); err != nil {
+		t.Fatal(err)
+	}
+	frozen, err := l.FreezeRun(context.Background(), client.ObjectKeyFromObject(&run), selection, 33554432)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return l, c, frozen
+}
+
+func TestFrozenSelectionRoundTripAndCurrentApprovals(t *testing.T) {
+	l, _, frozen := frozenFixture(t)
+	bytes, err := json.Marshal(frozen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored FrozenSelection
+	if err := json.Unmarshal(bytes, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Revalidate(context.Background(), restored); err != nil {
+		t.Fatal(err)
+	}
+	if restored.Run.UID != "run-uid" || restored.Run.SpecSHA256 == "" {
+		t.Fatal("run identity not pinned")
+	}
+}
+
+func TestFrozenSelectionNeverRetargetsOrExpandsOnRetry(t *testing.T) {
+	for _, mode := range []string{"run-task", "run-recreated", "source-revision", "source-withdrawn", "prepared-tampered", "limits-expanded", "tools-removed", "runtime-tampered"} {
+		t.Run(mode, func(t *testing.T) {
+			l, c, frozen := frozenFixture(t)
+			ctx := context.Background()
+			switch mode {
+			case "run-task", "run-recreated":
+				var run api.AgentRun
+				if err := c.Get(ctx, types.NamespacedName{Namespace: "tenant", Name: "run"}, &run); err != nil {
+					t.Fatal(err)
+				}
+				if mode == "run-task" {
+					if err := json.Unmarshal([]byte(`"different task"`), &run.Spec.Task); err != nil {
+						t.Fatal(err)
+					}
+					if err := c.Update(ctx, &run); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					if err := c.Delete(ctx, &run); err != nil {
+						t.Fatal(err)
+					}
+					run.UID = "new-uid"
+					run.ResourceVersion = ""
+					if err := c.Create(ctx, &run); err != nil {
+						t.Fatal(err)
+					}
+				}
+			case "source-revision", "source-withdrawn":
+				var cm corev1.ConfigMap
+				if err := c.Get(ctx, l.OperatorSource, &cm); err != nil {
+					t.Fatal(err)
+				}
+				if mode == "source-withdrawn" {
+					if err := c.Delete(ctx, &cm); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					cm.Labels = map[string]string{"review": "changed"}
+					if err := c.Update(ctx, &cm); err != nil {
+						t.Fatal(err)
+					}
+				}
+			case "prepared-tampered":
+				frozen.Prepared.Composition.Sources[0] = "blake3:replacement"
+			case "limits-expanded":
+				frozen.Snapshot.Tools[0].Limits.OutputBytes++
+			case "tools-removed":
+				frozen.Snapshot.Tools = nil
+			case "runtime-tampered":
+				frozen.Snapshot.RuntimeSpec.Celln.EntryPoint = "/replacement"
+			}
+			if err := l.Revalidate(ctx, *frozen); err == nil {
+				t.Fatalf("accepted %s", mode)
+			}
+		})
+	}
+}

--- a/internal/cellnauthority/loader.go
+++ b/internal/cellnauthority/loader.go
@@ -1,0 +1,222 @@
+package cellnauthority
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Subject binds approvals to a live object and its complete spec, not status.
+type Subject struct {
+	Kind       string    `json:"kind"`
+	Namespace  string    `json:"namespace"`
+	Name       string    `json:"name"`
+	UID        types.UID `json:"uid"`
+	Generation int64     `json:"generation"`
+	SpecSHA256 string    `json:"specSHA256"`
+}
+
+func IdentifySubject(kind string, meta metav1.ObjectMeta, spec any) (Subject, error) {
+	if (kind != "Agent" && kind != "AgentRuntime" && kind != "AgentRun") || meta.Name == "" || meta.Namespace == "" || meta.UID == "" || meta.Generation < 1 || meta.DeletionTimestamp != nil {
+		return Subject{}, fmt.Errorf("subject must be a live namespaced Agent, AgentRun or AgentRuntime")
+	}
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return Subject{}, err
+	}
+	digest := sha256.Sum256(b)
+	return Subject{kind, meta.Namespace, meta.Name, meta.UID, meta.Generation, "sha256:" + hex.EncodeToString(digest[:])}, nil
+}
+
+// GrantDocument is stored under grants.json in an operator-owned ConfigMap.
+// All three layers bind both subjects so approvals cannot cross runtime/Agent
+// combinations. Source locations are deployment configuration, never run input.
+type GrantDocument struct {
+	APIVersion string  `json:"apiVersion"`
+	Layer      string  `json:"layer"`
+	Agent      Subject `json:"agent"`
+	Runtime    Subject `json:"runtime"`
+	Grants     []Grant `json:"grants"`
+}
+
+type SourceRevision struct {
+	Namespace       string    `json:"namespace"`
+	Name            string    `json:"name"`
+	UID             types.UID `json:"uid"`
+	ResourceVersion string    `json:"resourceVersion"`
+	SHA256          string    `json:"sha256"`
+}
+
+type Selection struct {
+	Name     string
+	Revision string
+	Limits   *api.CellnToolLimits
+}
+
+// Loader requires an uncached APIReader and source refs selected by trusted
+// controller configuration. RBAC must deny tenant writes to these ConfigMaps.
+// The loader cannot infer write ownership from a ConfigMap label or status.
+type Loader struct {
+	Reader         client.Reader
+	OperatorSource types.NamespacedName
+	RuntimeSource  types.NamespacedName
+	AgentSource    types.NamespacedName
+}
+
+type SelectionSnapshot struct {
+	Agent       Subject              `json:"agent"`
+	Runtime     Subject              `json:"runtime"`
+	Sources     []SourceRevision     `json:"sources"`
+	Tools       []ResolvedTool       `json:"tools"`
+	RuntimeSpec api.AgentRuntimeSpec `json:"runtimeSpec"`
+}
+
+func (l Loader) Resolve(ctx context.Context, agentKey types.NamespacedName, selection []Selection) (*SelectionSnapshot, error) {
+	if l.Reader == nil || agentKey.Namespace == "" || agentKey.Name == "" || len(selection) > 16 {
+		return nil, fmt.Errorf("reader, Agent identity and bounded selection required")
+	}
+	var agent api.Agent
+	if err := l.Reader.Get(ctx, agentKey, &agent); err != nil {
+		return nil, err
+	}
+	if agent.Spec.RuntimeRef == "" {
+		return nil, fmt.Errorf("Agent has no approved runtime reference")
+	}
+	var runtime api.AgentRuntime
+	runtimeKey := types.NamespacedName{Namespace: agentKey.Namespace, Name: agent.Spec.RuntimeRef}
+	if err := l.Reader.Get(ctx, runtimeKey, &runtime); err != nil {
+		return nil, err
+	}
+	agentID, err := IdentifySubject("Agent", agent.ObjectMeta, agent.Spec)
+	if err != nil {
+		return nil, err
+	}
+	runtimeID, err := IdentifySubject("AgentRuntime", runtime.ObjectMeta, runtime.Spec)
+	if err != nil {
+		return nil, err
+	}
+	if runtime.Spec.Celln == nil || runtime.Spec.Celln.ContractVersion != "celln.json-tools/v1" {
+		return nil, fmt.Errorf("runtime does not declare the JSON Celln contract")
+	}
+	result := &SelectionSnapshot{Agent: agentID, Runtime: runtimeID, RuntimeSpec: *runtime.Spec.DeepCopy()}
+	request := ToolRequest{Namespace: agentKey.Namespace}
+	refs := []types.NamespacedName{l.OperatorSource, l.RuntimeSource, l.AgentSource}
+	seen := map[types.NamespacedName]bool{}
+	layers := []string{"operator", "runtime", "agent"}
+	grants := make([][]Grant, 3)
+	for i, ref := range refs {
+		if ref.Namespace == "" || ref.Name == "" || seen[ref] {
+			return nil, fmt.Errorf("three distinct configured grant sources required")
+		}
+		seen[ref] = true
+		doc, rev, err := l.read(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		if doc.APIVersion != "sympozium.ai/celln-grants-v1" || doc.Layer != layers[i] || doc.Agent != agentID || doc.Runtime != runtimeID || doc.Grants == nil || len(doc.Grants) > 16 {
+			return nil, fmt.Errorf("%s grant source absent, stale or wrong subject", layers[i])
+		}
+		result.Sources = append(result.Sources, rev)
+		grants[i] = doc.Grants
+	}
+	request.Operator, request.Runtime, request.Agent = grants[0], grants[1], grants[2]
+	for _, s := range selection {
+		if s.Name == "" || s.Revision == "" {
+			return nil, fmt.Errorf("tool name and revision required")
+		}
+		var tool api.CellnTool
+		if err := l.Reader.Get(ctx, types.NamespacedName{Namespace: agentKey.Namespace, Name: s.Name}, &tool); err != nil {
+			return nil, err
+		}
+		id, err := Identify(tool)
+		if err != nil {
+			return nil, err
+		}
+		if tool.Spec.InvocationABI != "celln.json-stdio/v1" || tool.Spec.Lane != "tool" {
+			return nil, fmt.Errorf("selection requires an approved JSON tool-lane artifact")
+		}
+		if id.Revision != s.Revision {
+			return nil, fmt.Errorf("selected revision changed")
+		}
+		limits := tool.Spec.Limits
+		if s.Limits != nil {
+			limits = *s.Limits.DeepCopy()
+		}
+		request.Selection = append(request.Selection, Grant{Tool: id, Limits: limits})
+		request.Catalogue = append(request.Catalogue, tool)
+	}
+	result.Tools, err = ResolveTools(request)
+	if err != nil {
+		return nil, err
+	}
+	// Detect observed changes during this multi-object read. This is not a
+	// Kubernetes transaction or a lease; revalidation is mandatory before work.
+	for i, ref := range refs {
+		_, rev, err := l.read(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		if rev != result.Sources[i] {
+			return nil, fmt.Errorf("grant source changed during resolution")
+		}
+	}
+	var currentAgent api.Agent
+	if err := l.Reader.Get(ctx, agentKey, &currentAgent); err != nil {
+		return nil, err
+	}
+	currentAgentID, err := IdentifySubject("Agent", currentAgent.ObjectMeta, currentAgent.Spec)
+	if err != nil || currentAgentID != agentID {
+		return nil, fmt.Errorf("Agent changed during resolution")
+	}
+	var currentRuntime api.AgentRuntime
+	if err := l.Reader.Get(ctx, runtimeKey, &currentRuntime); err != nil {
+		return nil, err
+	}
+	currentRuntimeID, err := IdentifySubject("AgentRuntime", currentRuntime.ObjectMeta, currentRuntime.Spec)
+	if err != nil || currentRuntimeID != runtimeID {
+		return nil, fmt.Errorf("runtime changed during resolution")
+	}
+	for _, resolved := range result.Tools {
+		var current api.CellnTool
+		if err := l.Reader.Get(ctx, types.NamespacedName{Namespace: resolved.Identity.Namespace, Name: resolved.Identity.Name}, &current); err != nil {
+			return nil, err
+		}
+		id, err := Identify(current)
+		if err != nil || id != resolved.Identity {
+			return nil, fmt.Errorf("tool changed during resolution")
+		}
+	}
+	return result, nil
+}
+
+func (l Loader) read(ctx context.Context, ref types.NamespacedName) (GrantDocument, SourceRevision, error) {
+	var cm corev1.ConfigMap
+	if err := l.Reader.Get(ctx, ref, &cm); err != nil {
+		return GrantDocument{}, SourceRevision{}, err
+	}
+	raw, ok := cm.Data["grants.json"]
+	if !ok || len(raw) > 262144 || cm.UID == "" || cm.ResourceVersion == "" || cm.DeletionTimestamp != nil {
+		return GrantDocument{}, SourceRevision{}, fmt.Errorf("grant source unavailable or invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewBufferString(raw))
+	decoder.DisallowUnknownFields()
+	var doc GrantDocument
+	if err := decoder.Decode(&doc); err != nil {
+		return doc, SourceRevision{}, fmt.Errorf("invalid grant document: %w", err)
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		return doc, SourceRevision{}, fmt.Errorf("trailing grant data")
+	}
+	digest := sha256.Sum256([]byte(raw))
+	return doc, SourceRevision{cm.Namespace, cm.Name, cm.UID, cm.ResourceVersion, "sha256:" + hex.EncodeToString(digest[:])}, nil
+}

--- a/internal/cellnauthority/loader_test.go
+++ b/internal/cellnauthority/loader_test.go
@@ -1,0 +1,162 @@
+package cellnauthority
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func loaderFixture(t *testing.T) (Loader, client.Client, types.NamespacedName, []Selection) {
+	t.Helper()
+	r := fixture(t)
+	tool := r.Catalogue[0]
+	tool.Spec.InvocationABI = "celln.json-stdio/v1"
+	id, err := Identify(tool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant := Grant{Tool: id, Limits: tool.Spec.Limits}
+	agent := &api.Agent{ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "agent", UID: "agent-uid", Generation: 1}, Spec: api.AgentSpec{RuntimeRef: "harness"}}
+	hash := api.CellnImmutableRef{Hash: "blake3:" + strings.Repeat("c", 64)}
+	harness := &api.AgentRuntime{ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "harness", UID: "runtime-uid", Generation: 1}, Spec: api.AgentRuntimeSpec{Celln: &api.AgentRuntimeCellnProfile{
+		ContractVersion: "celln.json-tools/v1", Revision: "v1", Platform: "linux/amd64", Lane: "agent", Lifecycle: "disposable-one-shot",
+		Executable: hash, Closure: hash, Mote: hash, PublisherKey: strings.Repeat("d", 64), EntryPoint: "/harness",
+		JSON: &api.CellnHarnessJSONLimits{MaxTurns: 3, MaxCalls: 2}, Limits: api.AgentRuntimeCellnLimits{TimeoutMillis: 90000, MemoryBytes: 268435456, TaskBytes: 2048, OutputBytes: 65536, Workspace: "none"},
+	}}}
+	agentID, _ := IdentifySubject("Agent", agent.ObjectMeta, agent.Spec)
+	runtimeID, _ := IdentifySubject("AgentRuntime", harness.ObjectMeta, harness.Spec)
+	scheme := runtime.NewScheme()
+	if err := api.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	objects := []client.Object{agent, harness, &tool}
+	for _, layer := range []string{"operator", "runtime", "agent"} {
+		raw, err := json.Marshal(GrantDocument{APIVersion: "sympozium.ai/celln-grants-v1", Layer: layer, Agent: agentID, Runtime: runtimeID, Grants: []Grant{grant}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		objects = append(objects, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "operator", Name: layer, UID: types.UID(layer + "-uid"), ResourceVersion: "1"}, Data: map[string]string{"grants.json": string(raw)}})
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	l := Loader{Reader: c, OperatorSource: types.NamespacedName{Namespace: "operator", Name: "operator"}, RuntimeSource: types.NamespacedName{Namespace: "operator", Name: "runtime"}, AgentSource: types.NamespacedName{Namespace: "operator", Name: "agent"}}
+	return l, c, client.ObjectKeyFromObject(agent), []Selection{{Name: tool.Name, Revision: tool.Spec.Revision}}
+}
+
+func TestLoaderReadsAllLayersAndPinsSources(t *testing.T) {
+	l, _, agent, selection := loaderFixture(t)
+	got, err := l.Resolve(context.Background(), agent, selection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Tools) != 1 || len(got.Sources) != 3 || got.Runtime.UID != "runtime-uid" {
+		t.Fatalf("bad snapshot: %+v", got)
+	}
+	selection[0].Limits = &api.CellnToolLimits{TimeoutMillis: 100, MemoryBytes: 1024, ArgumentBytes: 64, OutputBytes: 64, Workspace: "none", Effects: "none"}
+	got, err = l.Resolve(context.Background(), agent, selection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tools[0].Limits.TimeoutMillis != 100 {
+		t.Fatal("selection ceiling ignored")
+	}
+	got, err = l.Resolve(context.Background(), agent, nil)
+	if err != nil || len(got.Tools) != 0 {
+		t.Fatalf("empty selection: %+v %v", got, err)
+	}
+}
+
+func TestLoaderRefusesWithdrawalStaleSubjectsAndUntrustedLookalikes(t *testing.T) {
+	for _, mode := range []string{"withdrawn", "wrong-layer", "stale-agent", "stale-runtime", "wrong-revision", "missing-source", "trailing-json", "unknown-field", "tenant-lookalike", "duplicate-source"} {
+		t.Run(mode, func(t *testing.T) {
+			l, c, agent, selection := loaderFixture(t)
+			ctx := context.Background()
+			var cm corev1.ConfigMap
+			if err := c.Get(ctx, l.AgentSource, &cm); err != nil {
+				t.Fatal(err)
+			}
+			var doc GrantDocument
+			if err := json.Unmarshal([]byte(cm.Data["grants.json"]), &doc); err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "withdrawn":
+				doc.Grants = []Grant{}
+			case "wrong-layer":
+				doc.Layer = "operator"
+			case "stale-agent":
+				doc.Agent.UID = "recreated"
+			case "stale-runtime":
+				doc.Runtime.SpecSHA256 = "changed"
+			case "wrong-revision":
+				selection[0].Revision = "v2"
+			case "missing-source", "tenant-lookalike":
+				if err := c.Delete(ctx, &cm); err != nil {
+					t.Fatal(err)
+				}
+				if mode == "tenant-lookalike" {
+					cm.Namespace = "tenant"
+					cm.ResourceVersion = ""
+					cm.UID = "tenant-forged"
+					if err := c.Create(ctx, &cm); err != nil {
+						t.Fatal(err)
+					}
+				}
+			case "duplicate-source":
+				l.AgentSource = l.RuntimeSource
+			}
+			if mode != "missing-source" && mode != "tenant-lookalike" {
+				raw, _ := json.Marshal(doc)
+				if mode == "trailing-json" {
+					raw = append(raw, []byte(" {}")...)
+				}
+				if mode == "unknown-field" {
+					raw = append([]byte(`{"approval":true,`), raw[1:]...)
+				}
+				cm.Data["grants.json"] = string(raw)
+				if err := c.Update(ctx, &cm); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got, err := l.Resolve(ctx, agent, selection); err == nil || got != nil {
+				t.Fatalf("accepted %s: %+v", mode, got)
+			}
+		})
+	}
+}
+
+type changingReader struct {
+	client.Reader
+	reads int
+}
+
+func (r *changingReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := r.Reader.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	if cm, ok := obj.(*corev1.ConfigMap); ok && key.Name == "operator" {
+		r.reads++
+		if r.reads > 1 {
+			cm.ResourceVersion = "changed"
+		}
+	}
+	return nil
+}
+func TestLoaderRefusesObservedPolicyChange(t *testing.T) {
+	l, c, agent, selection := loaderFixture(t)
+	l.Reader = &changingReader{Reader: c}
+	if got, err := l.Resolve(context.Background(), agent, selection); err == nil || got != nil {
+		t.Fatal("accepted changing source")
+	}
+}

--- a/internal/cellnauthority/plan.go
+++ b/internal/cellnauthority/plan.go
@@ -1,0 +1,85 @@
+package cellnauthority
+
+import (
+	"fmt"
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CompositionPlan is the exact celln closure compose input wire contract.
+// Its source identities are descriptor-byte BLAKE3 hashes, not metadata hashes.
+type CompositionPlan struct {
+	APIVersion string   `json:"apiVersion"`
+	Sources    []string `json:"sources"`
+	ImageBytes int64    `json:"imageBytes"`
+}
+
+// PreparedSelection is an operator packaging input, not a runnable request.
+// The actual composed image/mote, host model grant, conformance and readiness
+// are deliberately absent: no selection metadata can manufacture those proofs.
+type PreparedSelection struct {
+	Composition       CompositionPlan             `json:"composition"`
+	RuntimeExecutable api.CellnImmutableRef       `json:"runtimeExecutable"`
+	RuntimeEntryPoint string                      `json:"runtimeEntryPoint"`
+	BorrowedTools     []api.CellnBorrowedTool     `json:"borrowedTools"`
+	Limits            api.AgentRuntimeCellnLimits `json:"limits"`
+	JSON              api.CellnHarnessJSONLimits  `json:"json"`
+}
+
+func Prepare(snapshot SelectionSnapshot, imageBytes int64) (*PreparedSelection, error) {
+	subject := snapshot.Runtime
+	id, err := IdentifySubject("AgentRuntime", metav1.ObjectMeta{Namespace: subject.Namespace, Name: subject.Name, UID: subject.UID, Generation: subject.Generation}, snapshot.RuntimeSpec)
+	if err != nil || id != subject || subject.Namespace != snapshot.Agent.Namespace {
+		return nil, fmt.Errorf("runtime metadata changed or crossed namespace")
+	}
+	p := snapshot.RuntimeSpec.Celln
+	if p == nil {
+		return nil, fmt.Errorf("Celln runtime profile required")
+	}
+	if p.ContractVersion != "celln.json-tools/v1" || p.Platform != "linux/amd64" || p.Lane != "agent" || p.Lifecycle != "disposable-one-shot" || len(p.RuntimeData) != 0 || p.JSON == nil || p.JSON.MaxTurns < 1 || p.JSON.MaxTurns > 6 || p.JSON.MaxCalls < 0 || p.JSON.MaxCalls > 16 || !hashPattern.MatchString(p.Executable.Hash) || !hashPattern.MatchString(p.Closure.Hash) || !hashPattern.MatchString(p.Mote.Hash) || !publisherPattern.MatchString(p.PublisherKey) || !pathPattern.MatchString(p.EntryPoint) || len(p.EntryPoint) > 256 || p.EntryPoint == "/pilot-fetch" || len(p.Revision) < 1 || len(p.Revision) > 64 {
+		return nil, fmt.Errorf("invalid or unsupported JSON runtime profile")
+	}
+	l := p.Limits
+	if l.TimeoutMillis < 1 || l.TimeoutMillis > 300000 || l.MemoryBytes < 1 || l.MemoryBytes > 268435456 || l.TaskBytes < 1 || l.TaskBytes > 2048 || l.OutputBytes < 1 || l.OutputBytes > 65536 || l.Workspace != "none" || len(snapshot.Tools) > 16 {
+		return nil, fmt.Errorf("invalid runtime ceilings")
+	}
+	if imageBytes < 33554432 || imageBytes > 536870912 || imageBytes%2097152 != 0 {
+		return nil, fmt.Errorf("image must be 32..512 MiB, 2 MiB aligned")
+	}
+	result := &PreparedSelection{Composition: CompositionPlan{APIVersion: "celln.dev/composition-plan-v1", Sources: []string{p.Closure.Hash}, ImageBytes: imageBytes}, RuntimeExecutable: p.Executable, RuntimeEntryPoint: p.EntryPoint, Limits: l, JSON: *p.JSON, BorrowedTools: []api.CellnBorrowedTool{}}
+	names := map[string]bool{}
+	paths := map[string]bool{p.EntryPoint: true, "/pilot-fetch": true}
+	sources := map[string]bool{p.Closure.Hash: true}
+	for _, tool := range snapshot.Tools {
+		s := tool.Spec
+		if tool.Identity.Namespace != snapshot.Agent.Namespace || tool.Identity.Name == "" || names[tool.Identity.Name] || paths[s.EntryPoint] || sources[s.Closure.Hash] || s.InvocationABI != "celln.json-stdio/v1" || s.Lane != "tool" {
+			return nil, fmt.Errorf("unsupported or colliding selected tool")
+		}
+		// Recheck metadata identity so a mutated copy cannot substitute artifact
+		// bytes between authorization and preparation.
+		object := api.CellnTool{Spec: s}
+		object.Namespace = tool.Identity.Namespace
+		object.Name = tool.Identity.Name
+		object.UID = tool.Identity.UID
+		object.Generation = tool.Identity.Generation
+		id, err := Identify(object)
+		if err != nil || id != tool.Identity {
+			return nil, fmt.Errorf("selected tool metadata changed")
+		}
+		if err := validateLimits(tool.Limits); err != nil {
+			return nil, err
+		}
+		if tool.Limits.TimeoutMillis > s.Limits.TimeoutMillis || tool.Limits.MemoryBytes > s.Limits.MemoryBytes || tool.Limits.ArgumentBytes > s.Limits.ArgumentBytes || tool.Limits.OutputBytes > s.Limits.OutputBytes || tool.Limits.Effects != s.Limits.Effects {
+			return nil, fmt.Errorf("selected limits exceed tool declaration")
+		}
+		names[tool.Identity.Name] = true
+		paths[s.EntryPoint] = true
+		sources[s.Closure.Hash] = true
+		result.Composition.Sources = append(result.Composition.Sources, s.Closure.Hash)
+		result.BorrowedTools = append(result.BorrowedTools, api.CellnBorrowedTool{Name: tool.Identity.Name, Path: s.EntryPoint, Hash: s.Executable.Hash, Description: s.Description, JSONStdio: &api.CellnJSONToolIO{ABI: s.InvocationABI, InputSchema: s.ArgumentsSchema.Hash, OutputSchema: s.ResultSchema.Hash, InputBytes: tool.Limits.ArgumentBytes, OutputBytes: tool.Limits.OutputBytes, TimeoutMs: tool.Limits.TimeoutMillis}})
+		// Tools share the cell memory budget. Until a separate per-process memory
+		// contract exists, cap the entire cell at every selected tool's ceiling.
+		result.Limits.MemoryBytes = min(result.Limits.MemoryBytes, tool.Limits.MemoryBytes)
+	}
+	return result, nil
+}

--- a/internal/cellnauthority/plan.go
+++ b/internal/cellnauthority/plan.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"regexp"
 )
+
+var jsonToolName = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 
 // CompositionPlan is the exact celln closure compose input wire contract.
 // Its source identities are descriptor-byte BLAKE3 hashes, not metadata hashes.
@@ -52,7 +55,7 @@ func Prepare(snapshot SelectionSnapshot, imageBytes int64) (*PreparedSelection, 
 	sources := map[string]bool{p.Closure.Hash: true}
 	for _, tool := range snapshot.Tools {
 		s := tool.Spec
-		if tool.Identity.Namespace != snapshot.Agent.Namespace || tool.Identity.Name == "" || names[tool.Identity.Name] || paths[s.EntryPoint] || sources[s.Closure.Hash] || s.InvocationABI != "celln.json-stdio/v1" || s.Lane != "tool" {
+		if tool.Identity.Namespace != snapshot.Agent.Namespace || !jsonToolName.MatchString(tool.Identity.Name) || names[tool.Identity.Name] || paths[s.EntryPoint] || sources[s.Closure.Hash] || s.InvocationABI != "celln.json-stdio/v1" || s.Lane != "tool" {
 			return nil, fmt.Errorf("unsupported or colliding selected tool")
 		}
 		// Recheck metadata identity so a mutated copy cannot substitute artifact

--- a/internal/cellnauthority/plan_test.go
+++ b/internal/cellnauthority/plan_test.go
@@ -3,6 +3,7 @@ package cellnauthority
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -45,7 +46,7 @@ func TestPrepareBindsCompositorAndJSONToolWire(t *testing.T) {
 }
 
 func TestPrepareRefusesMutationAndUnsupportedBounds(t *testing.T) {
-	for _, mode := range []string{"runtime-mutation", "tool-mutation", "grant-expansion", "duplicate", "small-image", "cross-namespace"} {
+	for _, mode := range []string{"runtime-mutation", "tool-mutation", "grant-expansion", "duplicate", "small-image", "cross-namespace", "dotted-name", "long-name"} {
 		t.Run(mode, func(t *testing.T) {
 			l, _, agent, selection := loaderFixture(t)
 			snapshot, err := l.Resolve(context.Background(), agent, selection)
@@ -54,6 +55,10 @@ func TestPrepareRefusesMutationAndUnsupportedBounds(t *testing.T) {
 			}
 			image := int64(33554432)
 			switch mode {
+			case "dotted-name":
+				snapshot.Tools[0].Identity.Name = "tool.example"
+			case "long-name":
+				snapshot.Tools[0].Identity.Name = strings.Repeat("x", 65)
 			case "runtime-mutation":
 				snapshot.RuntimeSpec.Celln.EntryPoint = "/replacement"
 			case "tool-mutation":

--- a/internal/cellnauthority/plan_test.go
+++ b/internal/cellnauthority/plan_test.go
@@ -1,0 +1,75 @@
+package cellnauthority
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestPrepareBindsCompositorAndJSONToolWire(t *testing.T) {
+	l, _, agent, selection := loaderFixture(t)
+	snapshot, err := l.Resolve(context.Background(), agent, selection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := Prepare(*snapshot, 33554432)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Composition.Sources) != 2 || plan.Composition.Sources[0] != snapshot.RuntimeSpec.Celln.Closure.Hash || plan.Composition.Sources[1] != snapshot.Tools[0].Spec.Closure.Hash {
+		t.Fatal("source ordering/identity lost")
+	}
+	if plan.Limits.MemoryBytes != snapshot.Tools[0].Limits.MemoryBytes {
+		t.Fatal("whole-cell memory did not honor tool ceiling")
+	}
+	tool := plan.BorrowedTools[0]
+	if tool.Name != selection[0].Name || tool.JSONStdio.InputSchema != snapshot.Tools[0].Spec.ArgumentsSchema.Hash || tool.JSONStdio.TimeoutMs != snapshot.Tools[0].Limits.TimeoutMillis {
+		t.Fatal("tool mapping lost authority")
+	}
+	raw, err := json.Marshal(plan.Composition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatal(err)
+	}
+	if len(wire) != 3 || wire["apiVersion"] != "celln.dev/composition-plan-v1" || wire["imageBytes"] != float64(33554432) {
+		t.Fatalf("wrong compositor wire: %s", raw)
+	}
+	snapshot.Tools = nil
+	empty, err := Prepare(*snapshot, 33554432)
+	if err != nil || len(empty.BorrowedTools) != 0 || len(empty.Composition.Sources) != 1 {
+		t.Fatal("empty selection expanded")
+	}
+}
+
+func TestPrepareRefusesMutationAndUnsupportedBounds(t *testing.T) {
+	for _, mode := range []string{"runtime-mutation", "tool-mutation", "grant-expansion", "duplicate", "small-image", "cross-namespace"} {
+		t.Run(mode, func(t *testing.T) {
+			l, _, agent, selection := loaderFixture(t)
+			snapshot, err := l.Resolve(context.Background(), agent, selection)
+			if err != nil {
+				t.Fatal(err)
+			}
+			image := int64(33554432)
+			switch mode {
+			case "runtime-mutation":
+				snapshot.RuntimeSpec.Celln.EntryPoint = "/replacement"
+			case "tool-mutation":
+				snapshot.Tools[0].Spec.EntryPoint = "/replacement"
+			case "grant-expansion":
+				snapshot.Tools[0].Limits.MemoryBytes++
+			case "duplicate":
+				snapshot.Tools = append(snapshot.Tools, snapshot.Tools[0])
+			case "small-image":
+				image = 4096
+			case "cross-namespace":
+				snapshot.Agent.Namespace = "other"
+			}
+			if plan, err := Prepare(*snapshot, image); err == nil || plan != nil {
+				t.Fatalf("accepted %s", mode)
+			}
+		})
+	}
+}

--- a/internal/cellnauthority/tools.go
+++ b/internal/cellnauthority/tools.go
@@ -1,6 +1,7 @@
-// Package cellnauthority resolves explicit tool selections without I/O. It does
-// not verify signatures, authorize callers, certify node readiness or dispatch.
-// Callers must obtain each grant layer from its independently trusted source.
+// Package cellnauthority intersects explicit tool selections. ResolveTools is
+// pure; Loader reads live objects and configured grant sources from Kubernetes.
+// Neither verifies signatures, certifies readiness, nor dispatches. Callers must
+// independently protect grant sources and authenticate selection ownership.
 package cellnauthority
 
 import (

--- a/internal/cellnreview/compose.go
+++ b/internal/cellnreview/compose.go
@@ -1,0 +1,138 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+)
+
+type ComposeOptions struct {
+	Binary     string
+	PolicyRoot string
+	KeyFile    string
+	OutputDir  string
+}
+
+type CompositionReport struct {
+	APIVersion        string   `json:"apiVersion"`
+	PlanHash          string   `json:"planHash"`
+	PolicyHash        string   `json:"policyHash"`
+	Closure           string   `json:"closure"`
+	Toolfs            string   `json:"toolfs"`
+	Sources           []string `json:"sources"`
+	ArtifactReadiness string   `json:"artifactReadiness"`
+	Conformance       string   `json:"conformance"`
+}
+
+// Compose builds local artifacts only. The caller supplies operator-owned paths
+// and grant sources; no request-provided command, source URL or credential is
+// executed. A refused post-build revalidation leaves diagnostic artifacts, not
+// an admission or runnable plan. No Kubernetes state is written.
+func Compose(ctx context.Context, loader cellnauthority.Loader, frozen cellnauthority.FrozenSelection, options ComposeOptions) (*CompositionReport, error) {
+	return compose(ctx, loader, frozen, options, func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		return runBudget(ctx, 60*time.Second, binary, args...)
+	})
+}
+
+func compose(ctx context.Context, loader cellnauthority.Loader, frozen cellnauthority.FrozenSelection, o ComposeOptions, execute runner) (*CompositionReport, error) {
+	for _, path := range []string{o.Binary, o.PolicyRoot, o.KeyFile, o.OutputDir} {
+		if !filepath.IsAbs(path) {
+			return nil, fmt.Errorf("composition paths must be absolute operator paths")
+		}
+	}
+	if _, err := os.Lstat(o.OutputDir); err == nil {
+		return nil, fmt.Errorf("composition output already exists")
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	if err := loader.Revalidate(ctx, frozen); err != nil {
+		return nil, err
+	}
+	p := frozen.Snapshot.RuntimeSpec.Celln
+	if p == nil {
+		return nil, fmt.Errorf("missing runtime profile")
+	}
+	var policyHash string
+	check := func(hash, publisher, entry, executable string) error {
+		path, err := storeObject(o.PolicyRoot, "closures", hash)
+		if err != nil {
+			return err
+		}
+		var report closureReport
+		args := []string{"--root", o.PolicyRoot, "closure", "verify", path, "--expected-hash", hash, "--publisher", publisher, "--entry-point", entry, "--executable", executable}
+		if err := verify(ctx, execute, o.Binary, args, &report); err != nil {
+			return err
+		}
+		if report.APIVersion != "celln.dev/closure-verification-v1" || report.Scope != "descriptor-authenticity-only" || report.Interpreter || report.Closure != hash || report.Publisher != publisher || report.EntryPoint != entry || report.ClosureEntryPoint != entry || report.Executable != executable || !artifactHash(report.PolicyHash) || report.ArtifactReadiness != "not_checked" || report.Conformance != "not_checked" {
+			return fmt.Errorf("source verification identity mismatch")
+		}
+		if policyHash != "" && policyHash != report.PolicyHash {
+			return fmt.Errorf("source policy changed during composition")
+		}
+		policyHash = report.PolicyHash
+		return nil
+	}
+	if err := check(p.Closure.Hash, p.PublisherKey, p.EntryPoint, p.Executable.Hash); err != nil {
+		return nil, err
+	}
+	for _, tool := range frozen.Snapshot.Tools {
+		s := tool.Spec
+		if err := check(s.Closure.Hash, s.PublisherKey, s.EntryPoint, s.Executable.Hash); err != nil {
+			return nil, err
+		}
+		for _, hash := range []string{s.ArgumentsSchema.Hash, s.ResultSchema.Hash} {
+			path, err := storeObject(o.PolicyRoot, "tool-schemas", hash)
+			if err != nil {
+				return nil, err
+			}
+			var report schemaReport
+			if err := verify(ctx, execute, o.Binary, []string{"schema", "verify", path, "--expected-hash", hash}, &report); err != nil {
+				return nil, err
+			}
+			if report.Schema != hash || report.APIVersion != "celln.dev/tool-schema-verification-v1" || report.Profile != "celln.tool-schema/v1" || report.Scope != "schema-and-data-only" || report.ValueValidated {
+				return nil, fmt.Errorf("schema verification identity mismatch")
+			}
+		}
+	}
+	staging, err := os.MkdirTemp("", "sympozium-celln-composition-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(staging)
+	bytes, err := json.Marshal(frozen.Prepared.Composition)
+	if err != nil {
+		return nil, err
+	}
+	planFile := filepath.Join(staging, "plan.json")
+	if err := os.WriteFile(planFile, bytes, 0600); err != nil {
+		return nil, err
+	}
+	if err := loader.Revalidate(ctx, frozen); err != nil {
+		return nil, err
+	}
+	var report CompositionReport
+	if err := verify(ctx, execute, o.Binary, []string{"--root", o.PolicyRoot, "closure", "compose", planFile, "--key-file", o.KeyFile, "--output-dir", o.OutputDir}, &report); err != nil {
+		return nil, err
+	}
+	if report.APIVersion != "celln.dev/composition-report-v1" || !artifactHash(report.PlanHash) || !artifactHash(report.Closure) || !artifactHash(report.Toolfs) || report.PolicyHash != policyHash || !reflect.DeepEqual(report.Sources, frozen.Prepared.Composition.Sources) || report.ArtifactReadiness != "not_checked" || report.Conformance != "not_checked" {
+		return nil, fmt.Errorf("composition report mismatch")
+	}
+	if err := loader.Revalidate(ctx, frozen); err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
+func storeObject(root, store, hash string) (string, error) {
+	if !artifactHash(hash) {
+		return "", fmt.Errorf("invalid artifact identity")
+	}
+	hex := hash[7:]
+	return filepath.Join(root, store, "objects", hex[:2], hex), nil
+}

--- a/internal/cellnreview/compose_live_test.go
+++ b/internal/cellnreview/compose_live_test.go
@@ -1,0 +1,170 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Real API-server authorization and selection proof. Never creates AgentRuns,
+// executes a cell, pauses controllers or obtains model credentials.
+func TestLiveCatalogueSelectionAndGrantIsolation(t *testing.T) {
+	configPath := os.Getenv("CELLN_COMPOSITION_KUBECONFIG")
+	fixture := os.Getenv("CELLN_COMPOSITION_FIXTURE")
+	if configPath == "" || fixture == "" {
+		t.Skip("explicit isolated kubeconfig and composition fixture required")
+	}
+	if !filepath.IsAbs(configPath) || !filepath.IsAbs(fixture) {
+		t.Fatal("absolute paths required")
+	}
+	config, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.CurrentContext != "kind-celln-deployed" {
+		t.Fatal("refusing non-test Kubernetes context")
+	}
+	cfg, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Timeout = 10 * time.Second
+	scheme := runtime.NewScheme()
+	_ = api.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	create := func(object client.Object) {
+		t.Helper()
+		if err := c.Create(ctx, object); err != nil {
+			t.Fatal(err)
+		}
+	}
+	namespace := func(prefix string) string {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: prefix}}
+		create(ns)
+		t.Cleanup(func() {
+			cleanup, stop := context.WithTimeout(context.Background(), 20*time.Second)
+			defer stop()
+			if err := c.Delete(cleanup, ns); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("namespace cleanup: %v", err)
+			}
+		})
+		return ns.Name
+	}
+	tenant := namespace("celln-selection-tenant-")
+	operator := namespace("celln-selection-operator-")
+	bytes, err := os.ReadFile(filepath.Join(fixture, "catalogue.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var catalogue struct {
+		RuntimeSpec api.AgentRuntimeSpec `json:"runtimeSpec"`
+		Tools       []struct {
+			Name string            `json:"name"`
+			Spec api.CellnToolSpec `json:"spec"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(bytes, &catalogue); err != nil {
+		t.Fatal(err)
+	}
+	rt := &api.AgentRuntime{ObjectMeta: metav1.ObjectMeta{Name: "runtime", Namespace: tenant}, Spec: catalogue.RuntimeSpec}
+	create(rt)
+	agent := &api.Agent{ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: tenant}, Spec: api.AgentSpec{RuntimeRef: rt.Name}}
+	agent.Spec.Agents.Default.Model = "deepseek-chat"
+	create(agent)
+	aid, err := cellnauthority.IdentifySubject("Agent", agent.ObjectMeta, agent.Spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rid, err := cellnauthority.IdentifySubject("AgentRuntime", rt.ObjectMeta, rt.Spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var grants []cellnauthority.Grant
+	var selected []cellnauthority.Selection
+	for _, tool := range catalogue.Tools {
+		object := &api.CellnTool{ObjectMeta: metav1.ObjectMeta{Name: tool.Name, Namespace: tenant}, Spec: tool.Spec}
+		create(object)
+		id, err := cellnauthority.Identify(*object)
+		if err != nil {
+			t.Fatal(err)
+		}
+		grants = append(grants, cellnauthority.Grant{Tool: id, Limits: object.Spec.Limits})
+		selected = append(selected, cellnauthority.Selection{Name: object.Name, Revision: object.Spec.Revision})
+	}
+	for _, layer := range []string{"operator", "runtime", "agent"} {
+		bytes, _ := json.Marshal(cellnauthority.GrantDocument{APIVersion: "sympozium.ai/celln-grants-v1", Layer: layer, Agent: aid, Runtime: rid, Grants: grants})
+		create(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: layer, Namespace: operator}, Data: map[string]string{"grants.json": string(bytes)}})
+	}
+	l := cellnauthority.Loader{Reader: c, OperatorSource: types.NamespacedName{Namespace: operator, Name: "operator"}, RuntimeSource: types.NamespacedName{Namespace: operator, Name: "runtime"}, AgentSource: types.NamespacedName{Namespace: operator, Name: "agent"}}
+	snapshot, err := l.Resolve(ctx, client.ObjectKeyFromObject(agent), selected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := cellnauthority.Prepare(*snapshot, 33554432)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Composition.Sources) != 3 || len(plan.BorrowedTools) != 2 {
+		t.Fatal("live source selection mismatch")
+	}
+	// Give the tenant real ConfigMap write permission in its own namespace.
+	// It must still be unable to edit the independently configured grant source.
+	user := "celln-selection-user-" + tenant
+	create(&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "tenant-configmaps", Namespace: tenant}, Rules: []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get", "create", "update"}}}})
+	create(&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tenant-configmaps", Namespace: tenant}, RoleRef: rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "tenant-configmaps"}, Subjects: []rbacv1.Subject{{Kind: "User", APIGroup: "rbac.authorization.k8s.io", Name: user}}})
+	tenantConfig := rest.CopyConfig(cfg)
+	tenantConfig.Impersonate = rest.ImpersonationConfig{UserName: user}
+	tenantClient, err := client.New(tenantConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var original corev1.ConfigMap
+	if err := c.Get(ctx, l.OperatorSource, &original); err != nil {
+		t.Fatal(err)
+	}
+	lookalike := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: original.Name, Namespace: tenant}, Data: original.Data}
+	if err := tenantClient.Create(ctx, lookalike); err != nil {
+		t.Fatal(err)
+	}
+	original.Data = map[string]string{"grants.json": "{}"}
+	if err := tenantClient.Update(ctx, &original); !apierrors.IsForbidden(err) {
+		t.Fatalf("tenant grant update must be forbidden: %v", err)
+	}
+	// Removing the genuine operator grant must not fall back to the lookalike.
+	if err := c.Delete(ctx, &original); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Resolve(ctx, client.ObjectKeyFromObject(agent), selected); err == nil {
+		t.Fatal("withdrawn source fell back to tenant lookalike")
+	}
+	var runs api.AgentRunList
+	if err := c.List(ctx, &runs, client.InNamespace(tenant)); err != nil {
+		t.Fatal(err)
+	}
+	if len(runs.Items) != 0 {
+		t.Fatal("unexpected AgentRun")
+	}
+	t.Logf("PASS live API selection of two real-artifact catalogue tools; tenant grant edit forbidden; genuine grant withdrawal refuses; namespaces=%s,%s; AgentRuns=0, modelCalls=0, KVM=not-run", tenant, operator)
+}

--- a/internal/cellnreview/compose_real_test.go
+++ b/internal/cellnreview/compose_real_test.go
@@ -1,0 +1,140 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Real binary/artifacts, fake Kubernetes metadata. Opt in explicitly; this is
+// not a live API-server, guest execution or model-call proof.
+func TestComposeRealCellnArtifacts(t *testing.T) {
+	fixture := os.Getenv("CELLN_COMPOSITION_FIXTURE")
+	binary := os.Getenv("CELLN_COMPOSITION_BINARY")
+	if fixture == "" || binary == "" {
+		t.Skip("explicit real Celln fixture and binary required")
+	}
+	if !filepath.IsAbs(fixture) || !filepath.IsAbs(binary) {
+		t.Fatal("absolute fixture and binary paths required")
+	}
+	l, _, _, _ := compositionFixture(t)
+	c := l.Reader.(client.Client)
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "store")
+	if err := os.CopyFS(root, os.DirFS(fixture)); err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := os.ReadFile(filepath.Join(root, "catalogue.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var catalogue struct {
+		RuntimeSpec api.AgentRuntimeSpec `json:"runtimeSpec"`
+		Tools       []struct {
+			Name string            `json:"name"`
+			Spec api.CellnToolSpec `json:"spec"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(bytes, &catalogue); err != nil {
+		t.Fatal(err)
+	}
+	var runtime api.AgentRuntime
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "tenant", Name: "runtime"}, &runtime); err != nil {
+		t.Fatal(err)
+	}
+	runtime.Spec = catalogue.RuntimeSpec
+	if err := c.Update(ctx, &runtime); err != nil {
+		t.Fatal(err)
+	}
+	var agent api.Agent
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "tenant", Name: "agent"}, &agent); err != nil {
+		t.Fatal(err)
+	}
+	aid, _ := cellnauthority.IdentifySubject("Agent", agent.ObjectMeta, agent.Spec)
+	rid, _ := cellnauthority.IdentifySubject("AgentRuntime", runtime.ObjectMeta, runtime.Spec)
+	var grants []cellnauthority.Grant
+	var selections []cellnauthority.Selection
+	for _, tool := range catalogue.Tools {
+		object := &api.CellnTool{ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: tool.Name, UID: types.UID(tool.Name), Generation: 1}, Spec: tool.Spec}
+		if err := c.Create(ctx, object); err != nil {
+			t.Fatal(err)
+		}
+		id, err := cellnauthority.Identify(*object)
+		if err != nil {
+			t.Fatal(err)
+		}
+		grants = append(grants, cellnauthority.Grant{Tool: id, Limits: tool.Spec.Limits})
+		selections = append(selections, cellnauthority.Selection{Name: tool.Name, Revision: tool.Spec.Revision})
+	}
+	for _, ref := range []types.NamespacedName{l.OperatorSource, l.RuntimeSource, l.AgentSource} {
+		var cm corev1.ConfigMap
+		if err := c.Get(ctx, ref, &cm); err != nil {
+			t.Fatal(err)
+		}
+		doc := cellnauthority.GrantDocument{APIVersion: "sympozium.ai/celln-grants-v1", Layer: ref.Name, Agent: aid, Runtime: rid, Grants: grants}
+		bytes, _ := json.Marshal(doc)
+		cm.Data["grants.json"] = string(bytes)
+		if err := c.Update(ctx, &cm); err != nil {
+			t.Fatal(err)
+		}
+	}
+	frozen, err := l.FreezeRun(ctx, types.NamespacedName{Namespace: "tenant", Name: "run"}, selections, 33554432)
+	if err != nil {
+		t.Fatal(err)
+	}
+	options := ComposeOptions{Binary: binary, PolicyRoot: root, KeyFile: filepath.Join(root, "public-fixture-seed"), OutputDir: filepath.Join(t.TempDir(), "composed")}
+	report, err := Compose(ctx, l, *frozen, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Sources) != 3 {
+		t.Fatal("runtime plus two tools not composed")
+	}
+	descriptor := filepath.Join(options.OutputDir, "signed-closure.json")
+	bytes, err = os.ReadFile(descriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var signed struct {
+		Publisher string `json:"publisher"`
+	}
+	if err := json.Unmarshal(bytes, &signed); err != nil {
+		t.Fatal(err)
+	}
+	var verified closureReport
+	if err := verify(ctx, run, binary, []string{"--root", root, "closure", "verify", descriptor, "--expected-hash", report.Closure, "--publisher", signed.Publisher, "--entry-point", "/harness", "--executable", catalogue.RuntimeSpec.Celln.Executable.Hash, "--toolfs", filepath.Join(options.OutputDir, "toolfs.ext2")}, &verified); err != nil {
+		t.Fatal(err)
+	}
+	if !verified.LocalToolfsVerified || verified.Toolfs != report.Toolfs {
+		t.Fatal("actual image identity mismatch")
+	}
+	// Withdraw a real signed source in the Celln policy: the composed artifact
+	// must refuse even while all Kubernetes grant objects still exist unchanged.
+	policy := filepath.Join(root, "trusted-closures.json")
+	bytes, err = os.ReadFile(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var changed map[string]any
+	if err := json.Unmarshal(bytes, &changed); err != nil {
+		t.Fatal(err)
+	}
+	changed["revoked"] = []string{report.Sources[1]}
+	bytes, _ = json.Marshal(changed)
+	if err := os.WriteFile(policy, bytes, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := verify(ctx, run, binary, []string{"--root", root, "closure", "verify", descriptor, "--expected-hash", report.Closure, "--publisher", signed.Publisher, "--entry-point", "/harness", "--executable", catalogue.RuntimeSpec.Celln.Executable.Hash}, &verified); err == nil {
+		t.Fatal("source withdrawal did not refuse composed closure")
+	}
+	t.Logf("PASS real signed runtime + two tools -> actual compositor -> verified 32 MiB image -> source withdrawal refused; closure=%s toolfs=%s; Kubernetes=fake, KVM=not-run, modelCalls=0", report.Closure, report.Toolfs)
+}

--- a/internal/cellnreview/compose_test.go
+++ b/internal/cellnreview/compose_test.go
@@ -1,0 +1,144 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func compositionFixture(t *testing.T) (cellnauthority.Loader, *cellnauthority.FrozenSelection, ComposeOptions, runner) {
+	t.Helper()
+	ctx := context.Background()
+	hash := "blake3:" + strings.Repeat("a", 64)
+	ref := api.CellnImmutableRef{Hash: hash}
+	agent := &api.Agent{ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "agent", UID: "agent", Generation: 1}, Spec: api.AgentSpec{RuntimeRef: "runtime"}}
+	rt := &api.AgentRuntime{ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "runtime", UID: "runtime", Generation: 1}, Spec: api.AgentRuntimeSpec{Celln: &api.AgentRuntimeCellnProfile{Revision: "v1", ContractVersion: "celln.json-tools/v1", Executable: ref, Closure: ref, Mote: ref, PublisherKey: strings.Repeat("b", 64), EntryPoint: "/harness", Platform: "linux/amd64", Lane: "agent", Lifecycle: "disposable-one-shot", JSON: &api.CellnHarnessJSONLimits{MaxTurns: 1, MaxCalls: 0}, Limits: api.AgentRuntimeCellnLimits{TimeoutMillis: 1000, MemoryBytes: 268435456, TaskBytes: 2048, OutputBytes: 1024, Workspace: "none"}}}}
+	var run api.AgentRun
+	if err := json.Unmarshal([]byte(`{"metadata":{"namespace":"tenant","name":"run","uid":"run","generation":1},"spec":{"agentRef":"agent","backend":"celln","task":"answer"}}`), &run); err != nil {
+		t.Fatal(err)
+	}
+	aid, _ := cellnauthority.IdentifySubject("Agent", agent.ObjectMeta, agent.Spec)
+	rid, _ := cellnauthority.IdentifySubject("AgentRuntime", rt.ObjectMeta, rt.Spec)
+	objects := []client.Object{agent, rt, &run}
+	for _, layer := range []string{"operator", "runtime", "agent"} {
+		raw, _ := json.Marshal(cellnauthority.GrantDocument{APIVersion: "sympozium.ai/celln-grants-v1", Layer: layer, Agent: aid, Runtime: rid, Grants: []cellnauthority.Grant{}})
+		objects = append(objects, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "operators", Name: layer, UID: types.UID(layer), ResourceVersion: "1"}, Data: map[string]string{"grants.json": string(raw)}})
+	}
+	scheme := runtime.NewScheme()
+	_ = api.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	loader := cellnauthority.Loader{Reader: c, OperatorSource: types.NamespacedName{Namespace: "operators", Name: "operator"}, RuntimeSource: types.NamespacedName{Namespace: "operators", Name: "runtime"}, AgentSource: types.NamespacedName{Namespace: "operators", Name: "agent"}}
+	frozen, err := loader.FreezeRun(ctx, client.ObjectKeyFromObject(&run), nil, 33554432)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	options := ComposeOptions{Binary: filepath.Join(root, "celln"), PolicyRoot: root, KeyFile: filepath.Join(root, "seed"), OutputDir: filepath.Join(root, "output")}
+	execute := func(_ context.Context, binary string, args ...string) ([]byte, error) {
+		if binary != options.Binary {
+			t.Fatal("untrusted binary substitution")
+		}
+		if args[3] == "verify" {
+			return json.Marshal(closureReport{APIVersion: "celln.dev/closure-verification-v1", Scope: "descriptor-authenticity-only", Closure: hash, PolicyHash: hash, Publisher: rt.Spec.Celln.PublisherKey, EntryPoint: "/harness", ClosureEntryPoint: "/harness", Executable: hash, ArtifactReadiness: "not_checked", Conformance: "not_checked"})
+		}
+		if args[3] != "compose" {
+			t.Fatalf("unexpected command: %v", args)
+		}
+		bytes, err := os.ReadFile(args[4])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var plan cellnauthority.CompositionPlan
+		if err := json.Unmarshal(bytes, &plan); err != nil {
+			t.Fatal(err)
+		}
+		if plan.Sources[0] != hash || plan.ImageBytes != 33554432 {
+			t.Fatal("plan changed")
+		}
+		return json.Marshal(CompositionReport{APIVersion: "celln.dev/composition-report-v1", PlanHash: hash, PolicyHash: hash, Closure: hash, Toolfs: hash, Sources: plan.Sources, ArtifactReadiness: "not_checked", Conformance: "not_checked"})
+	}
+	return loader, frozen, options, execute
+}
+
+func TestComposeChecksSourcesAndRevalidatesWithoutAdmission(t *testing.T) {
+	l, f, o, run := compositionFixture(t)
+	calls := 0
+	var temporary string
+	wrapped := func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		calls++
+		if args[3] == "compose" {
+			temporary = args[4]
+		}
+		return run(ctx, binary, args...)
+	}
+	report, err := compose(context.Background(), l, *f, o, wrapped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || report.ArtifactReadiness != "not_checked" {
+		t.Fatal("missing checks")
+	}
+	if _, err := os.Stat(temporary); !os.IsNotExist(err) {
+		t.Fatal("temporary plan not cleaned up")
+	}
+}
+
+func TestComposeRejectsUnboundReportsAndPostBuildWithdrawal(t *testing.T) {
+	for _, mode := range []string{"publisher", "source-order", "policy", "readiness", "withdrawal", "existing-output"} {
+		t.Run(mode, func(t *testing.T) {
+			l, f, o, execute := compositionFixture(t)
+			if mode == "existing-output" {
+				if err := os.Mkdir(o.OutputDir, 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			wrapped := func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+				raw, err := execute(ctx, binary, args...)
+				if err != nil {
+					return nil, err
+				}
+				var report map[string]any
+				_ = json.Unmarshal(raw, &report)
+				if args[3] == "verify" && mode == "publisher" {
+					report["publisher"] = "wrong"
+				}
+				if args[3] == "compose" {
+					switch mode {
+					case "source-order":
+						report["sources"] = []string{}
+					case "policy":
+						report["policyHash"] = "blake3:" + strings.Repeat("f", 64)
+					case "readiness":
+						report["artifactReadiness"] = "ready"
+					case "withdrawal":
+						var cm corev1.ConfigMap
+						c := l.Reader.(client.Client)
+						if err := c.Get(ctx, l.AgentSource, &cm); err != nil {
+							t.Fatal(err)
+						}
+						if err := c.Delete(ctx, &cm); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+				return json.Marshal(report)
+			}
+			if report, err := compose(context.Background(), l, *f, o, wrapped); err == nil || report != nil {
+				t.Fatalf("accepted %s", mode)
+			}
+		})
+	}
+}

--- a/internal/cellnreview/review.go
+++ b/internal/cellnreview/review.go
@@ -140,6 +140,7 @@ type closureReport struct {
 	PolicyHash          string `json:"policyHash"`
 	Publisher           string `json:"publisher"`
 	EntryPoint          string `json:"entryPoint"`
+	ClosureEntryPoint   string `json:"closureEntryPoint"`
 	Executable          string `json:"executable"`
 	Toolfs              string `json:"toolfs"`
 	LocalToolfsVerified bool   `json:"localToolfsVerified"`
@@ -195,7 +196,11 @@ func (b *boundedOutput) Write(p []byte) (int, error) {
 }
 
 func run(ctx context.Context, binary string, args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	return runBudget(ctx, 30*time.Second, binary, args...)
+}
+
+func runBudget(ctx context.Context, budget time.Duration, binary string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, binary, args...)
 	// In particular, never pass provider credentials or tenant-selected env.


### PR DESCRIPTION
Progresses #426; does not close it.

Adds uncached Kubernetes grant-source loading, exact Agent/runtime/tool identity binding, ordered restrictive selection, frozen AgentRun plan revalidation, and operator celln-tool plan/compose commands. Compositions use the actual Celln CLI with explicit source publisher/root/executable/schema checks, bounded subprocess execution and post-build approval revalidation. No tenant-supplied grant source is accepted by a controller API; this PR exposes operator CLI workflows only.

Validation: targeted race-enabled CLI/authority/review/controller/webhook tests, full Go build and targeted vet. Opt-in real-artifact test composed native Harness + uppercase + length, verified the 32 MiB image and refused it after source revocation. Separate live isolated Kind API test verified real identities, tenant ConfigMap writes versus forbidden operator-grant writes, and refusal after genuine source withdrawal despite a tenant lookalike. No AgentRuns, model calls or cells were created in the live API test; generated namespaces were removed; Framework untouched. Evidence is committed.

Remaining: controller/UI/YAML high-level selection, trusted host-model grant issuance, artifact conformance/distribution/prewarm, conversation lifecycle and full catalogue-backed execution E2E. Readiness stays not_checked and executionAuthorized stays false in operator reports. Real-artifact test fixture is supplied by the paired Celln prepare_composition_fixture example.