### PR TITLE
feat: durable local issuer journal and interrupted-profile recovery

### DIFF
--- a/cmd/sympozium/celln_recover_cmd.go
+++ b/cmd/sympozium/celln_recover_cmd.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/spf13/cobra"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+)
+
+func newCellnRecoverGrantsCmd() *cobra.Command {
+	var root string
+	cmd := &cobra.Command{Use: "recover-grants", Args: cobra.NoArgs, SilenceUsage: true,
+		Short:             "Withdraw incomplete local issuer profiles from the durable journal",
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			recovered, err := cellnreview.RecoverPending(root)
+			writeErr := json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-issuer-recovery-v1", "withdrawnProfiles": recovered, "complete": err == nil, "scope": "local-incomplete-issuance-only", "executionAuthorized": false})
+			return errors.Join(err, writeErr)
+		}}
+	cmd.Flags().StringVar(&root, "policy-root", "", "Absolute trusted local host policy root")
+	_ = cmd.MarkFlagRequired("policy-root")
+	return cmd
+}

--- a/cmd/sympozium/celln_tool_cmd.go
+++ b/cmd/sympozium/celln_tool_cmd.go
@@ -51,5 +51,6 @@ func newCellnToolCmd() *cobra.Command {
 	cmd.AddCommand(newCellnSelectionComposeCmd())
 	cmd.AddCommand(newCellnSelectionIssueCmd())
 	cmd.AddCommand(newCellnWithdrawGrantCmd())
+	cmd.AddCommand(newCellnRecoverGrantsCmd())
 	return cmd
 }

--- a/cmd/sympozium/celln_withdraw_cmd_test.go
+++ b/cmd/sympozium/celln_withdraw_cmd_test.go
@@ -60,3 +60,18 @@ func TestWithdrawGrantWorksWithoutKubernetesAndRetainsUnrelatedFiles(t *testing.
 		t.Fatal("audit changed")
 	}
 }
+
+func TestRecoverGrantsDoesNotInitializeKubernetes(t *testing.T) {
+	parent := &cobra.Command{Use: "root", PersistentPreRunE: func(*cobra.Command, []string) error { return fmt.Errorf("Kubernetes unavailable") }}
+	parent.AddCommand(newCellnRecoverGrantsCmd())
+	parent.SetArgs([]string{"recover-grants", "--policy-root", t.TempDir()})
+	var output bytes.Buffer
+	parent.SetOut(&output)
+	parent.SetErr(&output)
+	if err := parent.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(output.Bytes(), []byte(`"complete":true`)) || !bytes.Contains(output.Bytes(), []byte(`"executionAuthorized":false`)) {
+		t.Fatalf("unexpected recovery: %s", output.Bytes())
+	}
+}

--- a/docs/evidence/celln-issuer-recovery-2026-09-07.json
+++ b/docs/evidence/celln-issuer-recovery-2026-09-07.json
@@ -1,0 +1,27 @@
+{
+  "date": "2026-09-07",
+  "status": "passed",
+  "crashProof": {
+    "method": "child process exits with code 47, bypassing all Go defers",
+    "stages": ["before-host-issuance", "after-host-issuance", "after-durable-commit", "during-withdrawal"],
+    "incompleteProfilesWithdrawn": true,
+    "committedOutcomeRetained": true,
+    "grantAuditBytesRetained": true,
+    "recoveryIdempotent": true,
+    "changedProfilesAndCorruptRecordsRefused": true,
+    "kubernetes": "fake",
+    "hostIssuer": "mocked-command-runner",
+    "powerLossTested": false
+  },
+  "separateRealKVMRegression": {
+    "scope": "catalogue composition and local host issuance, not a crash during guest execution",
+    "grant": "blake3:1b07694f7a92564d6ab3e1c7b31cd7fa284170da7533e3f3da49021bd43d4460",
+    "closure": "blake3:d4812de20561f11107eafea2b0f76981899abbb26d17135a81d56b7059e758f1",
+    "toolfs": "blake3:6d119482d74f32e718b91d71dafb314f4fcdf19d1bc1770b21da3bc724f32ffb",
+    "idempotentIssuanceAndWithdrawalPassed": true,
+    "kubernetes": "fake",
+    "modelCalls": 0
+  },
+  "deployedStartupGateProven": false,
+  "ongoingApprovalWatcherImplemented": false
+}

