### PR TITLE
feat: catalogue-derived requests and local host grant provisioning

### DIFF
--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,17 +12,22 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// This is an operator review command, not a tenant-facing execution endpoint.
-// Selecting source flags here does not issue grants or attest to ownership.
+// These are operator review/provisioning commands, not tenant-facing endpoints.
+// Source flags are trusted operator configuration, never proof of ownership.
 func newCellnSelectionPlanCmd() *cobra.Command {
-	return newCellnSelectionCmd(false)
+	return newCellnSelectionCmd("plan")
 }
 
 func newCellnSelectionComposeCmd() *cobra.Command {
-	return newCellnSelectionCmd(true)
+	return newCellnSelectionCmd("compose")
 }
 
-func newCellnSelectionCmd(compose bool) *cobra.Command {
+func newCellnSelectionIssueCmd() *cobra.Command {
+	return newCellnSelectionCmd("issue")
+}
+
+func newCellnSelectionCmd(mode string) *cobra.Command {
+	compose, issue := mode == "compose", mode == "issue"
 	var sourceNamespace, operatorSource, runtimeSource, agentSource string
 	var selected []string
 	var imageBytes int64
@@ -29,6 +35,7 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 	var modelPolicy string
 	var executionMote, executionClosure string
 	var options cellnreview.ComposeOptions
+	var issueOptions cellnreview.IssueOptions
 	cmd := &cobra.Command{Use: "plan AGENT", Args: cobra.ExactArgs(1), SilenceUsage: true,
 		Short: "Resolve live grants and emit a Celln composition plan without executing",
 		Long:  "Operator-only planning input. Read three independently configured grant ConfigMaps and live Agent/runtime/tool identities. Prints the resolved authority snapshot and exact compositor input; does not grant authority, certify readiness, write resources, compose images or execute. Tenant-facing callers must not accept these source flags from run requests.",
@@ -75,6 +82,16 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 				if executionMote != "" {
 					artifacts := cellnauthority.ExecutionArtifacts{}
 					artifacts.Mote.Hash, artifacts.Closure.Hash = executionMote, executionClosure
+					if issue {
+						issued, err := cellnreview.Issue(cmd.Context(), modelLoader, *frozen, *modelApproval, artifacts, issueOptions)
+						if err != nil {
+							return err
+						}
+						if err := json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-issuance-report-v1", "frozen": frozen, "issued": issued, "executed": false, "artifactReadiness": "not_checked"}); err != nil {
+							return errors.Join(err, cellnreview.Withdraw(issueOptions.PolicyRoot, *issued))
+						}
+						return nil
+					}
 					candidate, err := modelLoader.BuildExecution(cmd.Context(), *frozen, *modelApproval, artifacts)
 					if err != nil {
 						return err
@@ -112,8 +129,8 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 	cmd.Flags().StringArrayVar(&selected, "tool", nil, "Explicit NAME@REVISION; repeat in desired order; omission selects no tools")
 	cmd.Flags().Int64Var(&imageBytes, "image-bytes", 33554432, "Composed image size, 32..512 MiB and 2 MiB aligned")
 	cmd.Flags().StringVar(&runName, "run", "", "Bind and revalidate the plan against an existing same-namespace AgentRun (no dispatch)")
-	cmd.Flags().StringVar(&modelPolicy, "model-policy", "", "Independent operator model-policy ConfigMap in grant namespace; requires --run; does not issue a host grant")
-	cmd.Flags().StringVar(&executionMote, "execution-mote", "", "Actual materialized mote hash for an unissued execution candidate (plan only; requires run, model policy and closure)")
+	cmd.Flags().StringVar(&modelPolicy, "model-policy", "", "Independent operator model-policy ConfigMap in grant namespace; requires --run")
+	cmd.Flags().StringVar(&executionMote, "execution-mote", "", "Actual materialized mote hash for plan/issue (requires run, model policy and closure)")
 	cmd.Flags().StringVar(&executionClosure, "execution-closure", "", "Actual composed closure hash for an unissued execution candidate; host verification remains required")
 	for _, name := range []string{"grant-namespace", "operator-grants", "runtime-grants", "agent-grants"} {
 		_ = cmd.MarkFlagRequired(name)
@@ -127,6 +144,17 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 		cmd.Flags().StringVar(&options.KeyFile, "key-file", "", "Absolute operator composer seed path (never read into Kubernetes)")
 		cmd.Flags().StringVar(&options.OutputDir, "output-dir", "", "Absolute new output directory; must not exist")
 		for _, name := range []string{"run", "celln-binary", "policy-root", "key-file", "output-dir"} {
+			_ = cmd.MarkFlagRequired(name)
+		}
+	}
+	if issue {
+		cmd.Use = "issue AGENT"
+		cmd.Short = "Provision a local request-bound host grant from live independent approvals"
+		cmd.Long = "Operator-only local issuance. Verifies exact signed composition sources, resolves an independently configured host credential mapping, performs real sealed member verification, and publishes a request-bound grant. No dispatch or positive readiness. Persist the output and withdraw the profile when approval changes; this is not an autonomous revocation controller."
+		cmd.Flags().StringVar(&issueOptions.Binary, "celln-binary", "", "Absolute operator-selected Celln binary")
+		cmd.Flags().StringVar(&issueOptions.PolicyRoot, "policy-root", "", "Absolute trusted local host policy/store root")
+		cmd.Flags().StringVar(&issueOptions.ComposerPublisher, "composer-publisher", "", "Exact operator-approved composition publisher key")
+		for _, name := range []string{"run", "model-policy", "execution-mote", "execution-closure", "celln-binary", "policy-root", "composer-publisher"} {
 			_ = cmd.MarkFlagRequired(name)
 		}
 	}

--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -27,11 +27,17 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 	var imageBytes int64
 	var runName string
 	var modelPolicy string
+	var executionMote, executionClosure string
 	var options cellnreview.ComposeOptions
 	cmd := &cobra.Command{Use: "plan AGENT", Args: cobra.ExactArgs(1), SilenceUsage: true,
 		Short: "Resolve live grants and emit a Celln composition plan without executing",
 		Long:  "Operator-only planning input. Read three independently configured grant ConfigMaps and live Agent/runtime/tool identities. Prints the resolved authority snapshot and exact compositor input; does not grant authority, certify readiness, write resources, compose images or execute. Tenant-facing callers must not accept these source flags from run requests.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if executionMote != "" || executionClosure != "" {
+				if compose || executionMote == "" || executionClosure == "" || modelPolicy == "" || runName == "" {
+					return fmt.Errorf("execution candidate requires plan, --run, --model-policy, --execution-mote and --execution-closure")
+				}
+			}
 			if modelPolicy != "" && runName == "" {
 				return fmt.Errorf("model policy review requires --run")
 			}
@@ -66,6 +72,15 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 						return err
 					}
 				}
+				if executionMote != "" {
+					artifacts := cellnauthority.ExecutionArtifacts{}
+					artifacts.Mote.Hash, artifacts.Closure.Hash = executionMote, executionClosure
+					candidate, err := modelLoader.BuildExecution(cmd.Context(), *frozen, *modelApproval, artifacts)
+					if err != nil {
+						return err
+					}
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-selection-report-v1", "frozen": frozen, "candidate": candidate, "executionAuthorized": false, "artifactReadiness": "not_checked", "conformance": "not_checked"})
+				}
 				if compose {
 					report, err := cellnreview.Compose(cmd.Context(), loader, *frozen, options)
 					if err != nil {
@@ -98,6 +113,8 @@ func newCellnSelectionCmd(compose bool) *cobra.Command {
 	cmd.Flags().Int64Var(&imageBytes, "image-bytes", 33554432, "Composed image size, 32..512 MiB and 2 MiB aligned")
 	cmd.Flags().StringVar(&runName, "run", "", "Bind and revalidate the plan against an existing same-namespace AgentRun (no dispatch)")
 	cmd.Flags().StringVar(&modelPolicy, "model-policy", "", "Independent operator model-policy ConfigMap in grant namespace; requires --run; does not issue a host grant")
+	cmd.Flags().StringVar(&executionMote, "execution-mote", "", "Actual materialized mote hash for an unissued execution candidate (plan only; requires run, model policy and closure)")
+	cmd.Flags().StringVar(&executionClosure, "execution-closure", "", "Actual composed closure hash for an unissued execution candidate; host verification remains required")
 	for _, name := range []string{"grant-namespace", "operator-grants", "runtime-grants", "agent-grants"} {
 		_ = cmd.MarkFlagRequired(name)
 	}

--- a/cmd/sympozium/celln_selection_cmd_test.go
+++ b/cmd/sympozium/celln_selection_cmd_test.go
@@ -37,3 +37,20 @@ func TestModelPolicyReviewRequiresRunBeforeReadingAPI(t *testing.T) {
 		t.Fatalf("wrong refusal: %v", err)
 	}
 }
+
+func TestExecutionCandidateRequiresAllAuthorityAndArtifactInputs(t *testing.T) {
+	for _, flags := range [][]string{
+		{"--execution-mote", "blake3:incomplete"},
+		{"--execution-mote", "blake3:incomplete", "--execution-closure", "blake3:incomplete", "--run", "run"},
+	} {
+		cmd := newCellnSelectionPlanCmd()
+		args := []string{"agent", "--grant-namespace", "operator", "--operator-grants", "ops", "--runtime-grants", "runtime", "--agent-grants", "agent"}
+		cmd.SetArgs(append(args, flags...))
+		var output bytes.Buffer
+		cmd.SetOut(&output)
+		cmd.SetErr(&output)
+		if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "execution candidate requires") {
+			t.Fatalf("wrong refusal: %v", err)
+		}
+	}
+}

--- a/cmd/sympozium/celln_tool_cmd.go
+++ b/cmd/sympozium/celln_tool_cmd.go
@@ -49,5 +49,7 @@ func newCellnToolCmd() *cobra.Command {
 	cmd.AddCommand(approve)
 	cmd.AddCommand(newCellnSelectionPlanCmd())
 	cmd.AddCommand(newCellnSelectionComposeCmd())
+	cmd.AddCommand(newCellnSelectionIssueCmd())
+	cmd.AddCommand(newCellnWithdrawGrantCmd())
 	return cmd
 }

--- a/cmd/sympozium/celln_withdraw_cmd.go
+++ b/cmd/sympozium/celln_withdraw_cmd.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+)
+
+func newCellnWithdrawGrantCmd() *cobra.Command {
+	var root string
+	cmd := &cobra.Command{Use: "withdraw-grant ISSUANCE_REPORT", Args: cobra.ExactArgs(1), SilenceUsage: true,
+		Short: "Withdraw the exact local host profile from a saved issuance report",
+		// Recovery must remain available when Kubernetes is unreachable.
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		RunE: func(cmd *cobra.Command, args []string) error {
+			f, err := os.Open(args[0])
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			raw, err := io.ReadAll(io.LimitReader(f, 1048577))
+			if err != nil {
+				return err
+			}
+			if len(raw) > 1048576 {
+				return fmt.Errorf("issuance report exceeds 1 MiB")
+			}
+			var report struct {
+				APIVersion string                      `json:"apiVersion"`
+				Issued     cellnreview.IssuedSelection `json:"issued"`
+			}
+			if err := json.Unmarshal(raw, &report); err != nil {
+				return err
+			}
+			if report.APIVersion != "sympozium.ai/celln-issuance-report-v1" || report.Issued.APIVersion != "sympozium.ai/celln-issued-selection-v1" {
+				return fmt.Errorf("invalid issuance report")
+			}
+			if err := cellnreview.Withdraw(root, report.Issued); err != nil {
+				return err
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-withdrawal-report-v1", "profile": report.Issued.Profile, "scope": "local-profile-only", "grantAndAuditRetained": true})
+		}}
+	cmd.Flags().StringVar(&root, "policy-root", "", "Absolute trusted local host policy root")
+	_ = cmd.MarkFlagRequired("policy-root")
+	return cmd
+}

--- a/cmd/sympozium/celln_withdraw_cmd_test.go
+++ b/cmd/sympozium/celln_withdraw_cmd_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+)
+
+func TestWithdrawGrantWorksWithoutKubernetesAndRetainsUnrelatedFiles(t *testing.T) {
+	root := t.TempDir()
+	data := []byte(`{"fixture":"profile"}`)
+	digest := sha256.Sum256(data)
+	name := "symp-" + hex.EncodeToString(digest[:])[:58]
+	dir := filepath.Join(root, "trusted-model-profiles")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name+".json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	retained := filepath.Join(root, "audit-retained")
+	if err := os.WriteFile(retained, []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(map[string]any{"apiVersion": "sympozium.ai/celln-issuance-report-v1", "issued": cellnreview.IssuedSelection{APIVersion: "sympozium.ai/celln-issued-selection-v1", Profile: name, ProfileSHA256: "sha256:" + hex.EncodeToString(digest[:])}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(root, "issuance.json")
+	if err := os.WriteFile(report, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		parent := &cobra.Command{Use: "root", PersistentPreRunE: func(*cobra.Command, []string) error { return fmt.Errorf("Kubernetes unavailable") }}
+		parent.AddCommand(newCellnWithdrawGrantCmd())
+		parent.SetArgs([]string{"withdraw-grant", report, "--policy-root", root})
+		var out bytes.Buffer
+		parent.SetOut(&out)
+		parent.SetErr(&out)
+		if err := parent.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(out.Bytes(), []byte(`"grantAndAuditRetained":true`)) {
+			t.Fatalf("unexpected report: %s", out.Bytes())
+		}
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("profile remains")
+	}
+	if data, err := os.ReadFile(retained); err != nil || string(data) != "keep" {
+		t.Fatal("audit changed")
+	}
+}

--- a/docs/evidence/celln-local-issuance-2026-09-07.json
+++ b/docs/evidence/celln-local-issuance-2026-09-07.json
@@ -1,0 +1,18 @@
+{
+  "date": "2026-09-07",
+  "status": "passed",
+  "scope": "real signed catalogue composition, local host provisioning and KVM sealed-member verification; fake Kubernetes; not model/controller E2E",
+  "grant": "blake3:e637ca195f8fd8d0cd4e7d7d47eeb111f013ff730bc9541acca7fecd16dd8ad0",
+  "closure": "blake3:e25d67b886a439b0e724775ae8de8b5ba96c918831c8b91f6d18a0df386fa4e0",
+  "toolfs": "blake3:dba11e10fed485bd4ff6b3e35d7b00873e78ad71f21c00869cb7159e2e226bd0",
+  "runtimeCount": 1,
+  "borrowedToolCount": 2,
+  "issuances": 2,
+  "idempotentGrantAndProfile": true,
+  "withdrawalRefusedFurtherIssuance": true,
+  "grantBytesRetained": true,
+  "modelCalls": 0,
+  "credentialContentsRead": false,
+  "servingProcessPrewarmProven": false,
+  "crashRecoveryProven": false
+}

--- a/docs/guides/celln-local-issuance.md
+++ b/docs/guides/celln-local-issuance.md
@@ -1,0 +1,103 @@
+# Catalogue-backed local host issuance
+
+`sympozium celln-tool issue AGENT` is an operator-only bridge from live
+Kubernetes approvals to the local Celln host issuer. It does not submit an
+execution, distribute artifacts to a fleet, advertise readiness or implement
+the end-user UI/controller journey.
+
+It requires the existing three independent tool-grant source flags, `--run`,
+`--model-policy`, actual `--execution-mote` and `--execution-closure` hashes,
+plus operator-configured `--celln-binary`, `--policy-root` and
+`--composer-publisher`. Runtime/tool members and schemas must already exist in
+the host stores, and the mote must already be independently admitted.
+
+The operator maintains `POLICY_ROOT/model-credentials.json`:
+
+```json
+{
+  "apiVersion": "sympozium.ai/celln-host-credentials-v1",
+  "profiles": {"approved-deepseek": "/operator-owned/deepseek-token"}
+}
+```
+
+The selected name comes from the independently reviewed model policy; the
+credential path comes only from this host mapping. The bridge never reads the
+credential contents, puts them in Kubernetes, or sends them to the guest.
+Tenant access to artifact stores must not permit writes to host credentials,
+issuer profiles, grant files or the operator-configured approval sources.
+
+## Issuance and withdrawal
+
+The bridge builds the exact request from its revalidated frozen selection and
+live run. It compares the composed descriptor's ordered signed source identities
+with the selected sources and asks Celln to authenticate a private captured copy
+of those descriptor bytes. It then obtains the normalized request binding from
+the real Celln parser and atomically creates a private, content-derived host
+profile without overwriting different existing bytes.
+
+Celln performs sealed guest member verification and issues a v3 grant. The bridge
+rechecks the returned request binding, current Kubernetes approval, host mapping
+revision and composed descriptor before returning. Local issuance/withdrawal
+operations share a nonblocking OS file lock; unsupported platforms refuse.
+
+Failure after profile publication removes exactly that profile, including a
+matching profile retained by an earlier identical retry. Changed/unrelated bytes
+are not deleted, and a cleanup failure is returned alongside the original error.
+Grant/audit files remain intact; a v3 grant cannot pass its host profile check
+after that profile is removed. This is local refusal at a new resolution, not a
+fleet-wide active-cell withdrawal guarantee.
+
+Persist the complete command output as an issuance report. To withdraw it:
+
+```sh
+sympozium celln-tool withdraw-grant issuance-report.json \
+  --policy-root /absolute/operator/host-root
+```
+
+This removes only the profile with the matching saved name and SHA256. Already
+absent profiles are an idempotent success. It does not remove credentials,
+grants, execution journals or audit records.
+Withdrawal bypasses Kubernetes client initialization, so local recovery remains
+available when the API server is unreachable.
+
+## Recovery limits and remaining controller work
+
+This is **not an autonomous approval watcher**. Approval withdrawal after a
+successful invocation requires explicit withdrawal, or the future controller
+reconciler. A failed initial approval check cannot discover and withdraw all
+profiles from older invocations. Keep saved issuance identities for recovery.
+
+Process death between profile publication and final validation can leave an
+orphan profile/grant. The OS lock releases on exit, but the profile is not
+automatically deleted. Operators must audit retained profiles against current
+approval and withdraw stale profiles before dispatch/retry. Do not expose this
+local operator primitive as a tenant-facing or unattended production service
+until durable reconciliation/expiry and crash recovery are implemented.
+
+A successful issuance does not prove that the serving process has a warm mote,
+that the requested Harness/tool behavior conforms functionally, or that a model
+can complete the task. The remaining controller path must persist issuance
+identity, maintain withdrawal, prewarm the selected serving node, dispatch once,
+and correlate terminal results and receipts. Conversation and UI/YAML acceptance
+remain separate gates.
+
+## Evidence
+
+Portable race tests cover idempotent publication, concurrent-issuer refusal,
+failed issuer/report/binding checks, post-issuance approval/mapping/composition
+withdrawal, capacity-independent lock release, and refusal to delete unrelated
+profile bytes. These tests use fake Kubernetes and a mocked command runner.
+
+The explicit real test uses the real compositor, signed runtime plus two tools,
+real Celln issuer and KVM member verification, then repeats issuance and proves
+profile withdrawal refuses further issuance while retaining grant bytes. It
+still uses fake Kubernetes and makes **zero model calls**. Enable it only with
+`CELLN_ISSUANCE_KVM=1`, `CELLN_ISSUANCE_MATERIALIZER` (the public-seed
+`prepare_issuance_fixture` executable), `CELLN_HARNESS_PACKAGE`,
+`CELLN_COMPOSITION_FIXTURE` and `CELLN_COMPOSITION_BINARY`, then run:
+
+```sh
+go test -race ./internal/cellnreview -run '^TestComposeRealCellnArtifacts$' -count=1 -v
+```
+
+Require the explicit real-KVM issuance PASS line; an opt-in skip is not proof.

--- a/docs/guides/celln-model-authority.md
+++ b/docs/guides/celln-model-authority.md
@@ -43,6 +43,36 @@ observation and keep `executionAuthorized: false`.
 
 ## Remaining issuance boundary
 
+### Catalogue-derived execution candidate
+
+Operator `celln-tool plan` accepts paired `--execution-mote` and
+`--execution-closure` hashes with `--run` and `--model-policy`. These name actual
+packaging outputs, not the runtime profile's template mote. The command derives
+a `celln.dev/v1alpha3` request from the revalidated frozen selection and live
+AgentRun: exact task/persona/model, runtime executable, ordered borrowed tools,
+schema/loop limits, intersected memory/output ceilings, and the lower of the
+run timeout and runtime ceiling. It does not accept a caller-provided tool list
+or task override at this stage.
+
+The deterministic execution ID binds the frozen run/selection/model approval
+and materialized artifact hashes. A retry must persist/reuse this candidate;
+changed approval must be reconciled, not silently turned into a fresh attempt.
+SessionKey is only correlation metadata here: this is not a transcript or
+conversation implementation. Pod environment, sidecars/skills, parent runs,
+custom lifecycle/storage, server/dry-run modes, existing low-level Celln bindings
+and unsupported context settings refuse instead of being silently discarded.
+
+The candidate contains a zero placeholder model-grant hash. It is **not
+authorized for dispatch**. Hash syntax validation does not authenticate the
+packaging outputs. Trusted provisioning must verify their exact composition
+sources, obtain the actual host request binding and issue a grant after fresh
+approval checks. The host issuer must independently verify artifacts and model
+policy. Tests include passing the generated request to the actual Celln
+`harness-binding` command; that is parser/binding compatibility, not KVM/model
+execution or deployed controller proof.
+
+### Host bridge still required
+
 This implementation reads no credentials, writes no Kubernetes resources or
 host grant files, and performs no model calls. Tests use a fake Kubernetes API;
 they are not deployment/RBAC or live-model proof. Observed rereads are not an

--- a/docs/guides/celln-model-authority.md
+++ b/docs/guides/celln-model-authority.md
@@ -73,7 +73,7 @@ execution or deployed controller proof.
 
 ### Host bridge still required
 
-This implementation reads no credentials, writes no Kubernetes resources or
+The model-policy resolver reads no credentials, writes no Kubernetes resources or
 host grant files, and performs no model calls. Tests use a fake Kubernetes API;
 they are not deployment/RBAC or live-model proof. Observed rereads are not an
 atomic transaction, lease or fleet-wide withdrawal guarantee.
@@ -85,3 +85,8 @@ borrowed tools, persona and budgets, and publish a content-addressed grant only
 after fresh policy checks. Distribution, issuer/controller integration and the
 catalogue-backed real-model E2E remain required. An uploaded approval JSON or
 successful prewarm observation alone must never create model authority.
+
+The [local operator issuance bridge](celln-local-issuance.md) now connects these
+approvals to the real host issuer, including failure cleanup and explicit
+withdrawal. It is not yet an autonomous deployed controller or a crash-safe
+fleet approval watcher; see its recovery limits before use.

--- a/internal/cellnauthority/execution.go
+++ b/internal/cellnauthority/execution.go
@@ -1,0 +1,101 @@
+package cellnauthority
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ExecutionArtifacts are actual packaging outputs, not the runtime catalogue's
+// template mote. Their bytes, source provenance and admission must still be
+// verified by the host issuer; syntactically valid hashes are not readiness.
+type ExecutionArtifacts struct {
+	Mote    api.CellnImmutableRef `json:"mote"`
+	Closure api.CellnImmutableRef `json:"closure"`
+}
+
+// ExecutionCandidate is deliberately not dispatchable: the model grant hash
+// is a placeholder. Only the trusted host issuer may replace it. No caller-
+// supplied task, tool list, persona, model or resource ceiling is copied in.
+type ExecutionCandidate struct {
+	APIVersion string          `json:"apiVersion"`
+	Approval   ModelApproval   `json:"approval"`
+	Request    json.RawMessage `json:"request"`
+}
+
+func (l ModelLoader) BuildExecution(ctx context.Context, frozen FrozenSelection, approval ModelApproval, artifacts ExecutionArtifacts) (*ExecutionCandidate, error) {
+	if err := l.Revalidate(ctx, frozen, approval); err != nil {
+		return nil, err
+	}
+	if !hashPattern.MatchString(artifacts.Mote.Hash) || !hashPattern.MatchString(artifacts.Closure.Hash) {
+		return nil, fmt.Errorf("exact materialized mote and composed closure required")
+	}
+	run, id, err := l.Selection.readRun(ctx, types.NamespacedName{Namespace: frozen.Run.Namespace, Name: frozen.Run.Name})
+	if err != nil {
+		return nil, err
+	}
+	if id != frozen.Run {
+		return nil, fmt.Errorf("run changed before execution construction")
+	}
+	s := run.Spec
+	if s.Parent != nil || len(s.Env) != 0 || s.Sandbox != nil || s.AgentSandbox != nil || len(s.Skills) != 0 || s.ToolPolicy != nil || s.Celln != nil || s.CanaryMode || s.DryRun || len(s.ImagePullSecrets) != 0 || s.Lifecycle != nil || len(s.Volumes) != 0 || len(s.VolumeMounts) != 0 || (s.Mode != "" && s.Mode != "task") || (s.UseContext != nil && !*s.UseContext) || (s.Cleanup != "" && s.Cleanup != "delete") {
+		return nil, fmt.Errorf("run requests unsupported pod, execution, lifecycle or context semantics")
+	}
+	task := s.Task.GetPrompt()
+	limits := frozen.Prepared.Limits
+	if len(task) > int(limits.TaskBytes) || strings.TrimSpace(task) == "" || strings.ContainsRune(task, '\x00') || len(s.SystemPrompt) > 2048 || strings.ContainsRune(s.SystemPrompt, '\x00') {
+		return nil, fmt.Errorf("task or persona exceeds the bounded JSON Harness contract")
+	}
+	timeout := limits.TimeoutMillis
+	if s.Timeout != nil {
+		requested := s.Timeout.Duration.Milliseconds()
+		if requested < 1 {
+			return nil, fmt.Errorf("positive millisecond timeout required")
+		}
+		timeout = min(timeout, requested)
+	}
+	// The identity is independent of the model grant's self-reference but binds
+	// run UID/spec, every approval revision and actual packaging output. Retries
+	// reuse it; callers must persist this candidate before any execution effect.
+	identity, err := json.Marshal(struct {
+		Approval  ModelApproval
+		Artifacts ExecutionArtifacts
+	}{approval, artifacts})
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(identity)
+	executionID := "celln-" + hex.EncodeToString(digest[:])
+	borrowed := frozen.Prepared.BorrowedTools
+	if borrowed == nil {
+		borrowed = []api.CellnBorrowedTool{}
+	}
+	request := map[string]any{
+		"apiVersion": "celln.dev/v1alpha3", "id": executionID,
+		"workload":   map[string]any{"id": string(frozen.Run.UID), "caller": approval.Caller},
+		"mote":       artifacts.Mote,
+		"tools":      []api.CellnToolRef{{Alias: frozen.Prepared.RuntimeEntryPoint, Hash: frozen.Prepared.RuntimeExecutable.Hash, Closure: &artifacts.Closure}},
+		"invocation": api.CellnInvocation{Alias: frozen.Prepared.RuntimeEntryPoint},
+		"harness": map[string]any{"contractVersion": "celln.json-tools/v1", "modelGrant": api.CellnImmutableRef{Hash: "blake3:" + strings.Repeat("0", 64)}, "model": approval.Policy.Model, "task": task, "borrowedTools": borrowed,
+			"json": map[string]any{"system": s.SystemPrompt, "maxTurns": frozen.Prepared.JSON.MaxTurns, "maxCalls": frozen.Prepared.JSON.MaxCalls}},
+		"capabilities": map[string]any{"workspace": "none", "egress": []string{"https://api.deepseek.com"}, "timeoutMs": timeout, "memoryBytes": limits.MemoryBytes, "outputBytes": limits.OutputBytes},
+		"execution":    map[string]any{"lane": "agent", "requireHardwareIsolation": true},
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) > 65536 {
+		return nil, fmt.Errorf("execution request exceeds 64 KiB")
+	}
+	if err := l.Revalidate(ctx, frozen, approval); err != nil {
+		return nil, err
+	}
+	return &ExecutionCandidate{APIVersion: "sympozium.ai/celln-execution-candidate-v1", Approval: approval, Request: raw}, nil
+}

--- a/internal/cellnauthority/execution_test.go
+++ b/internal/cellnauthority/execution_test.go
@@ -1,0 +1,177 @@
+package cellnauthority
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func artifactFixture() ExecutionArtifacts {
+	return ExecutionArtifacts{Mote: api.CellnImmutableRef{Hash: "blake3:" + strings.Repeat("a", 64)}, Closure: api.CellnImmutableRef{Hash: "blake3:" + strings.Repeat("b", 64)}}
+}
+
+func TestExecutionCandidateUsesOnlyFrozenSelectionAndLiveRun(t *testing.T) {
+	ctx := context.Background()
+	l, _, frozen := modelFixture(t)
+	approval, err := l.Resolve(ctx, *frozen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := l.BuildExecution(ctx, *frozen, *approval, artifactFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := l.BuildExecution(ctx, *frozen, *approval, artifactFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first.Request) != string(second.Request) {
+		t.Fatal("retry retargeted request")
+	}
+	var r struct {
+		APIVersion string                `json:"apiVersion"`
+		ID         string                `json:"id"`
+		Mote       api.CellnImmutableRef `json:"mote"`
+		Tools      []api.CellnToolRef    `json:"tools"`
+		Harness    struct {
+			Task       string                  `json:"task"`
+			ModelGrant api.CellnImmutableRef   `json:"modelGrant"`
+			Tools      []api.CellnBorrowedTool `json:"borrowedTools"`
+		} `json:"harness"`
+	}
+	if err := json.Unmarshal(first.Request, &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.APIVersion != "celln.dev/v1alpha3" || r.Mote != artifactFixture().Mote || r.Tools[0].Hash != frozen.Prepared.RuntimeExecutable.Hash || len(r.Harness.Tools) != len(frozen.Prepared.BorrowedTools) || r.Harness.Task != "use the lent tool" || r.Harness.ModelGrant.Hash != "blake3:"+strings.Repeat("0", 64) {
+		t.Fatalf("wrong request: %s", first.Request)
+	}
+	bad := *approval
+	bad.Caller = "other-tenant"
+	if _, err := l.BuildExecution(ctx, *frozen, bad, artifactFixture()); err == nil {
+		t.Fatal("accepted altered approval")
+	}
+	if _, err := l.BuildExecution(ctx, *frozen, *approval, ExecutionArtifacts{}); err == nil {
+		t.Fatal("accepted missing artifacts")
+	}
+}
+
+func TestExecutionCandidateRefusesUnsupportedFreshRunAndCapsTimeout(t *testing.T) {
+	for _, mode := range []string{"env", "parent", "dry-run", "lifecycle", "server", "existing-celln", "blank-task", "task-too-long", "persona-too-long", "timeout-zero", "timeout-lower"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			l, c, old := modelFixture(t)
+			key := types.NamespacedName{Namespace: old.Run.Namespace, Name: old.Run.Name}
+			var run api.AgentRun
+			if err := c.Get(ctx, key, &run); err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "env":
+				run.Spec.Env = map[string]string{"KEY": "value"}
+			case "parent":
+				run.Spec.Parent = &api.ParentRunRef{RunName: "parent"}
+			case "dry-run":
+				run.Spec.DryRun = true
+			case "lifecycle":
+				run.Spec.Lifecycle = &api.LifecycleHooks{}
+			case "server":
+				run.Spec.Mode = "server"
+			case "existing-celln":
+				run.Spec.Celln = &api.CellnExecutionSpec{}
+			case "blank-task":
+				run.Spec.Task = api.NewStringTask(" ")
+			case "task-too-long":
+				run.Spec.Task = api.NewStringTask(strings.Repeat("x", 2049))
+			case "persona-too-long":
+				run.Spec.SystemPrompt = strings.Repeat("x", 2049)
+			case "timeout-zero":
+				run.Spec.Timeout = &metav1.Duration{}
+			case "timeout-lower":
+				run.Spec.Timeout = &metav1.Duration{Duration: time.Second}
+			}
+			if err := c.Update(ctx, &run); err != nil {
+				t.Fatal(err)
+			}
+			var selections []Selection
+			for _, tool := range old.Snapshot.Tools {
+				selections = append(selections, Selection{Name: tool.Identity.Name, Revision: tool.Identity.Revision})
+			}
+			frozen, err := l.Selection.FreezeRun(ctx, key, selections, old.Prepared.Composition.ImageBytes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			approval, err := l.Resolve(ctx, *frozen)
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidate, err := l.BuildExecution(ctx, *frozen, *approval, artifactFixture())
+			if mode != "timeout-lower" {
+				if err == nil {
+					t.Fatal("accepted unsupported run")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			var wire map[string]any
+			if err := json.Unmarshal(candidate.Request, &wire); err != nil {
+				t.Fatal(err)
+			}
+			if wire["capabilities"].(map[string]any)["timeoutMs"] != float64(1000) {
+				t.Fatal("lost lower run timeout")
+			}
+		})
+	}
+}
+
+func TestExecutionCandidateMatchesRealCellnParser(t *testing.T) {
+	binary := os.Getenv("CELLN_COMPOSITION_BINARY")
+	if binary == "" {
+		t.Skip("explicit trusted Celln binary required")
+	}
+	if !filepath.IsAbs(binary) {
+		t.Fatal("absolute trusted binary required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	l, _, frozen := modelFixture(t)
+	approval, err := l.Resolve(ctx, *frozen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := l.BuildExecution(ctx, *frozen, *approval, artifactFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "request.json")
+	if err := os.WriteFile(path, candidate.Request, 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.CommandContext(ctx, binary, "harness-binding", path)
+	cmd.Env = []string{"LANG=C"}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("real Celln refused: %v: %s", err, out)
+	}
+	var result struct {
+		APIVersion          string `json:"apiVersion"`
+		RequestBinding      string `json:"requestBinding"`
+		ExecutionAuthorized bool   `json:"executionAuthorized"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.APIVersion != "celln.dev/harness-request-binding-v1" || !hashPattern.MatchString(result.RequestBinding) || result.ExecutionAuthorized {
+		t.Fatalf("unexpected binding: %s", out)
+	}
+}

--- a/internal/cellnreview/compose_real_test.go
+++ b/internal/cellnreview/compose_real_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 // Real binary/artifacts, fake Kubernetes metadata. Opt in explicitly; this is
-// not a live API-server, guest execution or model-call proof.
+// not a live API-server or model-call proof. CELLN_ISSUANCE_KVM=1 adds an
+// explicit real-KVM sealed verification and host issuance/withdrawal proof.
 func TestComposeRealCellnArtifacts(t *testing.T) {
 	fixture := os.Getenv("CELLN_COMPOSITION_FIXTURE")
 	binary := os.Getenv("CELLN_COMPOSITION_BINARY")
@@ -87,6 +88,17 @@ func TestComposeRealCellnArtifacts(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	if os.Getenv("CELLN_ISSUANCE_KVM") == "1" {
+		var agentRun api.AgentRun
+		if err := c.Get(ctx, types.NamespacedName{Namespace: "tenant", Name: "run"}, &agentRun); err != nil {
+			t.Fatal(err)
+		}
+		agentRun.Spec.Model = api.ModelSpec{Provider: "deepseek", Model: "deepseek-chat"}
+		agentRun.Spec.SystemPrompt = "Use the explicitly lent tools."
+		if err := c.Update(ctx, &agentRun); err != nil {
+			t.Fatal(err)
+		}
+	}
 	frozen, err := l.FreezeRun(ctx, types.NamespacedName{Namespace: "tenant", Name: "run"}, selections, 33554432)
 	if err != nil {
 		t.Fatal(err)
@@ -117,6 +129,9 @@ func TestComposeRealCellnArtifacts(t *testing.T) {
 	if !verified.LocalToolfsVerified || verified.Toolfs != report.Toolfs {
 		t.Fatal("actual image identity mismatch")
 	}
+	if os.Getenv("CELLN_ISSUANCE_KVM") == "1" {
+		proveCatalogueIssuance(t, ctx, l, *frozen, options, signed.Publisher)
+	}
 	// Withdraw a real signed source in the Celln policy: the composed artifact
 	// must refuse even while all Kubernetes grant objects still exist unchanged.
 	policy := filepath.Join(root, "trusted-closures.json")
@@ -136,5 +151,5 @@ func TestComposeRealCellnArtifacts(t *testing.T) {
 	if err := verify(ctx, run, binary, []string{"--root", root, "closure", "verify", descriptor, "--expected-hash", report.Closure, "--publisher", signed.Publisher, "--entry-point", "/harness", "--executable", catalogue.RuntimeSpec.Celln.Executable.Hash}, &verified); err == nil {
 		t.Fatal("source withdrawal did not refuse composed closure")
 	}
-	t.Logf("PASS real signed runtime + two tools -> actual compositor -> verified 32 MiB image -> source withdrawal refused; closure=%s toolfs=%s; Kubernetes=fake, KVM=not-run, modelCalls=0", report.Closure, report.Toolfs)
+	t.Logf("PASS real signed runtime + two tools -> actual compositor -> verified 32 MiB image -> source withdrawal refused; closure=%s toolfs=%s; Kubernetes=fake, issuanceKVM=%t, modelCalls=0", report.Closure, report.Toolfs, os.Getenv("CELLN_ISSUANCE_KVM") == "1")
 }

--- a/internal/cellnreview/issue.go
+++ b/internal/cellnreview/issue.go
@@ -1,0 +1,347 @@
+package cellnreview
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+)
+
+// IssueOptions are operator/deployment configuration, never tenant fields.
+type IssueOptions struct{ Binary, PolicyRoot, ComposerPublisher string }
+
+type IssuedSelection struct {
+	APIVersion    string                            `json:"apiVersion"`
+	Candidate     cellnauthority.ExecutionCandidate `json:"candidate"`
+	Request       json.RawMessage                   `json:"request"`
+	Grant         string                            `json:"grant"`
+	Profile       string                            `json:"profile"`
+	ProfileSHA256 string                            `json:"profileSHA256"`
+}
+
+// Issue provisions a local host profile and invokes the real Celln issuer.
+// It does not submit an execution or advertise readiness. The caller must
+// persist the returned identities and arrange continued withdrawal checks.
+func Issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthority.FrozenSelection, approval cellnauthority.ModelApproval, artifacts cellnauthority.ExecutionArtifacts, o IssueOptions) (*IssuedSelection, error) {
+	return issue(ctx, l, frozen, approval, artifacts, o, func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		return runBudget(ctx, 45*time.Second, binary, args...)
+	})
+}
+
+func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthority.FrozenSelection, approval cellnauthority.ModelApproval, artifacts cellnauthority.ExecutionArtifacts, o IssueOptions, execute runner) (result *IssuedSelection, err error) {
+	if !filepath.IsAbs(o.Binary) || !filepath.IsAbs(o.PolicyRoot) || len(o.ComposerPublisher) != 64 {
+		return nil, fmt.Errorf("absolute operator paths and composer publisher required")
+	}
+	if _, e := hex.DecodeString(o.ComposerPublisher); e != nil {
+		return nil, fmt.Errorf("invalid composer publisher")
+	}
+	unlock, err := lockIssuer(o.PolicyRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	candidate, err := l.BuildExecution(ctx, frozen, approval, artifacts)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyComposition(ctx, execute, o, frozen, artifacts.Closure.Hash); err != nil {
+		return nil, err
+	}
+	credentials, credentialRevision, err := readCredentialMapping(o.PolicyRoot, approval.Policy.CredentialProfile)
+	if err != nil {
+		return nil, err
+	}
+	stage, err := os.MkdirTemp(o.PolicyRoot, ".sympozium-issue-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(stage)
+	requestFile := filepath.Join(stage, "request.json")
+	if err := os.WriteFile(requestFile, candidate.Request, 0600); err != nil {
+		return nil, err
+	}
+	var binding struct {
+		APIVersion          string `json:"apiVersion"`
+		RequestBinding      string `json:"requestBinding"`
+		ExecutionAuthorized bool   `json:"executionAuthorized"`
+	}
+	if err := verify(ctx, execute, o.Binary, []string{"harness-binding", requestFile}, &binding); err != nil {
+		return nil, err
+	}
+	if binding.APIVersion != "celln.dev/harness-request-binding-v1" || !artifactHash(binding.RequestBinding) || binding.ExecutionAuthorized {
+		return nil, fmt.Errorf("invalid host request binding")
+	}
+	p := approval.Policy
+	profileBytes, err := json.Marshal(map[string]any{"apiVersion": "celln.dev/model-issuer-profile-v1", "requestBinding": binding.RequestBinding, "credentialFile": credentials, "model": p.Model, "url": p.URL, "maxRequests": p.MaxRequests, "maxOutputTokens": p.MaxOutputTokens, "maxTotalOutputTokens": p.MaxTotalOutputTokens})
+	if err != nil {
+		return nil, err
+	}
+	profileDigest := sha256.Sum256(profileBytes)
+	name := "symp-" + hex.EncodeToString(profileDigest[:])[:58]
+	directory := filepath.Join(o.PolicyRoot, "trusted-model-profiles")
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return nil, err
+	}
+	profilePath := filepath.Join(directory, name+".json")
+	if err := l.Revalidate(ctx, frozen, approval); err != nil {
+		return nil, err
+	}
+	// Any later failure withdraws exactly this profile, even if a previous
+	// identical retry created it. Existing grant bytes remain inert under v3.
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, removeProfile(profilePath, profileBytes))
+		}
+	}()
+	if err := publishProfile(profilePath, profileBytes); err != nil {
+		return nil, err
+	}
+	var issued struct {
+		APIVersion        string          `json:"apiVersion"`
+		Grant             string          `json:"grant"`
+		Request           json.RawMessage `json:"request"`
+		ArtifactReadiness string          `json:"artifactReadiness"`
+		Conformance       string          `json:"conformance"`
+		Executed          bool            `json:"executed"`
+	}
+	if err = verify(ctx, execute, o.Binary, []string{"--root", o.PolicyRoot, "harness-grant", requestFile, "--profile", name}, &issued); err != nil {
+		return nil, err
+	}
+	if issued.APIVersion != "celln.dev/harness-issuance-v1" || !artifactHash(issued.Grant) || issued.Executed || issued.ArtifactReadiness != "not_checked" || issued.Conformance != "not_checked" {
+		return nil, fmt.Errorf("invalid host issuance report")
+	}
+	// Re-normalize the returned request with the actual Rust parser. This
+	// tolerates wire defaults, but not changed task/identity/authority fields.
+	var returned map[string]any
+	if err = json.Unmarshal(issued.Request, &returned); err != nil {
+		return nil, err
+	}
+	h, ok := returned["harness"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("issued request missing Harness")
+	}
+	g, ok := h["modelGrant"].(map[string]any)
+	if !ok || g["hash"] != issued.Grant {
+		return nil, fmt.Errorf("issued grant mismatch")
+	}
+	if err = os.WriteFile(requestFile, issued.Request, 0600); err != nil {
+		return nil, err
+	}
+	var rebound struct {
+		APIVersion          string `json:"apiVersion"`
+		RequestBinding      string `json:"requestBinding"`
+		ExecutionAuthorized bool   `json:"executionAuthorized"`
+	}
+	if err = verify(ctx, execute, o.Binary, []string{"harness-binding", requestFile}, &rebound); err != nil {
+		return nil, err
+	}
+	if rebound.APIVersion != binding.APIVersion || rebound.RequestBinding != binding.RequestBinding || rebound.ExecutionAuthorized {
+		return nil, fmt.Errorf("issuer changed the reviewed request")
+	}
+	if err = l.Revalidate(ctx, frozen, approval); err != nil {
+		return nil, err
+	}
+	_, current, readErr := readCredentialMapping(o.PolicyRoot, p.CredentialProfile)
+	if readErr != nil {
+		return nil, readErr
+	}
+	if current != credentialRevision {
+		return nil, fmt.Errorf("host credential mapping changed during issuance")
+	}
+	if err = verifyComposition(ctx, execute, o, frozen, artifacts.Closure.Hash); err != nil {
+		return nil, err
+	}
+	return &IssuedSelection{APIVersion: "sympozium.ai/celln-issued-selection-v1", Candidate: *candidate, Request: issued.Request, Grant: issued.Grant, Profile: name, ProfileSHA256: "sha256:" + hex.EncodeToString(profileDigest[:])}, nil
+}
+
+func readCredentialMapping(root, name string) (string, [32]byte, error) {
+	raw, err := readLimit(filepath.Join(root, "model-credentials.json"), 65536)
+	if err != nil {
+		return "", [32]byte{}, err
+	}
+	var doc struct {
+		APIVersion string            `json:"apiVersion"`
+		Profiles   map[string]string `json:"profiles"`
+	}
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if err := d.Decode(&doc); err != nil {
+		return "", [32]byte{}, fmt.Errorf("invalid host credential mapping")
+	}
+	if d.Decode(new(any)) != io.EOF {
+		return "", [32]byte{}, fmt.Errorf("trailing host credential mapping")
+	}
+	path, ok := doc.Profiles[name]
+	if doc.APIVersion != "sympozium.ai/celln-host-credentials-v1" || !ok || !filepath.IsAbs(path) {
+		return "", [32]byte{}, fmt.Errorf("credential profile not mapped by host operator")
+	}
+	return path, sha256.Sum256(raw), nil
+}
+
+func verifyComposition(ctx context.Context, execute runner, o IssueOptions, frozen cellnauthority.FrozenSelection, hash string) error {
+	path, err := storeObject(o.PolicyRoot, "closures", hash)
+	if err != nil {
+		return err
+	}
+	raw, err := readLimit(path, 262144)
+	if err != nil {
+		return err
+	}
+	var descriptor struct {
+		Closure struct {
+			APIVersion string `json:"apiVersion"`
+			Sources    []struct {
+				Hash string `json:"hash"`
+			} `json:"sources"`
+		} `json:"closure"`
+	}
+	if err := json.Unmarshal(raw, &descriptor); err != nil {
+		return fmt.Errorf("invalid composed descriptor")
+	}
+	sources := []string{}
+	for _, s := range descriptor.Closure.Sources {
+		sources = append(sources, s.Hash)
+	}
+	if descriptor.Closure.APIVersion != "celln.dev/closure-v2" || !reflect.DeepEqual(sources, frozen.Prepared.Composition.Sources) {
+		return fmt.Errorf("composed sources differ from reviewed selection")
+	}
+	var report closureReport
+	// Verify the very bytes whose source list was compared above, not a store
+	// pathname that could be replaced between our read and the subprocess read.
+	copy, err := os.CreateTemp(o.PolicyRoot, ".verify-composition-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(copy.Name())
+	defer copy.Close()
+	if _, err := copy.Write(raw); err != nil {
+		return err
+	}
+	if err := copy.Sync(); err != nil {
+		return err
+	}
+	if err := verify(ctx, execute, o.Binary, []string{"--root", o.PolicyRoot, "closure", "verify", copy.Name(), "--expected-hash", hash, "--publisher", o.ComposerPublisher, "--entry-point", frozen.Prepared.RuntimeEntryPoint, "--executable", frozen.Prepared.RuntimeExecutable.Hash}, &report); err != nil {
+		return err
+	}
+	if report.APIVersion != "celln.dev/closure-verification-v1" || report.Scope != "descriptor-authenticity-only" || report.Closure != hash || report.Publisher != o.ComposerPublisher || report.EntryPoint != frozen.Prepared.RuntimeEntryPoint || report.ClosureEntryPoint != frozen.Prepared.RuntimeEntryPoint || report.Executable != frozen.Prepared.RuntimeExecutable.Hash || report.Interpreter || !artifactHash(report.PolicyHash) || report.Conformance != "not_checked" || report.ArtifactReadiness != "not_checked" {
+		return fmt.Errorf("unbound composed descriptor verification")
+	}
+	after, err := readLimit(path, 262144)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(raw, after) {
+		return fmt.Errorf("composition changed during verification")
+	}
+	return nil
+}
+
+func readLimit(path string, limit int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	b, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > limit {
+		return nil, fmt.Errorf("operator document exceeds byte ceiling")
+	}
+	return b, nil
+}
+
+func publishProfile(path string, data []byte) error {
+	f, err := os.CreateTemp(filepath.Dir(path), ".profile-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := os.Link(f.Name(), path); err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+		old, err := readLimit(path, 65536)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(old, data) {
+			return fmt.Errorf("refusing to overwrite existing host profile")
+		}
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func removeProfile(path string, expected []byte) error {
+	actual, err := readLimit(path, 65536)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(actual, expected) {
+		return fmt.Errorf("host profile changed; refusing unrelated deletion")
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func syncDirectory(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+// Withdraw removes only the exact profile named by a persisted issuer result.
+// Serialize with issuance and never delete grant/audit records or credentials.
+func Withdraw(root string, issued IssuedSelection) error {
+	if !filepath.IsAbs(root) || !strings.HasPrefix(issued.Profile, "symp-") || len(issued.Profile) != 63 || len(issued.ProfileSHA256) != 71 || !strings.HasPrefix(issued.ProfileSHA256, "sha256:") {
+		return fmt.Errorf("invalid issued profile identity")
+	}
+	if _, err := hex.DecodeString(issued.Profile[5:]); err != nil {
+		return err
+	}
+	unlock, err := lockIssuer(root)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	path := filepath.Join(root, "trusted-model-profiles", issued.Profile+".json")
+	data, err := readLimit(path, 65536)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	digest := sha256.Sum256(data)
+	if "sha256:"+hex.EncodeToString(digest[:]) != issued.ProfileSHA256 {
+		return fmt.Errorf("profile revision changed")
+	}
+	return removeProfile(path, data)
+}

--- a/internal/cellnreview/issue_real_test.go
+++ b/internal/cellnreview/issue_real_test.go
@@ -1,0 +1,80 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Invoked only by the explicit CELLN_ISSUANCE_KVM=1 composition test.
+// This uses real artifacts/CLI/KVM, but fake Kubernetes and no model calls.
+func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.Loader, frozen cellnauthority.FrozenSelection, o ComposeOptions, publisher string) {
+	t.Helper()
+	materializer := os.Getenv("CELLN_ISSUANCE_MATERIALIZER")
+	packagePath := os.Getenv("CELLN_HARNESS_PACKAGE")
+	if !filepath.IsAbs(materializer) || !filepath.IsAbs(packagePath) {
+		t.Fatal("explicit absolute fixture materializer and Harness package required")
+	}
+	var artifacts cellnauthority.ExecutionArtifacts
+	if err := verify(ctx, run, materializer, []string{o.PolicyRoot, o.OutputDir, packagePath}, &artifacts); err != nil {
+		t.Fatal(err)
+	}
+	c := l.Reader.(client.Client)
+	doc := cellnauthority.ModelPolicyDocument{APIVersion: "sympozium.ai/celln-model-policy-v1", Agent: frozen.Snapshot.Agent, Runtime: frozen.Snapshot.Runtime, Provider: "deepseek", Model: "deepseek-chat", URL: "https://api.deepseek.com/chat/completions", CredentialProfile: "public-test-only", MaxRequests: 3, MaxOutputTokens: 512, MaxTotalOutputTokens: 1536}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "operators", Name: "model", UID: "model-policy"}, Data: map[string]string{"model-policy.json": string(raw)}}
+	if err := c.Create(ctx, cm); err != nil {
+		t.Fatal(err)
+	}
+	ml := cellnauthority.ModelLoader{Selection: l, Source: client.ObjectKeyFromObject(cm)}
+	approval, err := ml.Resolve(ctx, frozen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(o.PolicyRoot, "model-credentials.json"), []byte(`{"apiVersion":"sympozium.ai/celln-host-credentials-v1","profiles":{"public-test-only":"/never-read-catalogue-issuance-credential"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	options := IssueOptions{Binary: o.Binary, PolicyRoot: o.PolicyRoot, ComposerPublisher: publisher}
+	issued, err := Issue(ctx, ml, frozen, *approval, artifacts, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := Issue(ctx, ml, frozen, *approval, artifacts, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Grant != issued.Grant || again.Profile != issued.Profile {
+		t.Fatal("actual issuance retry changed identity")
+	}
+	grantPath := filepath.Join(o.PolicyRoot, "trusted-harness", issued.Grant[7:]+".json")
+	before, err := os.ReadFile(grantPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Withdraw(o.PolicyRoot, *issued); err != nil {
+		t.Fatal(err)
+	}
+	requestFile := filepath.Join(o.PolicyRoot, "withdrawn-request.json")
+	if err := os.WriteFile(requestFile, issued.Request, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(ctx, o.Binary, "--root", o.PolicyRoot, "harness-grant", requestFile, "--profile", issued.Profile); err == nil {
+		t.Fatal("withdrawn profile still issued")
+	}
+	after, err := os.ReadFile(grantPath)
+	if err != nil || string(before) != string(after) {
+		t.Fatal("withdrawal changed retained grant bytes")
+	}
+	assertNoProfiles(t, o.PolicyRoot)
+	t.Logf("PASS real catalogue composition -> independently approved host profile -> real-KVM sealed verification -> identical v3 issuance -> withdrawal refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
+}

--- a/internal/cellnreview/issue_test.go
+++ b/internal/cellnreview/issue_test.go
@@ -1,0 +1,249 @@
+package cellnreview
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type issuerFixture struct {
+	l         cellnauthority.ModelLoader
+	f         *cellnauthority.FrozenSelection
+	a         *cellnauthority.ModelApproval
+	artifacts cellnauthority.ExecutionArtifacts
+	o         IssueOptions
+	c         client.Client
+	run       runner
+}
+
+func provisionFixture(t *testing.T) issuerFixture {
+	t.Helper()
+	ctx := context.Background()
+	l, old, o, _ := compositionFixture(t)
+	c := l.Reader.(client.Client)
+	key := types.NamespacedName{Namespace: old.Run.Namespace, Name: old.Run.Name}
+	var run api.AgentRun
+	if err := c.Get(ctx, key, &run); err != nil {
+		t.Fatal(err)
+	}
+	run.Spec.Model = api.ModelSpec{Provider: "deepseek", Model: "deepseek-chat"}
+	if err := c.Update(ctx, &run); err != nil {
+		t.Fatal(err)
+	}
+	f, err := l.FreezeRun(ctx, key, nil, 33554432)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := cellnauthority.ModelPolicyDocument{APIVersion: "sympozium.ai/celln-model-policy-v1", Agent: f.Snapshot.Agent, Runtime: f.Snapshot.Runtime, Provider: "deepseek", Model: "deepseek-chat", URL: "https://api.deepseek.com/chat/completions", CredentialProfile: "host-deepseek", MaxRequests: 1, MaxOutputTokens: 512, MaxTotalOutputTokens: 512}
+	raw, _ := json.Marshal(doc)
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "operators", Name: "model", UID: "model-policy"}, Data: map[string]string{"model-policy.json": string(raw)}}
+	if err := c.Create(ctx, cm); err != nil {
+		t.Fatal(err)
+	}
+	ml := cellnauthority.ModelLoader{Selection: l, Source: client.ObjectKeyFromObject(cm)}
+	a, err := ml.Resolve(ctx, *f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := "blake3:" + strings.Repeat("c", 64)
+	artifacts := cellnauthority.ExecutionArtifacts{Mote: api.CellnImmutableRef{Hash: hash}, Closure: api.CellnImmutableRef{Hash: hash}}
+	options := IssueOptions{Binary: o.Binary, PolicyRoot: o.PolicyRoot, ComposerPublisher: strings.Repeat("d", 64)}
+	path, err := storeObject(o.PolicyRoot, "closures", hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = json.Marshal(map[string]any{"closure": map[string]any{"apiVersion": "celln.dev/closure-v2", "sources": []map[string]string{{"hash": f.Prepared.Composition.Sources[0]}}}})
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(o.PolicyRoot, "model-credentials.json"), []byte(`{"apiVersion":"sympozium.ai/celln-host-credentials-v1","profiles":{"host-deepseek":"/never-read-host-credential"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	execute := func(_ context.Context, binary string, args ...string) ([]byte, error) {
+		if binary != o.Binary {
+			t.Fatal("binary substituted")
+		}
+		if args[0] == "harness-binding" {
+			// A deterministic stand-in tests orchestration, not BLAKE3 or the
+			// real Rust parser. Real CLI/KVM proof is a separate test gate.
+			raw, err := os.ReadFile(args[1])
+			if err != nil {
+				return nil, err
+			}
+			var value map[string]any
+			if err := json.Unmarshal(raw, &value); err != nil {
+				return nil, err
+			}
+			value["harness"].(map[string]any)["modelGrant"] = map[string]any{"hash": "placeholder"}
+			normalized, _ := json.Marshal(value)
+			h := sha256.Sum256(normalized)
+			return json.Marshal(map[string]any{"apiVersion": "celln.dev/harness-request-binding-v1", "requestBinding": "blake3:" + hex.EncodeToString(h[:]), "executionAuthorized": false})
+		}
+		if args[2] == "closure" {
+			if args[4] == path {
+				t.Fatal("verification must use captured descriptor bytes")
+			}
+			return json.Marshal(closureReport{APIVersion: "celln.dev/closure-verification-v1", Scope: "descriptor-authenticity-only", Closure: hash, Publisher: options.ComposerPublisher, EntryPoint: f.Prepared.RuntimeEntryPoint, ClosureEntryPoint: f.Prepared.RuntimeEntryPoint, Executable: f.Prepared.RuntimeExecutable.Hash, PolicyHash: hash, ArtifactReadiness: "not_checked", Conformance: "not_checked"})
+		}
+		if args[2] != "harness-grant" {
+			return nil, fmt.Errorf("unexpected command")
+		}
+		profilePath := filepath.Join(o.PolicyRoot, "trusted-model-profiles", args[5]+".json")
+		profile, err := os.ReadFile(profilePath)
+		if err != nil {
+			return nil, err
+		}
+		if !strings.Contains(string(profile), "/never-read-host-credential") {
+			t.Fatal("operator credential mapping missing")
+		}
+		raw, err := os.ReadFile(args[3])
+		if err != nil {
+			return nil, err
+		}
+		var value map[string]any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, err
+		}
+		value["harness"].(map[string]any)["modelGrant"] = map[string]any{"hash": hash}
+		if err := os.WriteFile(filepath.Join(o.PolicyRoot, "grant-audit-sentinel"), []byte("retain"), 0600); err != nil {
+			return nil, err
+		}
+		return json.Marshal(map[string]any{"apiVersion": "celln.dev/harness-issuance-v1", "grant": hash, "request": value, "artifactReadiness": "not_checked", "conformance": "not_checked", "executed": false})
+	}
+	return issuerFixture{ml, f, a, artifacts, options, c, execute}
+}
+
+func TestProvisioningPublishesRetriesAndWithdrawsExactProfile(t *testing.T) {
+	f := provisionFixture(t)
+	ctx := context.Background()
+	first, err := issue(ctx, f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := issue(ctx, f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Profile != second.Profile || first.Grant != second.Grant {
+		t.Fatal("retry retargeted issuance")
+	}
+	if err := Withdraw(f.o.PolicyRoot, *first); err != nil {
+		t.Fatal(err)
+	}
+	if err := Withdraw(f.o.PolicyRoot, *first); err != nil {
+		t.Fatal(err)
+	}
+	assertNoProfiles(t, f.o.PolicyRoot)
+	if data, err := os.ReadFile(filepath.Join(f.o.PolicyRoot, "grant-audit-sentinel")); err != nil || string(data) != "retain" {
+		t.Fatal("withdrawal modified audit/grant data")
+	}
+}
+
+func assertNoProfiles(t *testing.T, root string) {
+	t.Helper()
+	files, err := os.ReadDir(filepath.Join(root, "trusted-model-profiles"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("live profiles retained: %v", files)
+	}
+}
+
+func TestProvisioningFailuresRemoveProfileAndReleaseLock(t *testing.T) {
+	for _, mode := range []string{"issuer-failed", "bad-report", "request-substitution", "approval-withdrawn", "credential-mapping-changed", "second-composition-check"} {
+		t.Run(mode, func(t *testing.T) {
+			f := provisionFixture(t)
+			checks := 0
+			execute := func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+				if args[0] == "--root" && args[2] == "closure" {
+					checks++
+					if mode == "second-composition-check" && checks == 2 {
+						return nil, fmt.Errorf("policy withdrawn")
+					}
+				}
+				out, err := f.run(ctx, binary, args...)
+				if err != nil {
+					return nil, err
+				}
+				if args[0] == "--root" && args[2] == "harness-grant" {
+					switch mode {
+					case "issuer-failed":
+						return nil, fmt.Errorf("issuer interrupted after publication")
+					case "bad-report":
+						return []byte(`{"apiVersion":"wrong"}`), nil
+					case "request-substitution":
+						var v map[string]any
+						_ = json.Unmarshal(out, &v)
+						v["request"].(map[string]any)["harness"].(map[string]any)["task"] = "other task"
+						return json.Marshal(v)
+					case "approval-withdrawn":
+						var cm corev1.ConfigMap
+						if err := f.c.Get(ctx, f.l.Source, &cm); err != nil {
+							t.Fatal(err)
+						}
+						if err := f.c.Delete(ctx, &cm); err != nil {
+							t.Fatal(err)
+						}
+					case "credential-mapping-changed":
+						if err := os.WriteFile(filepath.Join(f.o.PolicyRoot, "model-credentials.json"), []byte("{}"), 0600); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+				return out, nil
+			}
+			if _, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, execute); err == nil {
+				t.Fatal("accepted failed issuance")
+			}
+			assertNoProfiles(t, f.o.PolicyRoot)
+			unlock, err := lockIssuer(f.o.PolicyRoot)
+			if err != nil {
+				t.Fatal("lock leaked")
+			}
+			unlock()
+		})
+	}
+}
+
+func TestProvisioningLockAndWithdrawRefuseUnrelatedState(t *testing.T) {
+	f := provisionFixture(t)
+	unlock, err := lockIssuer(f.o.PolicyRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, f.run); err == nil {
+		t.Fatal("concurrent issuer admitted")
+	}
+	unlock()
+	issued, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json")
+	if err := os.WriteFile(path, []byte("replacement"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Withdraw(f.o.PolicyRoot, *issued); err == nil {
+		t.Fatal("removed changed profile")
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "replacement" {
+		t.Fatal("unrelated state changed")
+	}
+}

--- a/internal/cellnreview/issuer_lock_unix.go
+++ b/internal/cellnreview/issuer_lock_unix.go
@@ -1,0 +1,22 @@
+//go:build linux || darwin
+
+package cellnreview
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func lockIssuer(root string) (func(), error) {
+	f, err := os.OpenFile(filepath.Join(root, ".sympozium-issuer.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("host issuer is busy or cannot be locked")
+	}
+	return func() { _ = f.Close() }, nil
+}

--- a/internal/cellnreview/issuer_lock_unsupported.go
+++ b/internal/cellnreview/issuer_lock_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package cellnreview
+
+import "fmt"
+
+func lockIssuer(string) (func(), error) {
+	return nil, fmt.Errorf("host issuer locking unsupported on this platform")
+}


### PR DESCRIPTION
Progresses #426 from separate approval/composition/issuer primitives to a local operator provisioning path.

- Derive exact v1alpha3 requests from frozen catalogue/model approval plus the live run; stable identity, bounded persona/task/resources, unsupported option refusals. Real Celln parser compatibility tested.
- Verify exact ordered signed composition sources using a captured descriptor copy; read credentials only from an independent host mapping (no credential contents read).
- Serialize local provisioning, atomically publish request-bound profiles, invoke the real host issuer and recheck returned request/current approval/mapping/composition. Failure cleanup withdraws profiles but retains grant/audit data.
- Add operator issue and explicit withdraw-grant commands; withdrawal works without Kubernetes initialization and refuses unrelated/replaced profiles.
- Document process-death/orphan-profile limits and required future autonomous reconciliation.

Validation: targeted race tests, build/vet and a full repository race run passed. A final full race rerun after the local-withdrawal CLI recovery fix is running. Explicit real compositor + signed runtime/two tools + real Celln/KVM issuance + identical retry + withdrawal refusal passed with fake Kubernetes and zero model calls. Uses the paired Celln public issuance materializer fixture; evidence committed.

Not completion: no controller/API dispatch or user UI, no automatic fleet distribution/prewarm, no autonomous approval watcher or crash-safe durable issuer recovery. This local operator primitive must not be exposed as an unattended tenant endpoint until those gates are implemented.