### PR TITLE
feat: reconcile issued Celln profiles against current approvals

### DIFF
--- a/docs/evidence/celln-issued-reconciliation-2026-09-07.json
+++ b/docs/evidence/celln-issued-reconciliation-2026-09-07.json
@@ -1,0 +1,41 @@
+{
+  "date": "2026-09-07",
+  "scope": "one-pass local issued-profile approval reconciliation",
+  "base": "49a3e2315df5291f07a2a5b55e84b56b9bb30e96",
+  "regressions": {
+    "fullGoRaceSuite": "passed; real NATS binary available on PATH",
+    "goBuildAll": "passed",
+    "goVetAll": "passed"
+  },
+  "portable": {
+    "command": "go test -race ./internal/cellnreview ./internal/cellnauthority ./cmd/sympozium -count=1",
+    "result": "passed",
+    "cases": [
+      "unchanged approval preserves exact profile bytes",
+      "deleted tool or model policy withdraws profile",
+      "API error or context deadline withdraws profile",
+      "API restoration does not recreate withdrawn authority",
+      "missing or retargeted host credential mapping withdraws profile",
+      "missing profile reconciliation is durable and idempotent",
+      "changed unrelated profile bytes are not deleted",
+      "grant/audit sentinel remains intact"
+    ]
+  },
+  "realKVM": {
+    "test": "TestComposeRealCellnArtifacts with CELLN_ISSUANCE_KVM=1",
+    "result": "passed",
+    "sequence": "signed catalogue composition -> KVM sealed member verification -> identical v3 issuance retry -> model approval deletion -> reconciliation -> host issuance refusal",
+    "grant": "blake3:423abeb9ceaf65bd20198fb4660342baaaf378254b82c9bfc8721d7b60f09e24",
+    "closure": "blake3:999a5f7a279b1eccb1c7989e751852319d00bbdb512db7e81289d405ea0cdf64",
+    "toolfs": "blake3:2fe57dcd56594c0b4e26077b093851080ae0138ba3bd6f3868f4ad412614301f",
+    "kubernetes": "fake client",
+    "grantBytesRetained": true,
+    "modelCalls": 0
+  },
+  "notProven": [
+    "autonomous watcher or controller dispatch integration",
+    "host-enforced lease or expiry while reconciler is stopped",
+    "active-cell cancellation or fleet-wide withdrawal",
+    "final UI/YAML, conversational or real-model user journey"
+  ]
+}

--- a/docs/guides/celln-local-issuance.md
+++ b/docs/guides/celln-local-issuance.md
@@ -103,6 +103,32 @@ startup/dispatch must be gated on recovery. Do not expose this local operator
 primitive as an unattended production service until controller reconciliation,
 ongoing approval withdrawal/expiry and startup recovery gates are integrated.
 