--- a/docs/guides/celln-local-issuance.md
+++ b/docs/guides/celln-local-issuance.md
@@ -67,12 +67,41 @@ successful invocation requires explicit withdrawal, or the future controller
 reconciler. A failed initial approval check cannot discover and withdraw all
 profiles from older invocations. Keep saved issuance identities for recovery.
 
-Process death between profile publication and final validation can leave an
-orphan profile/grant. The OS lock releases on exit, but the profile is not
-automatically deleted. Operators must audit retained profiles against current
-approval and withdraw stale profiles before dispatch/retry. Do not expose this
-local operator primitive as a tenant-facing or unattended production service
-until durable reconciliation/expiry and crash recovery are implemented.
+Before profile publication, issuance durably writes a `pending` record under
+`POLICY_ROOT/sympozium-issuer-journal`. After all final checks, it atomically
+replaces that record with `issued`, including the frozen selection, candidate
+and full issued result, before returning success. Withdrawal first records
+`withdrawing`, then removes the exact profile and records `withdrawn`. Records
+are private, bounded to 1 MiB, fsynced and retained for reconciliation.
+
+If the process dies, the OS lock releases. Recovery withdraws exact profiles
+for `pending` or `withdrawing` records and durably marks them `withdrawn`; it
+never reissues a grant or executes a task. Every new local bridge issuance runs
+this recovery step under the lock first. It can also be invoked without a
+Kubernetes connection:
+
+```sh
+sympozium celln-tool recover-grants --policy-root /absolute/operator/host-root
+```
+
+Committed `issued` outcomes survive loss of stdout/the caller and can be read
+through `ReadIssuance` or the retained journal. They are history, not current
+permission: revalidate approvals and reconcile existing execution identity
+before dispatch/retry. Recovery does not delete grant/audit records, replay
+side effects, or withdraw every committed grant automatically.
+
+Recovery scans at most 1024 directory entries and refuses corrupt records,
+identity mismatches or a larger journal; operators must reconcile/archive
+history before exhausting that bound. Automatic retention is not implemented.
+Changed profile bytes are not removed, and any recovery error blocks new bridge
+issuance. Legacy profiles without journal records still require an explicit
+saved-report withdrawal or operator audit.
+
+While the bridge is down, an unfinished profile can remain effective until
+recovery runs; the host dispatcher does not consult this journal. Deployment
+startup/dispatch must be gated on recovery. Do not expose this local operator
+primitive as an unattended production service until controller reconciliation,
+ongoing approval withdrawal/expiry and startup recovery gates are integrated.
 
 A successful issuance does not prove that the serving process has a warm mote,
 that the requested Harness/tool behavior conforms functionally, or that a model
@@ -87,6 +116,11 @@ Portable race tests cover idempotent publication, concurrent-issuer refusal,
 failed issuer/report/binding checks, post-issuance approval/mapping/composition
 withdrawal, capacity-independent lock release, and refusal to delete unrelated
 profile bytes. These tests use fake Kubernetes and a mocked command runner.
+Abrupt child-process exits additionally prove recovery before host issuance,
+after host issuance, after durable commit and during withdrawal. They bypass
+all Go defers and verify retained audit data, committed outcomes, released
+locks and repeatable recovery. This is process-crash testing, not a filesystem
+power-loss or deployed-controller proof.
 
 The explicit real test uses the real compositor, signed runtime plus two tools,
 real Celln issuer and KVM member verification, then repeats issuance and proves

--- a/internal/cellnreview/issue.go
+++ b/internal/cellnreview/issue.go
@@ -51,6 +51,9 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 		return nil, err
 	}
 	defer unlock()
+	if _, err := recoverPending(o.PolicyRoot); err != nil {
+		return nil, err
+	}
 	candidate, err := l.BuildExecution(ctx, frozen, approval, artifacts)
 	if err != nil {
 		return nil, err
@@ -94,6 +97,7 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 		return nil, err
 	}
 	profilePath := filepath.Join(directory, name+".json")
