### PR TITLE
feat: independently resolve Celln model-policy approval

### DIFF
--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -26,11 +26,15 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 	var selected []string
 	var imageBytes int64
 	var runName string
+	var modelPolicy string
 	var options cellnreview.ComposeOptions
 	cmd := &cobra.Command{Use: "plan AGENT", Args: cobra.ExactArgs(1), SilenceUsage: true,
 		Short: "Resolve live grants and emit a Celln composition plan without executing",
 		Long:  "Operator-only planning input. Read three independently configured grant ConfigMaps and live Agent/runtime/tool identities. Prints the resolved authority snapshot and exact compositor input; does not grant authority, certify readiness, write resources, compose images or execute. Tenant-facing callers must not accept these source flags from run requests.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if modelPolicy != "" && runName == "" {
+				return fmt.Errorf("model policy review requires --run")
+			}
 			selection := make([]cellnauthority.Selection, 0, len(selected))
 			for _, ref := range selected {
 				name, revision, ok := strings.Cut(ref, "@")
@@ -54,14 +58,27 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 				if err := loader.Revalidate(cmd.Context(), *frozen); err != nil {
 					return err
 				}
+				var modelApproval *cellnauthority.ModelApproval
+				modelLoader := cellnauthority.ModelLoader{Selection: loader, Source: types.NamespacedName{Namespace: sourceNamespace, Name: modelPolicy}}
+				if modelPolicy != "" {
+					modelApproval, err = modelLoader.Resolve(cmd.Context(), *frozen)
+					if err != nil {
+						return err
+					}
+				}
 				if compose {
 					report, err := cellnreview.Compose(cmd.Context(), loader, *frozen, options)
 					if err != nil {
 						return err
 					}
-					return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-composed-selection-v1", "frozen": frozen, "composition": report, "executionAuthorized": false})
+					if modelApproval != nil {
+						if err := modelLoader.Revalidate(cmd.Context(), *frozen, *modelApproval); err != nil {
+							return err
+						}
+					}
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-composed-selection-v1", "frozen": frozen, "composition": report, "modelApproval": modelApproval, "executionAuthorized": false})
 				}
-				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-selection-report-v1", "frozen": frozen, "artifactReadiness": "not_checked", "conformance": "not_checked", "executionAuthorized": false})
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-selection-report-v1", "frozen": frozen, "modelApproval": modelApproval, "artifactReadiness": "not_checked", "conformance": "not_checked", "executionAuthorized": false})
 			}
 			snapshot, err := loader.Resolve(cmd.Context(), types.NamespacedName{Namespace: namespace, Name: args[0]}, selection)
 			if err != nil {
@@ -80,6 +97,7 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 	cmd.Flags().StringArrayVar(&selected, "tool", nil, "Explicit NAME@REVISION; repeat in desired order; omission selects no tools")
 	cmd.Flags().Int64Var(&imageBytes, "image-bytes", 33554432, "Composed image size, 32..512 MiB and 2 MiB aligned")
 	cmd.Flags().StringVar(&runName, "run", "", "Bind and revalidate the plan against an existing same-namespace AgentRun (no dispatch)")
+	cmd.Flags().StringVar(&modelPolicy, "model-policy", "", "Independent operator model-policy ConfigMap in grant namespace; requires --run; does not issue a host grant")
 	for _, name := range []string{"grant-namespace", "operator-grants", "runtime-grants", "agent-grants"} {
 		_ = cmd.MarkFlagRequired(name)
 	}

--- a/cmd/sympozium/celln_selection_cmd_test.go
+++ b/cmd/sympozium/celln_selection_cmd_test.go
@@ -26,3 +26,14 @@ func TestSelectionPlanRequiresExplicitSourcesAndWellFormedSelections(t *testing.
 		}
 	}
 }
+
+func TestModelPolicyReviewRequiresRunBeforeReadingAPI(t *testing.T) {
+	cmd := newCellnSelectionPlanCmd()
+	cmd.SetArgs([]string{"agent", "--grant-namespace", "operator", "--operator-grants", "ops", "--runtime-grants", "runtime", "--agent-grants", "agent", "--model-policy", "models"})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "requires --run") {
+		t.Fatalf("wrong refusal: %v", err)
+	}
+}