+### One-pass current-approval reconciliation
+
+`cellnreview.ReconcileIssued` is the controller integration primitive for checking
+one committed issuance. Its caller supplies the trusted, uncached Kubernetes
+reader and independent approval-source configuration; the saved journal cannot
+choose its own authority sources. Under the issuer lock it first recovers pending
+records, then revalidates the frozen run, selection and model approval with a
+five-second context deadline (or the caller's earlier deadline). The reader must
+honor context cancellation. Missing/changed approvals, API errors or timeout,
+and a removed/retargeted host credential mapping trigger durable withdrawal of
+the exact profile. Token contents at the same approved host path are not read.
+
+An unchanged observation does not rewrite or expand authority. Reconciliation
+never reissues, dispatches, or restores a withdrawn profile when the API returns.
+It preserves grant/audit records and refuses to delete different profile bytes.
+Filesystem failures are returned; they must not be reported as successful
+withdrawal. This API is not yet registered as a controller or autonomous watcher.
+
+An `issued` result is only a point-in-time observation, not a readiness result or
+permission lease. A watcher dying between checks would leave profiles usable.
+Before unattended dispatch, add host-enforced expiry (or an equivalent enforced
+gate), startup recovery and continuous reconciliation. Existing v3 grants pin
+the profile's exact bytes, so changing an expiry field in that profile cannot be
+treated as transparent lease renewal. This also does not cancel an active cell
+or establish fleet-wide revocation.
+
 A successful issuance does not prove that the serving process has a warm mote,
 that the requested Harness/tool behavior conforms functionally, or that a model
 can complete the task. The remaining controller path must persist issuance

--- a/internal/cellnreview/issue_real_test.go
+++ b/internal/cellnreview/issue_real_test.go
@@ -61,8 +61,16 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Withdraw(o.PolicyRoot, *issued); err != nil {
+	observed, err := ReconcileIssued(ctx, o.PolicyRoot, issued.Profile, issued.ProfileSHA256, ml)
+	if err != nil || observed.State != "issued" {
+		t.Fatalf("current approval refused: %+v %v", observed, err)
+	}
+	if err := c.Delete(ctx, cm); err != nil {
 		t.Fatal(err)
+	}
+	observed, err = ReconcileIssued(ctx, o.PolicyRoot, issued.Profile, issued.ProfileSHA256, ml)
+	if err != nil || observed.State != "withdrawn" || observed.Reason != "approval-changed-or-unavailable" {
+		t.Fatalf("withdrawn approval retained authority: %+v %v", observed, err)
 	}
 	requestFile := filepath.Join(o.PolicyRoot, "withdrawn-request.json")
 	if err := os.WriteFile(requestFile, issued.Request, 0600); err != nil {
@@ -76,5 +84,5 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 		t.Fatal("withdrawal changed retained grant bytes")
 	}
 	assertNoProfiles(t, o.PolicyRoot)
-	t.Logf("PASS real catalogue composition -> independently approved host profile -> real-KVM sealed verification -> identical v3 issuance -> withdrawal refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
+	t.Logf("PASS real catalogue composition -> independently approved host profile -> real-KVM sealed verification -> identical v3 issuance -> approval deletion -> reconciliation -> host withdrawal refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
 }

--- a/internal/cellnreview/issuer_reconcile.go
+++ b/internal/cellnreview/issuer_reconcile.go
@@ -1,0 +1,104 @@
+package cellnreview
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+)
+
+type IssuerReconciliation struct {
+	APIVersion string `json:"apiVersion"`
+	Profile    string `json:"profile"`
+	State      string `json:"state"`
+	Reason     string `json:"reason"`
+}
+
+// ReconcileIssued performs one current-approval observation against a durable
+// record. Caller configuration supplies the trusted APIReader/source locations;
+// a saved report cannot select its own authority sources. API failure shrinks
+// authority by withdrawing, never by trusting stale approval. This is neither
+// a lease nor an autonomous watcher, and never dispatches/reissues anything.
+func ReconcileIssued(ctx context.Context, root, profile, digest string, loader cellnauthority.ModelLoader) (*IssuerReconciliation, error) {
+	if !filepath.IsAbs(root) {
+		return nil, fmt.Errorf("absolute operator root required")
+	}
+	if err := validProfileIdentity(profile, digest); err != nil {
+		return nil, err
+	}
+	unlock, err := lockIssuer(root)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	if _, err := recoverPending(root); err != nil {
+		return nil, err
+	}
+	record, err := readIssuerRecord(filepath.Join(root, "sympozium-issuer-journal", profile+".json"))
+	if err != nil {
+		return nil, err
+	}
+	if record.ProfileSHA256 != digest {
+		return nil, fmt.Errorf("issuer journal revision mismatch")
+	}
+	result := &IssuerReconciliation{APIVersion: "sympozium.ai/celln-issuer-reconciliation-v1", Profile: profile, State: record.State, Reason: "already-withdrawn"}
+	if record.State == "withdrawn" {
+		return result, nil
+	}
+	if record.State != "issued" {
+		return nil, fmt.Errorf("issuer recovery did not reach a terminal state")
+	}
+	reason := ""
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := loader.Revalidate(checkCtx, record.Frozen, record.Candidate.Approval); err != nil {
+		reason = "approval-changed-or-unavailable"
+	}
+	path := filepath.Join(root, "trusted-model-profiles", profile+".json")
+	data, readErr := readLimit(path, 65536)
+	if os.IsNotExist(readErr) {
+		reason = "profile-absent"
+	} else if readErr != nil {
+		return nil, readErr
+	} else {
+		h := sha256.Sum256(data)
+		if "sha256:"+hex.EncodeToString(h[:]) != digest {
+			return nil, fmt.Errorf("profile revision changed; refusing unrelated deletion")
+		}
+		// Rotation of token contents at the same independently selected path is
+		// allowed. Retargeting/removing the selected host mapping is not.
+		var hostProfile struct {
+			CredentialFile string `json:"credentialFile"`
+		}
+		if err := json.Unmarshal(data, &hostProfile); err != nil {
+			return nil, fmt.Errorf("invalid host profile")
+		}
+		credential, _, err := readCredentialMapping(root, record.Candidate.Approval.Policy.CredentialProfile)
+		if err != nil || credential != hostProfile.CredentialFile {
+			reason = "host-credential-mapping-changed-or-unavailable"
+		}
+	}
+	if reason == "" {
+		result.Reason = "approval-observed-current"
+		return result, nil
+	}
+	record.State = "withdrawing"
+	if err := writeIssuerRecord(root, record); err != nil {
+		return nil, err
+	}
+	if err := withdrawProfile(root, *record.Issued); err != nil {
+		return nil, err
+	}
+	record.State = "withdrawn"
+	if err := writeIssuerRecord(root, record); err != nil {
+		return nil, err
+	}
+	result.State, result.Reason = "withdrawn", reason
+	return result, nil
+}

--- a/internal/cellnreview/issuer_reconcile_test.go
+++ b/internal/cellnreview/issuer_reconcile_test.go
@@ -1,0 +1,145 @@
+package cellnreview
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type unavailableApprovalReader struct{ client.Reader }
+
+func (r unavailableApprovalReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return fmt.Errorf("API unavailable")
+}
+
+type stalledApprovalReader struct {
+	client.Reader
+	t *testing.T
+}
+
+func (r stalledApprovalReader) Get(ctx context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	deadline, ok := ctx.Deadline()
+	if !ok || time.Until(deadline) > 5*time.Second {
+		r.t.Fatal("approval read has no bounded deadline")
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestIssuedReconciliationWithdrawsOnDeadline(t *testing.T) {
+	f := provisionFixture(t)
+	issued, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.l.Selection.Reader = stalledApprovalReader{f.c, t}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	result, err := ReconcileIssued(ctx, f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256, f.l)
+	if err != nil || result.State != "withdrawn" || result.Reason != "approval-changed-or-unavailable" {
+		t.Fatalf("deadline retained stale authority: %+v %v", result, err)
+	}
+	assertNoProfiles(t, f.o.PolicyRoot)
+	// Restored API availability must not silently recreate authority.
+	f.l.Selection.Reader = f.c
+	result, err = ReconcileIssued(context.Background(), f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256, f.l)
+	if err != nil || result.State != "withdrawn" || result.Reason != "already-withdrawn" {
+		t.Fatalf("reconciliation recreated authority: %+v %v", result, err)
+	}
+	assertNoProfiles(t, f.o.PolicyRoot)
+}
+
+func TestIssuedApprovalReconciliationOnlyShrinksAuthority(t *testing.T) {
+	for _, mode := range []string{"unchanged", "tool-policy-withdrawn", "model-policy-withdrawn", "API-unavailable", "mapping-retargeted", "mapping-unavailable", "profile-absent"} {
+		t.Run(mode, func(t *testing.T) {
+			f := provisionFixture(t)
+			ctx := context.Background()
+			issued, err := issue(ctx, f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json")
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "tool-policy-withdrawn", "model-policy-withdrawn":
+				ref := f.l.Source
+				if mode == "tool-policy-withdrawn" {
+					ref = f.l.Selection.OperatorSource
+				}
+				var cm corev1.ConfigMap
+				if err := f.c.Get(ctx, ref, &cm); err != nil {
+					t.Fatal(err)
+				}
+				if err := f.c.Delete(ctx, &cm); err != nil {
+					t.Fatal(err)
+				}
+			case "API-unavailable":
+				f.l.Selection.Reader = unavailableApprovalReader{f.c}
+			case "mapping-retargeted":
+				if err := os.WriteFile(filepath.Join(f.o.PolicyRoot, "model-credentials.json"), []byte(`{"apiVersion":"sympozium.ai/celln-host-credentials-v1","profiles":{"host-deepseek":"/different-host-credential"}}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "mapping-unavailable":
+				if err := os.Remove(filepath.Join(f.o.PolicyRoot, "model-credentials.json")); err != nil {
+					t.Fatal(err)
+				}
+			case "profile-absent":
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			result, err := ReconcileIssued(ctx, f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256, f.l)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "unchanged" {
+				if result.State != "issued" || result.Reason != "approval-observed-current" {
+					t.Fatalf("wrong observation: %+v", result)
+				}
+				after, err := os.ReadFile(path)
+				if err != nil || string(after) != string(before) {
+					t.Fatal("observation changed profile authority")
+				}
+			} else {
+				if result.State != "withdrawn" {
+					t.Fatalf("stale authority remains: %+v", result)
+				}
+				assertNoProfiles(t, f.o.PolicyRoot)
+				again, err := ReconcileIssued(ctx, f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256, f.l)
+				if err != nil || again.Reason != "already-withdrawn" {
+					t.Fatalf("reconciliation not idempotent: %+v %v", again, err)
+				}
+			}
+			if data, err := os.ReadFile(filepath.Join(f.o.PolicyRoot, "grant-audit-sentinel")); err != nil || string(data) != "retain" {
+				t.Fatal("reconciliation modified grant/audit data")
+			}
+		})
+	}
+}
+
+func TestIssuedReconciliationRefusesChangedProfile(t *testing.T) {
+	f := provisionFixture(t)
+	issued, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json")
+	if err := os.WriteFile(path, []byte("unrelated"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReconcileIssued(context.Background(), f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256, f.l); err == nil {
+		t.Fatal("accepted changed profile")
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "unrelated" {
+		t.Fatal("deleted unrelated state")
+	}
+}


### PR DESCRIPTION
Part of #426; follows merged #444.

Adds one-pass reconciliation of durable issued profiles against the independently configured live tool/model approvals and host credential mapping. API errors and bounded context deadlines withdraw exact profile authority. Withdrawal is durable and idempotent, never recreates authority on API recovery, and preserves grant/audit data. Changed unrelated profile bytes are not deleted.

Validation: full go test -race ./... with real NATS available, go build ./..., go vet ./..., targeted deadline/withdrawal tests, and real compositor + KVM sealed verification + identical v3 issuance + approval deletion + reconciliation + host issuance refusal. The KVM integration uses fake Kubernetes and makes zero model calls. Evidence is committed.

Explicit limits: not an autonomous watcher, controller dispatch integration, lease, active-cell cancellation or fleet revocation. Host-enforced expiry or an equivalent enforced dispatch gate is still required to prevent profiles surviving indefinitely while reconciliation is stopped. UI/YAML and conversational acceptance remain open.