+	record := IssuerRecord{APIVersion: "sympozium.ai/celln-issuer-record-v1", State: "pending", Profile: name, ProfileSHA256: "sha256:" + hex.EncodeToString(profileDigest[:]), Frozen: frozen, Candidate: *candidate}
 	if err := l.Revalidate(ctx, frozen, approval); err != nil {
 		return nil, err
 	}
@@ -101,9 +105,17 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 	// identical retry created it. Existing grant bytes remain inert under v3.
 	defer func() {
 		if err != nil {
-			err = errors.Join(err, removeProfile(profilePath, profileBytes))
+			cleanupErr := removeProfile(profilePath, profileBytes)
+			if cleanupErr == nil {
+				record.State = "withdrawn"
+				cleanupErr = writeIssuerRecord(o.PolicyRoot, record)
+			}
+			err = errors.Join(err, cleanupErr)
 		}
 	}()
+	if err := writeIssuerRecord(o.PolicyRoot, record); err != nil {
+		return nil, err
+	}
 	if err := publishProfile(profilePath, profileBytes); err != nil {
 		return nil, err
 	}
@@ -162,7 +174,12 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 	if err = verifyComposition(ctx, execute, o, frozen, artifacts.Closure.Hash); err != nil {
 		return nil, err
 	}
-	return &IssuedSelection{APIVersion: "sympozium.ai/celln-issued-selection-v1", Candidate: *candidate, Request: issued.Request, Grant: issued.Grant, Profile: name, ProfileSHA256: "sha256:" + hex.EncodeToString(profileDigest[:])}, nil
+	result = &IssuedSelection{APIVersion: "sympozium.ai/celln-issued-selection-v1", Candidate: *candidate, Request: issued.Request, Grant: issued.Grant, Profile: name, ProfileSHA256: record.ProfileSHA256}
+	record.State, record.Issued = "issued", result
+	if err := writeIssuerRecord(o.PolicyRoot, record); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func readCredentialMapping(root, name string) (string, [32]byte, error) {
@@ -320,10 +337,10 @@ func syncDirectory(path string) error {
 // Withdraw removes only the exact profile named by a persisted issuer result.
 // Serialize with issuance and never delete grant/audit records or credentials.
 func Withdraw(root string, issued IssuedSelection) error {
-	if !filepath.IsAbs(root) || !strings.HasPrefix(issued.Profile, "symp-") || len(issued.Profile) != 63 || len(issued.ProfileSHA256) != 71 || !strings.HasPrefix(issued.ProfileSHA256, "sha256:") {
-		return fmt.Errorf("invalid issued profile identity")
+	if !filepath.IsAbs(root) {
+		return fmt.Errorf("absolute operator root required")
 	}
-	if _, err := hex.DecodeString(issued.Profile[5:]); err != nil {
+	if err := validProfileIdentity(issued.Profile, issued.ProfileSHA256); err != nil {
 		return err
 	}
 	unlock, err := lockIssuer(root)
@@ -331,6 +348,40 @@ func Withdraw(root string, issued IssuedSelection) error {
 		return err
 	}
 	defer unlock()
+	r, err := readIssuerRecord(filepath.Join(root, "sympozium-issuer-journal", issued.Profile+".json"))
+	if os.IsNotExist(err) {
+		r = IssuerRecord{APIVersion: "sympozium.ai/celln-issuer-record-v1", Profile: issued.Profile, ProfileSHA256: issued.ProfileSHA256, Candidate: issued.Candidate, Issued: &issued}
+	} else if err != nil {
+		return err
+	}
+	if r.ProfileSHA256 != issued.ProfileSHA256 {
+		return fmt.Errorf("issuer journal identity mismatch")
+	}
+	r.State = "withdrawing"
+	if err := writeIssuerRecord(root, r); err != nil {
+		return err
+	}
+	if err := withdrawProfile(root, issued); err != nil {
+		return err
+	}
+	r.State = "withdrawn"
+	return writeIssuerRecord(root, r)
+}
+
+func validProfileIdentity(profile, digest string) error {
+	if !strings.HasPrefix(profile, "symp-") || len(profile) != 63 || !strings.HasPrefix(digest, "sha256:") || len(digest) != 71 || profile[5:] != digest[7:65] {
+		return fmt.Errorf("invalid issued profile identity")
+	}
+	if _, err := hex.DecodeString(digest[7:]); err != nil {
+		return fmt.Errorf("invalid profile digest")
+	}
+	return nil
+}
+
+func withdrawProfile(root string, issued IssuedSelection) error {
+	if err := validProfileIdentity(issued.Profile, issued.ProfileSHA256); err != nil {
+		return err
+	}
 	path := filepath.Join(root, "trusted-model-profiles", issued.Profile+".json")
 	data, err := readLimit(path, 65536)
 	if os.IsNotExist(err) {

--- a/internal/cellnreview/issue_test.go
+++ b/internal/cellnreview/issue_test.go
@@ -30,9 +30,17 @@ type issuerFixture struct {
 }
 
 func provisionFixture(t *testing.T) issuerFixture {
+	return provisionFixtureAt(t, "")
+}
+
+func provisionFixtureAt(t *testing.T, root string) issuerFixture {
 	t.Helper()
 	ctx := context.Background()
 	l, old, o, _ := compositionFixture(t)
+	if root != "" {
+		o.PolicyRoot = root
+		o.Binary = filepath.Join(root, "celln")
+	}
 	c := l.Reader.(client.Client)
 	key := types.NamespacedName{Namespace: old.Run.Namespace, Name: old.Run.Name}
 	var run api.AgentRun

--- a/internal/cellnreview/issuer_journal.go
+++ b/internal/cellnreview/issuer_journal.go
@@ -1,0 +1,190 @@
+package cellnreview
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+)
+
+// A pending record is durable before a profile can authorize anything. The
+// atomic transition to issued records the full outcome before returning it.
+// Recovery never runs a task or reissues a grant: it only removes incomplete
+// profile authority and retains the record for reconciliation.
+type IssuerRecord struct {
+	APIVersion    string                            `json:"apiVersion"`
+	State         string                            `json:"state"`
+	Profile       string                            `json:"profile"`
+	ProfileSHA256 string                            `json:"profileSHA256"`
+	Frozen        cellnauthority.FrozenSelection    `json:"frozen"`
+	Candidate     cellnauthority.ExecutionCandidate `json:"candidate"`
+	Issued        *IssuedSelection                  `json:"issued,omitempty"`
+}
+
+func writeIssuerRecord(root string, record IssuerRecord) error {
+	if err := validRecord(record); err != nil {
+		return err
+	}
+	dir := filepath.Join(root, "sympozium-issuer-journal")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	// Persist the newly created directory entry before any profile is created.
+	if err := syncDirectory(root); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, record.Profile+".json")
+	if previous, err := readIssuerRecord(path); err == nil {
+		if previous.ProfileSHA256 != record.ProfileSHA256 {
+			return fmt.Errorf("issuer journal identity collision")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	if len(data) > 1048576 {
+		return fmt.Errorf("issuer record exceeds 1 MiB")
+	}
+	f, err := os.CreateTemp(dir, ".record-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := os.Rename(f.Name(), path); err != nil {
+		return err
+	}
+	return syncDirectory(dir)
+}
+
+func validRecord(r IssuerRecord) error {
+	if r.APIVersion != "sympozium.ai/celln-issuer-record-v1" || (r.State != "pending" && r.State != "issued" && r.State != "withdrawing" && r.State != "withdrawn") {
+		return fmt.Errorf("invalid issuer journal record")
+	}
+	if err := validProfileIdentity(r.Profile, r.ProfileSHA256); err != nil {
+		return err
+	}
+	if r.State == "issued" && (r.Issued == nil || r.Issued.Profile != r.Profile || r.Issued.ProfileSHA256 != r.ProfileSHA256) {
+		return fmt.Errorf("incomplete committed issuer record")
+	}
+	return nil
+}
+
+func readIssuerRecord(path string) (IssuerRecord, error) {
+	var r IssuerRecord
+	raw, err := readLimit(path, 1048576)
+	if err != nil {
+		return r, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&r); err != nil {
+		return r, fmt.Errorf("invalid issuer journal JSON")
+	}
+	if decoder.Decode(new(any)) != io.EOF {
+		return r, fmt.Errorf("trailing issuer journal JSON")
+	}
+	if err := validRecord(r); err != nil {
+		return r, err
+	}
+	if filepath.Base(path) != r.Profile+".json" {
+		return r, fmt.Errorf("issuer journal path mismatch")
+	}
+	return r, nil
+}
+
+// RecoverPending is a local fail-closed recovery step, not a live policy watcher.
+// It works without Kubernetes. Committed records are preserved for subsequent
+// approval revalidation; their existence is not current execution permission.
+func RecoverPending(root string) ([]string, error) {
+	if !filepath.IsAbs(root) {
+		return nil, fmt.Errorf("absolute operator root required")
+	}
+	unlock, err := lockIssuer(root)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	return recoverPending(root)
+}
+
+func recoverPending(root string) ([]string, error) {
+	dir := filepath.Join(root, "sympozium-issuer-journal")
+	f, err := os.Open(dir)
+	if os.IsNotExist(err) {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	entries, err := f.ReadDir(1025)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(entries) > 1024 {
+		return nil, fmt.Errorf("issuer journal exceeds recovery bound; operator reconciliation required")
+	}
+	recovered := []string{}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".record-") {
+			continue
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			return recovered, fmt.Errorf("unexpected issuer journal entry")
+		}
+		r, err := readIssuerRecord(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return recovered, err
+		}
+		if r.State != "pending" && r.State != "withdrawing" {
+			continue
+		}
+		if err := withdrawProfile(root, IssuedSelection{Profile: r.Profile, ProfileSHA256: r.ProfileSHA256}); err != nil {
+			return recovered, err
+		}
+		r.State = "withdrawn"
+		if err := writeIssuerRecord(root, r); err != nil {
+			return recovered, err
+		}
+		recovered = append(recovered, r.Profile)
+	}
+	return recovered, nil
+}
+
+// ReadIssuance returns durable history, never authorization to dispatch/replay.
+func ReadIssuance(root, profile, digest string) (IssuerRecord, error) {
+	if !filepath.IsAbs(root) {
+		return IssuerRecord{}, fmt.Errorf("absolute operator root required")
+	}
+	if err := validProfileIdentity(profile, digest); err != nil {
+		return IssuerRecord{}, err
+	}
+	unlock, err := lockIssuer(root)
+	if err != nil {
+		return IssuerRecord{}, err
+	}
+	defer unlock()
+	r, err := readIssuerRecord(filepath.Join(root, "sympozium-issuer-journal", profile+".json"))
+	if err != nil {
+		return r, err
+	}
+	if r.ProfileSHA256 != digest {
+		return IssuerRecord{}, fmt.Errorf("issuer journal revision mismatch")
+	}
+	return r, nil
+}

--- a/internal/cellnreview/issuer_journal_test.go
+++ b/internal/cellnreview/issuer_journal_test.go
@@ -1,0 +1,142 @@
+package cellnreview
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestProvisioningCrashHelper(t *testing.T) {
+	root := os.Getenv("CELLN_TEST_ISSUER_CRASH_ROOT")
+	if root == "" {
+		t.Skip("subprocess helper only")
+	}
+	f := provisionFixtureAt(t, root)
+	stage := os.Getenv("CELLN_TEST_ISSUER_CRASH_STAGE")
+	run := func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		isIssue := args[0] == "--root" && args[2] == "harness-grant"
+		if isIssue && stage == "before-host" {
+			os.Exit(47)
+		}
+		out, err := f.run(ctx, binary, args...)
+		if isIssue && stage == "after-host" {
+			os.Exit(47)
+		}
+		return out, err
+	}
+	issued, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stage == "withdrawing" {
+		record, err := ReadIssuance(root, issued.Profile, issued.ProfileSHA256)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record.State = "withdrawing"
+		unlock, err := lockIssuer(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writeIssuerRecord(root, record); err != nil {
+			t.Fatal(err)
+		}
+		_ = unlock // deliberately exit with lock held, as in interrupted withdrawal.
+	}
+	os.Exit(47) // bypass all Go cleanup; issued outcome is already durable.
+}
+
+func TestIssuerRecoveryAfterActualProcessExit(t *testing.T) {
+	for _, stage := range []string{"before-host", "after-host", "committed", "withdrawing"} {
+		t.Run(stage, func(t *testing.T) {
+			root := t.TempDir()
+			cmd := exec.Command(os.Args[0], "-test.run=^TestProvisioningCrashHelper$")
+			cmd.Env = append(os.Environ(), "CELLN_TEST_ISSUER_CRASH_ROOT="+root, "CELLN_TEST_ISSUER_CRASH_STAGE="+stage)
+			out, err := cmd.CombinedOutput()
+			var status *exec.ExitError
+			if !errors.As(err, &status) || status.ExitCode() != 47 {
+				t.Fatalf("expected abrupt exit: %v %s", err, out)
+			}
+			entries, err := os.ReadDir(filepath.Join(root, "sympozium-issuer-journal"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("missing durable record: %v", entries)
+			}
+			path := filepath.Join(root, "sympozium-issuer-journal", entries[0].Name())
+			record, err := readIssuerRecord(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			recovered, err := RecoverPending(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stage == "committed" {
+				if len(recovered) != 0 || record.State != "issued" || record.Issued == nil {
+					t.Fatal("lost committed outcome")
+				}
+				if _, err := os.Stat(filepath.Join(root, "trusted-model-profiles", record.Profile+".json")); err != nil {
+					t.Fatal(err)
+				}
+				if err := Withdraw(root, *record.Issued); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if len(recovered) != 1 || recovered[0] != record.Profile {
+					t.Fatal("pending authority not recovered")
+				}
+			}
+			assertNoProfiles(t, root)
+			after, err := readIssuerRecord(path)
+			if err != nil || after.State != "withdrawn" {
+				t.Fatalf("withdrawal not durable: %+v %v", after, err)
+			}
+			if stage != "before-host" {
+				if data, err := os.ReadFile(filepath.Join(root, "grant-audit-sentinel")); err != nil || string(data) != "retain" {
+					t.Fatal("recovery changed audit/grant bytes")
+				}
+			}
+			if again, err := RecoverPending(root); err != nil || len(again) != 0 {
+				t.Fatalf("recovery not idempotent: %v %v", again, err)
+			}
+		})
+	}
+}
+
+func TestJournalRecoveryRefusesChangedProfileAndCorruptRecord(t *testing.T) {
+	f := provisionFixture(t)
+	issued, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := ReadIssuance(f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.State = "pending"
+	if err := writeIssuerRecord(f.o.PolicyRoot, record); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json")
+	if err := os.WriteFile(path, []byte("replacement"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RecoverPending(f.o.PolicyRoot); err == nil {
+		t.Fatal("removed unrelated profile")
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "replacement" {
+		t.Fatal("changed profile was deleted")
+	}
+	journal := filepath.Join(f.o.PolicyRoot, "sympozium-issuer-journal", issued.Profile+".json")
+	if err := os.WriteFile(journal, []byte("invalid"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, f.run); err == nil {
+		t.Fatal("issuance ignored broken recovery record")
+	}
+}


### PR DESCRIPTION
Follow-up to #443 for #426.

- Persist pending authority before profile publication; atomically commit the full frozen/issued outcome before returning success.
- Journal withdrawal intent before removing a profile. Recover pending/withdrawing records by withdrawing exact profile bytes, retaining grant/audit history, and never replaying tasks or reissuing grants.
- Run bounded recovery before new local issuance; add Kubernetes-independent recover-grants CLI and historical record reads.
- Refuse corrupt journals, revision mismatches and recovery beyond 1024 entries. Keep committed history distinct from current authorization.

Validation: abrupt child-process exit tests pass before host issuance, after issuance, after durable commit and during withdrawal. Tests bypass Go defers and verify idempotent recovery, retained audit bytes, committed outcomes and released locks. Full go test -race ./... -count=1, build/vet and real catalogue/compositor/KVM issuer regression passed. Rebase onto merged #443 changed no source bytes. Evidence committed.

Scope limits: crash tests use fake Kubernetes and a mocked issuer; separate actual KVM issuance regression made zero model calls. Not a power-loss test, ongoing approval watcher, automatic retention, deployed startup gate or controller user journey. A profile may remain effective while the bridge is down until recovery runs; deployment dispatch must be gated on recovery.