--- a/docs/guides/celln-model-authority.md
+++ b/docs/guides/celln-model-authority.md
@@ -19,8 +19,9 @@ The `sympozium.ai/celln-model-policy-v1` document contains:
   secret value, Kubernetes Secret reference, or authorization by itself.
 - `maxRequests`: 1–6, at least the selected runtime's maximum turns.
 - `maxOutputTokens`: 512, matching the current host broker contract.
-- `maxTotalOutputTokens`: 512–3072. A smaller total may exhaust before all
-  turns complete; it must never be silently expanded.
+- `maxTotalOutputTokens`: 512–3072 and at least `maxTurns * 512`, matching the
+  host's non-refundable reservation for every configured JSON Harness turn.
+  Insufficient funding refuses; it must never be silently expanded.
 
 Resolution revalidates the frozen selection, reads the policy, compares the
 live run's full identity and explicit model options, then revalidates selection

--- a/docs/guides/celln-model-authority.md
+++ b/docs/guides/celln-model-authority.md
@@ -1,0 +1,56 @@
+# Independent Celln model authority
+
+Tool approval does not grant permission to spend a model credential. The
+control-plane `cellnauthority.ModelLoader` reads a separate operator-configured
+ConfigMap, with its document in `data["model-policy.json"]`. Its location must
+come from trusted deployment configuration, not an AgentRun. RBAC must deny
+tenant writes; labels and same-named tenant ConfigMaps do not prove ownership.
+The model policy source must differ from each of the three tool-grant sources.
+
+The `sympozium.ai/celln-model-policy-v1` document contains:
+
+- `agent` and `runtime`: complete `Subject` identities from the reviewed
+  selection (namespace, name, UID, generation and full-spec SHA256).
+- `provider`, `model`, `url`: exact model authority. The currently supported
+  contract is `deepseek`, an explicit model, and
+  `https://api.deepseek.com/chat/completions`.
+- `credentialProfile`: an opaque 1–64 character alphanumeric/underscore/hyphen
+  name for an independently configured host credential mapping. Not a path,
+  secret value, Kubernetes Secret reference, or authorization by itself.
+- `maxRequests`: 1–6, at least the selected runtime's maximum turns.
+- `maxOutputTokens`: 512, matching the current host broker contract.
+- `maxTotalOutputTokens`: 512–3072. A smaller total may exhaust before all
+  turns complete; it must never be silently expanded.
+
+Resolution revalidates the frozen selection, reads the policy, compares the
+live run's full identity and explicit model options, then revalidates selection
+and policy revision again. Nonempty tenant credential references, provider
+headers, model discovery, node selectors and unsupported thinking modes refuse
+instead of falling back to an ambient provider or credential. Documents are
+bounded to 64 KiB and unknown fields or trailing JSON refuse.
+
+The resulting `sympozium.ai/celln-model-approval-v1` record pins the complete
+frozen-selection SHA256, run-derived caller, policy content and source
+namespace/name/UID/resourceVersion/exact-document SHA256. Revalidation compares
+the entire record and never substitutes a new plan or execution ID.
+
+Operators can add `--model-policy CONFIGMAP` to `celln-tool plan` or
+`celln-tool compose`, along with `--run` and the existing grant-source flags.
+The policy resides in `--grant-namespace`. Composition revalidates model
+approval after building artifacts. These commands print a `modelApproval`
+observation and keep `executionAuthorized: false`.
+
+## Remaining issuance boundary
+
+This implementation reads no credentials, writes no Kubernetes resources or
+host grant files, and performs no model calls. Tests use a fake Kubernetes API;
+they are not deployment/RBAC or live-model proof. Observed rereads are not an
+atomic transaction, lease or fleet-wide withdrawal guarantee.
+
+The host issuer must still independently authenticate its control-plane caller,
+resolve `credentialProfile` through operator-owned host configuration, validate
+the actual admitted/prewarmed mote and composed closure, bind exact runtime,
+borrowed tools, persona and budgets, and publish a content-addressed grant only
+after fresh policy checks. Distribution, issuer/controller integration and the
+catalogue-backed real-model E2E remain required. An uploaded approval JSON or
+successful prewarm observation alone must never create model authority.

--- a/internal/cellnauthority/model.go
+++ b/internal/cellnauthority/model.go
@@ -1,0 +1,131 @@
+package cellnauthority
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ModelPolicyDocument is independent of tool approvals. It lives under
+// model-policy.json in a distinct operator-configured ConfigMap. CredentialProfile
+// is an opaque host-side mapping name, never a credential, path or tenant Secret.
+type ModelPolicyDocument struct {
+	APIVersion           string  `json:"apiVersion"`
+	Agent                Subject `json:"agent"`
+	Runtime              Subject `json:"runtime"`
+	Provider             string  `json:"provider"`
+	Model                string  `json:"model"`
+	URL                  string  `json:"url"`
+	CredentialProfile    string  `json:"credentialProfile"`
+	MaxRequests          int64   `json:"maxRequests"`
+	MaxOutputTokens      int64   `json:"maxOutputTokens"`
+	MaxTotalOutputTokens int64   `json:"maxTotalOutputTokens"`
+}
+
+// ModelApproval is a frozen control-plane policy observation, not a host grant.
+// Issuance must additionally bind verified runnable artifact identities, resolve
+// the profile through independent host configuration, and revalidate this record.
+type ModelApproval struct {
+	APIVersion      string              `json:"apiVersion"`
+	SelectionSHA256 string              `json:"selectionSHA256"`
+	Caller          string              `json:"caller"`
+	Source          SourceRevision      `json:"source"`
+	Policy          ModelPolicyDocument `json:"policy"`
+}
+
+type ModelLoader struct {
+	Selection Loader
+	Source    types.NamespacedName
+}
+
+var credentialProfileName = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+func (l ModelLoader) Resolve(ctx context.Context, frozen FrozenSelection) (*ModelApproval, error) {
+	if l.Selection.Reader == nil || l.Source.Namespace == "" || l.Source.Name == "" {
+		return nil, fmt.Errorf("independent configured model policy source required")
+	}
+	for _, toolSource := range []types.NamespacedName{l.Selection.OperatorSource, l.Selection.RuntimeSource, l.Selection.AgentSource} {
+		if l.Source == toolSource {
+			return nil, fmt.Errorf("model policy must be separate from tool approval sources")
+		}
+	}
+	if err := l.Selection.Revalidate(ctx, frozen); err != nil {
+		return nil, err
+	}
+	doc, revision, err := l.read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if doc.APIVersion != "sympozium.ai/celln-model-policy-v1" || doc.Agent != frozen.Snapshot.Agent || doc.Runtime != frozen.Snapshot.Runtime || doc.Provider != "deepseek" || doc.URL != "https://api.deepseek.com/chat/completions" || len(doc.Model) == 0 || len(doc.Model) > 128 || strings.TrimSpace(doc.Model) != doc.Model || strings.ContainsRune(doc.Model, '\x00') || !credentialProfileName.MatchString(doc.CredentialProfile) || doc.MaxRequests < 1 || doc.MaxRequests > 6 || doc.MaxRequests < frozen.Prepared.JSON.MaxTurns || doc.MaxOutputTokens != 512 || doc.MaxTotalOutputTokens < 512 || doc.MaxTotalOutputTokens > 3072 {
+		return nil, fmt.Errorf("model policy is stale or outside the supported host contract")
+	}
+	run, id, err := l.Selection.readRun(ctx, types.NamespacedName{Namespace: frozen.Run.Namespace, Name: frozen.Run.Name})
+	if err != nil {
+		return nil, err
+	}
+	m := run.Spec.Model
+	if id != frozen.Run || m.Provider != doc.Provider || m.Model != doc.Model || m.AuthSecretRef != "" || (m.BaseURL != "" && m.BaseURL != "https://api.deepseek.com") || (m.Thinking != "" && m.Thinking != "off") || len(m.ProviderHeaders) != 0 || m.ProviderHeadersSecretRef != "" || m.ModelRef != "" || len(m.NodeSelector) != 0 {
+		return nil, fmt.Errorf("run model or credential selection is not authorized")
+	}
+	// No credential contents are read. A second read detects observed withdrawal
+	// or replacement, but does not create a transaction, lease or fleet guarantee.
+	if err := l.Selection.Revalidate(ctx, frozen); err != nil {
+		return nil, err
+	}
+	_, current, err := l.read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if current != revision {
+		return nil, fmt.Errorf("model policy changed during resolution")
+	}
+	raw, err := json.Marshal(frozen)
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(raw)
+	return &ModelApproval{APIVersion: "sympozium.ai/celln-model-approval-v1", SelectionSHA256: "sha256:" + hex.EncodeToString(digest[:]), Caller: fmt.Sprintf("sympozium:%s/%s", frozen.Run.Namespace, frozen.Run.Name), Source: revision, Policy: doc}, nil
+}
+
+func (l ModelLoader) Revalidate(ctx context.Context, frozen FrozenSelection, approval ModelApproval) error {
+	current, err := l.Resolve(ctx, frozen)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(*current, approval) {
+		return fmt.Errorf("frozen model approval changed")
+	}
+	return nil
+}
+
+func (l ModelLoader) read(ctx context.Context) (ModelPolicyDocument, SourceRevision, error) {
+	var cm corev1.ConfigMap
+	if err := l.Selection.Reader.Get(ctx, l.Source, &cm); err != nil {
+		return ModelPolicyDocument{}, SourceRevision{}, err
+	}
+	raw, ok := cm.Data["model-policy.json"]
+	if !ok || len(raw) > 65536 || cm.UID == "" || cm.ResourceVersion == "" || cm.DeletionTimestamp != nil {
+		return ModelPolicyDocument{}, SourceRevision{}, fmt.Errorf("model policy source unavailable or invalid")
+	}
+	d := json.NewDecoder(bytes.NewBufferString(raw))
+	d.DisallowUnknownFields()
+	var doc ModelPolicyDocument
+	if err := d.Decode(&doc); err != nil {
+		return doc, SourceRevision{}, fmt.Errorf("invalid model policy document")
+	}
+	if err := d.Decode(new(any)); err != io.EOF {
+		return doc, SourceRevision{}, fmt.Errorf("trailing model policy data")
+	}
+	digest := sha256.Sum256([]byte(raw))
+	return doc, SourceRevision{cm.Namespace, cm.Name, cm.UID, cm.ResourceVersion, "sha256:" + hex.EncodeToString(digest[:])}, nil
+}

--- a/internal/cellnauthority/model.go
+++ b/internal/cellnauthority/model.go
@@ -66,7 +66,7 @@ func (l ModelLoader) Resolve(ctx context.Context, frozen FrozenSelection) (*Mode
 	if err != nil {
 		return nil, err
 	}
-	if doc.APIVersion != "sympozium.ai/celln-model-policy-v1" || doc.Agent != frozen.Snapshot.Agent || doc.Runtime != frozen.Snapshot.Runtime || doc.Provider != "deepseek" || doc.URL != "https://api.deepseek.com/chat/completions" || len(doc.Model) == 0 || len(doc.Model) > 128 || strings.TrimSpace(doc.Model) != doc.Model || strings.ContainsRune(doc.Model, '\x00') || !credentialProfileName.MatchString(doc.CredentialProfile) || doc.MaxRequests < 1 || doc.MaxRequests > 6 || doc.MaxRequests < frozen.Prepared.JSON.MaxTurns || doc.MaxOutputTokens != 512 || doc.MaxTotalOutputTokens < 512 || doc.MaxTotalOutputTokens > 3072 {
+	if doc.APIVersion != "sympozium.ai/celln-model-policy-v1" || doc.Agent != frozen.Snapshot.Agent || doc.Runtime != frozen.Snapshot.Runtime || doc.Provider != "deepseek" || doc.URL != "https://api.deepseek.com/chat/completions" || len(doc.Model) == 0 || len(doc.Model) > 128 || strings.TrimSpace(doc.Model) != doc.Model || strings.ContainsRune(doc.Model, '\x00') || !credentialProfileName.MatchString(doc.CredentialProfile) || doc.MaxRequests < 1 || doc.MaxRequests > 6 || doc.MaxRequests < frozen.Prepared.JSON.MaxTurns || doc.MaxOutputTokens != 512 || doc.MaxTotalOutputTokens < frozen.Prepared.JSON.MaxTurns*512 || doc.MaxTotalOutputTokens > 3072 {
 		return nil, fmt.Errorf("model policy is stale or outside the supported host contract")
 	}
 	run, id, err := l.Selection.readRun(ctx, types.NamespacedName{Namespace: frozen.Run.Namespace, Name: frozen.Run.Name})

--- a/internal/cellnauthority/model_test.go
+++ b/internal/cellnauthority/model_test.go
@@ -1,0 +1,216 @@
+package cellnauthority
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func modelFixture(t *testing.T) (ModelLoader, client.Client, *FrozenSelection) {
+	t.Helper()
+	l, c, old := frozenFixture(t)
+	ctx := context.Background()
+	var run api.AgentRun
+	key := types.NamespacedName{Namespace: old.Run.Namespace, Name: old.Run.Name}
+	if err := c.Get(ctx, key, &run); err != nil {
+		t.Fatal(err)
+	}
+	run.Spec.Model = api.ModelSpec{Provider: "deepseek", Model: "deepseek-chat"}
+	if err := c.Update(ctx, &run); err != nil {
+		t.Fatal(err)
+	}
+	selection := []Selection{}
+	for _, tool := range old.Snapshot.Tools {
+		selection = append(selection, Selection{Name: tool.Identity.Name, Revision: tool.Identity.Revision})
+	}
+	frozen, err := l.FreezeRun(ctx, key, selection, old.Prepared.Composition.ImageBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := ModelPolicyDocument{APIVersion: "sympozium.ai/celln-model-policy-v1", Agent: frozen.Snapshot.Agent, Runtime: frozen.Snapshot.Runtime, Provider: "deepseek", Model: "deepseek-chat", URL: "https://api.deepseek.com/chat/completions", CredentialProfile: "reviewed-deepseek", MaxRequests: 3, MaxOutputTokens: 512, MaxTotalOutputTokens: 1536}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "operator", Name: "model-policy", UID: "model-policy-uid"}, Data: map[string]string{"model-policy.json": string(raw)}}
+	if err := c.Create(ctx, cm); err != nil {
+		t.Fatal(err)
+	}
+	return ModelLoader{Selection: l, Source: client.ObjectKeyFromObject(cm)}, c, frozen
+}
+
+func TestModelApprovalPinsSelectionAndIndependentSource(t *testing.T) {
+	l, _, frozen := modelFixture(t)
+	approval, err := l.Resolve(context.Background(), *frozen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if approval.Caller != "sympozium:tenant/run" || !strings.HasPrefix(approval.SelectionSHA256, "sha256:") || approval.Source.UID != "model-policy-uid" {
+		t.Fatalf("missing identity: %+v", approval)
+	}
+	raw, err := json.Marshal(approval)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored ModelApproval
+	if err := json.Unmarshal(raw, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Revalidate(context.Background(), *frozen, restored); err != nil {
+		t.Fatal(err)
+	}
+	restored.Policy.MaxTotalOutputTokens++
+	if err := l.Revalidate(context.Background(), *frozen, restored); err == nil {
+		t.Fatal("accepted changed budget")
+	}
+}
+
+func TestModelPolicyChecksFreshRunOptionsWithoutFallback(t *testing.T) {
+	for _, mode := range []string{"provider", "model", "base-url", "thinking", "secret", "headers", "header-secret", "model-ref", "node-selector"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			l, c, old := modelFixture(t)
+			var run api.AgentRun
+			key := types.NamespacedName{Namespace: old.Run.Namespace, Name: old.Run.Name}
+			if err := c.Get(ctx, key, &run); err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "provider":
+				run.Spec.Model.Provider = "other"
+			case "model":
+				run.Spec.Model.Model = "different"
+			case "base-url":
+				run.Spec.Model.BaseURL = "https://untrusted.example"
+			case "thinking":
+				run.Spec.Model.Thinking = "high"
+			case "secret":
+				run.Spec.Model.AuthSecretRef = "tenant-key"
+			case "headers":
+				run.Spec.Model.ProviderHeaders = map[string]string{"X-Test": "value"}
+			case "header-secret":
+				run.Spec.Model.ProviderHeadersSecretRef = "tenant-headers"
+			case "model-ref":
+				run.Spec.Model.ModelRef = "local-model"
+			case "node-selector":
+				run.Spec.Model.NodeSelector = map[string]string{"node": "selected"}
+			}
+			if err := c.Update(ctx, &run); err != nil {
+				t.Fatal(err)
+			}
+			var selection []Selection
+			for _, tool := range old.Snapshot.Tools {
+				selection = append(selection, Selection{Name: tool.Identity.Name, Revision: tool.Identity.Revision})
+			}
+			fresh, err := l.Selection.FreezeRun(ctx, key, selection, old.Prepared.Composition.ImageBytes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := l.Resolve(ctx, *fresh); err == nil || !strings.Contains(err.Error(), "run model") {
+				t.Fatalf("unsupported options accepted or wrong refusal: %v", err)
+			}
+		})
+	}
+}
+
+func TestModelPolicyRefusesWithdrawalSubstitutionAndExpansion(t *testing.T) {
+	for _, mode := range []string{"withdrawn", "lookalike", "revision", "agent", "runtime", "provider", "model", "url", "profile-path", "budget", "turns", "tokens", "unknown", "trailing", "oversized", "tool-source", "run-credentials", "run-model"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			l, c, frozen := modelFixture(t)
+			approval, err := l.Resolve(ctx, *frozen)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var cm corev1.ConfigMap
+			if err := c.Get(ctx, l.Source, &cm); err != nil {
+				t.Fatal(err)
+			}
+			doc := approval.Policy
+			switch mode {
+			case "withdrawn", "lookalike":
+				if err := c.Delete(ctx, &cm); err != nil {
+					t.Fatal(err)
+				}
+				if mode == "lookalike" {
+					cm.Namespace = "tenant"
+					cm.UID = "forged"
+					cm.ResourceVersion = ""
+					if err := c.Create(ctx, &cm); err != nil {
+						t.Fatal(err)
+					}
+				}
+			case "tool-source":
+				l.Source = l.Selection.AgentSource
+			case "run-credentials", "run-model":
+				var run api.AgentRun
+				if err := c.Get(ctx, types.NamespacedName{Namespace: frozen.Run.Namespace, Name: frozen.Run.Name}, &run); err != nil {
+					t.Fatal(err)
+				}
+				if mode == "run-credentials" {
+					run.Spec.Model.AuthSecretRef = "tenant-key"
+				} else {
+					run.Spec.Model.Model = "different"
+				}
+				if err := c.Update(ctx, &run); err != nil {
+					t.Fatal(err)
+				}
+			default:
+				switch mode {
+				case "revision":
+					cm.Labels = map[string]string{"revision": "changed"}
+				case "agent":
+					doc.Agent.UID = "replacement"
+				case "runtime":
+					doc.Runtime.SpecSHA256 = "changed"
+				case "provider":
+					doc.Provider = "other"
+				case "model":
+					doc.Model = "other"
+				case "url":
+					doc.URL = "https://untrusted.example/chat/completions"
+				case "profile-path":
+					doc.CredentialProfile = "/host/secret"
+				case "budget":
+					doc.MaxTotalOutputTokens = 3073
+				case "turns":
+					doc.MaxRequests = 1
+				case "tokens":
+					doc.MaxOutputTokens = 513
+				}
+				raw, err := json.Marshal(doc)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if mode == "unknown" {
+					raw = append([]byte(`{"approve":true,`), raw[1:]...)
+				}
+				if mode == "trailing" {
+					raw = append(raw, []byte(" {}")...)
+				}
+				if mode == "oversized" {
+					raw = []byte(strings.Repeat(" ", 65537))
+				}
+				cm.Data["model-policy.json"] = string(raw)
+				if err := c.Update(ctx, &cm); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := l.Revalidate(ctx, *frozen, *approval); err == nil {
+				t.Fatalf("accepted %s", mode)
+			}
+			if mode != "revision" {
+				if _, err := l.Resolve(ctx, *frozen); err == nil {
+					t.Fatalf("fresh resolution accepted %s", mode)
+				}
+			}
+		})
+	}
+}

--- a/internal/cellnauthority/model_test.go
+++ b/internal/cellnauthority/model_test.go
@@ -121,7 +121,7 @@ func TestModelPolicyChecksFreshRunOptionsWithoutFallback(t *testing.T) {
 }
 
 func TestModelPolicyRefusesWithdrawalSubstitutionAndExpansion(t *testing.T) {
-	for _, mode := range []string{"withdrawn", "lookalike", "revision", "agent", "runtime", "provider", "model", "url", "profile-path", "budget", "turns", "tokens", "unknown", "trailing", "oversized", "tool-source", "run-credentials", "run-model"} {
+	for _, mode := range []string{"withdrawn", "lookalike", "revision", "agent", "runtime", "provider", "model", "url", "profile-path", "budget", "underfunded", "turns", "tokens", "unknown", "trailing", "oversized", "tool-source", "run-credentials", "run-model"} {
 		t.Run(mode, func(t *testing.T) {
 			ctx := context.Background()
 			l, c, frozen := modelFixture(t)
@@ -180,6 +180,8 @@ func TestModelPolicyRefusesWithdrawalSubstitutionAndExpansion(t *testing.T) {
 					doc.CredentialProfile = "/host/secret"
 				case "budget":
 					doc.MaxTotalOutputTokens = 3073
+				case "underfunded":
+					doc.MaxTotalOutputTokens = 1535
 				case "turns":
 					doc.MaxRequests = 1
 				case "tokens":
@@ -212,5 +214,36 @@ func TestModelPolicyRefusesWithdrawalSubstitutionAndExpansion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+type changingModelReader struct {
+	client.Reader
+	source types.NamespacedName
+	reads  int
+}
+
+func (r *changingModelReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := r.Reader.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	if key == r.source {
+		r.reads++
+		if r.reads == 2 {
+			obj.SetResourceVersion("changed-between-reads")
+		}
+	}
+	return nil
+}
+
+func TestModelPolicyDetectsChangeDuringResolution(t *testing.T) {
+	l, c, frozen := modelFixture(t)
+	r := &changingModelReader{Reader: c, source: l.Source}
+	l.Selection.Reader = r
+	if _, err := l.Resolve(context.Background(), *frozen); err == nil || !strings.Contains(err.Error(), "changed during resolution") {
+		t.Fatalf("missed concurrent change: %v", err)
+	}
+	if r.reads != 2 {
+		t.Fatalf("expected two independent source reads, got %d", r.reads)
 	}
 }


### PR DESCRIPTION
## Purpose
Prerequisite for independently trusted host-model grant issuance in #426. Tool approval must not imply permission to spend model credentials.

## Changes
- Read a separate operator-configured model-policy ConfigMap with exact Agent/runtime subjects, provider/model, bounded host-compatible budgets and an opaque credential profile.
- Bind approval to the complete frozen selection and run-derived caller, pin source UID/resourceVersion/document digest, and revalidate without retargeting retries.
- Refuse tenant credential overrides, unsupported model options, stale/withdrawn sources and untrusted lookalikes. No credentials are read.
- Add optional operator plan/compose model-policy review; post-compose revalidation keeps output non-authorizing.
- Document the remaining host issuance boundary.

## Review and tests
Review found and fixed an underfunded-turn mismatch: model approval now requires maxTurns * 512 reserved output tokens, matching the existing host JSON contract. Targeted authority/review/CLI race tests, vet, build and diff checks passed. Full repository race testing is running and will be reported before merge.

## Explicit scope
This does not issue host grants, change Kubernetes resources, enable controller dispatch/readiness, or call a model. Unit tests use a fake API, not deployed policy/RBAC proof. Host issuance, prewarm/distribution integration and the full catalogue-backed user journey remain open. No cluster or credential changes.