### PR TITLE
feat: persist bounded Celln issuance windows without retry renewal

### DIFF
--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
@@ -154,6 +155,7 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 		cmd.Flags().StringVar(&issueOptions.Binary, "celln-binary", "", "Absolute operator-selected Celln binary")
 		cmd.Flags().StringVar(&issueOptions.PolicyRoot, "policy-root", "", "Absolute trusted local host policy/store root")
 		cmd.Flags().StringVar(&issueOptions.ComposerPublisher, "composer-publisher", "", "Exact operator-approved composition publisher key")
+		cmd.Flags().DurationVar(&issueOptions.ProfileLifetime, "profile-lifetime", 5*time.Minute, "Host admission lifetime (1ms..5m); retries reuse original expiry; 0 is legacy explicit-operator mode only")
 		for _, name := range []string{"run", "model-policy", "execution-mote", "execution-closure", "celln-binary", "policy-root", "composer-publisher"} {
 			_ = cmd.MarkFlagRequired(name)
 		}

--- a/cmd/sympozium/celln_selection_cmd_test.go
+++ b/cmd/sympozium/celln_selection_cmd_test.go
@@ -4,7 +4,23 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestIssuanceDefaultsToBoundedProfileWithExplicitLegacyOptOut(t *testing.T) {
+	cmd := newCellnSelectionIssueCmd()
+	lifetime, err := cmd.Flags().GetDuration("profile-lifetime")
+	if err != nil || lifetime != 5*time.Minute {
+		t.Fatalf("unsafe default: %v %v", lifetime, err)
+	}
+	if err := cmd.Flags().Set("profile-lifetime", "0"); err != nil {
+		t.Fatal(err)
+	}
+	lifetime, err = cmd.Flags().GetDuration("profile-lifetime")
+	if err != nil || lifetime != 0 {
+		t.Fatalf("explicit legacy mode unavailable: %v %v", lifetime, err)
+	}
+}
 
 func TestSelectionPlanRequiresExplicitSourcesAndWellFormedSelections(t *testing.T) {
 	for _, args := range [][]string{

--- a/docs/evidence/celln-bounded-issuance-2026-09-07.json
+++ b/docs/evidence/celln-bounded-issuance-2026-09-07.json
@@ -1,0 +1,38 @@
+{
+  "date": "2026-09-07",
+  "scope": "local catalogue provisioning with durable nonrenewing admission expiry",
+  "base": "3f660c3e262da5681337b994152d05135e8d2cb3",
+  "cellnDependency": "064b56814247f6d13997ad2d82c4e6129dd52312 (#93)",
+  "regressions": {
+    "fullGoRace": "passed with real NATS binary on PATH",
+    "goBuildAll": "passed",
+    "goVetAll": "passed",
+    "targetedRace": "passed",
+    "cases": [
+      "later retries preserve profile bytes and grant identity",
+      "expiry, changed host boot and changed configured lifetime refuse renewal",
+      "withdrawal or direct profile removal cannot be undone by retry",
+      "pending recovery retains window and refuses authority restoration",
+      "corrupt window, invalid clock, overflow and invalid lifetime refuse",
+      "expiry during host issuance withdraws exact profile",
+      "abrupt child-process exits preserve original expiry window through recovery",
+      "CLI defaults to five-minute expiry; zero requires explicit legacy opt-out"
+    ]
+  },
+  "realKVM": {
+    "test": "TestComposeRealCellnArtifacts with CELLN_ISSUANCE_KVM=1",
+    "result": "passed",
+    "sequence": "real signed composition -> durable boot-bound expiring profile -> real sealed member verification -> identical issuance retry without renewal -> approval deletion -> reconciliation -> host refusal",
+    "grant": "blake3:180a554921e4877b8a9439bd0e2eab3650a6e3d09361b37dd5e6ad04e2cb9d81",
+    "closure": "blake3:db3c206d66ef4f1773cfa81faa7f701105672bcd0cd3e08f071b53a74ac4cd33",
+    "toolfs": "blake3:c0ac4c600a93de37e0577209341cf092ce1998fd02e0fdbca4cdf77f5a4db86f",
+    "kubernetes": "fake client",
+    "modelCalls": 0
+  },
+  "notProven": [
+    "unattended controller startup/watch/dispatch integration",
+    "active-cell expiry cancellation or fleet revocation",
+    "safe automatic retention or expiry window compaction",
+    "UI/YAML selection, conversations or final real-model user journey"
+  ]
+}

--- a/docs/guides/celln-local-issuance.md
+++ b/docs/guides/celln-local-issuance.md
@@ -11,6 +11,14 @@ plus operator-configured `--celln-binary`, `--policy-root` and
 `--composer-publisher`. Runtime/tool members and schemas must already exist in
 the host stores, and the mote must already be independently admitted.
 
+Issuance now defaults to `--profile-lifetime 5m`, requiring Celln's
+`harness-profile-clock` and `model-issuer-profile-v2` support (Celln #93).
+Lifetimes must be whole milliseconds in `1ms..5m`. Missing support refuses;
+there is no automatic fallback. `--profile-lifetime 0` explicitly retains the
+legacy non-expiring operator path and must not be used for unattended issuance.
+Library callers select `IssueOptions.ProfileLifetime`; its zero value remains
+legacy-compatible, so future automated callers must explicitly require it.
+
 The operator maintains `POLICY_ROOT/model-credentials.json`:
 
 ```json
@@ -97,11 +105,44 @@ Changed profile bytes are not removed, and any recovery error blocks new bridge
 issuance. Legacy profiles without journal records still require an explicit
 saved-report withdrawal or operator audit.
 
-While the bridge is down, an unfinished profile can remain effective until
-recovery runs; the host dispatcher does not consult this journal. Deployment
+While the bridge is down, an unfinished legacy profile can remain effective until
+recovery runs; bounded profiles instead refuse at their original expiry. The
+host dispatcher does not consult this journal. Deployment
 startup/dispatch must be gated on recovery. Do not expose this local operator
 primitive as an unattended production service until controller reconciliation,
 ongoing approval withdrawal/expiry and startup recovery gates are integrated.
+
+### Durable bounded admission windows
+
+Bounded issuance reads Linux boot identity and elapsed boot milliseconds from
+the independently configured local Celln binary. It never trusts tenant or wall
+clock timestamps. Before publishing any model profile it persists an immutable,
+private window under `POLICY_ROOT/sympozium-issuer-windows`. The key binds the
+complete execution candidate and independently mapped base profile; the record
+pins boot identity, issuance time and expiry. Creation is fsynced and does not
+overwrite different bytes. Window access is serialized by the existing issuer
+lock.
+
+An identical retry reuses the original window and hence the same profile and
+grant identity. It cannot renew the window by restarting the bridge, changing
+the configured lifetime, or waiting for expiry. A different boot, expiry,
+malformed window or withdrawn bounded issuance refuses. Recovery of an
+interrupted pending issuance withdraws it and retains its window; retries cannot
+restore it. Independently changed approval creates a different candidate, but
+never bypasses the host execution ownership/replay rules. A final host-clock
+check after issuance catches an observed expiry during provisioning and removes
+the exact profile before returning an error.
+
+Retain windows with issuance history: deleting a window could allow an operator
+to create a new start time. Automatic retention/compaction is not implemented;
+tenant access must never permit modifying this directory. A window is not itself
+host authority or a runnable grant. Host-side checks enforce expiry even while
+the bridge is down. Existing non-expiring profiles are not retroactively migrated.
+
+This closes local admission-window renewal on retry, not the complete unattended
+controller path. Continuous reconciliation, startup gates, selected-node prewarm,
+single dispatch and result correlation still need integration. Expiry gates new
+issuance/resolution, not active-cell cancellation or fleet revocation.
 
 ### One-pass current-approval reconciliation
 
@@ -122,9 +163,10 @@ Filesystem failures are returned; they must not be reported as successful
 withdrawal. This API is not yet registered as a controller or autonomous watcher.
 
 An `issued` result is only a point-in-time observation, not a readiness result or
-permission lease. A watcher dying between checks would leave profiles usable.
-Before unattended dispatch, add host-enforced expiry (or an equivalent enforced
-gate), startup recovery and continuous reconciliation. Existing v3 grants pin
+permission lease. A watcher dying between checks leaves a bounded profile usable
+until its original expiry (and a legacy profile without that time bound).
+Before unattended dispatch, require the bounded profile mode described above,
+startup recovery and continuous reconciliation. Existing v3 grants pin
 the profile's exact bytes, so changing an expiry field in that profile cannot be
 treated as transparent lease renewal. This also does not cancel an active cell
 or establish fleet-wide revocation.

--- a/internal/cellnreview/issue.go
+++ b/internal/cellnreview/issue.go
@@ -19,7 +19,12 @@ import (
 )
 
 // IssueOptions are operator/deployment configuration, never tenant fields.
-type IssueOptions struct{ Binary, PolicyRoot, ComposerPublisher string }
+type IssueOptions struct {
+	Binary, PolicyRoot, ComposerPublisher string
+	// Zero retains legacy explicit-operator issuance. Unattended callers must
+	// select a positive bounded lifetime; retries never refresh its start time.
+	ProfileLifetime time.Duration
+}
 
 type IssuedSelection struct {
 	APIVersion    string                            `json:"apiVersion"`
@@ -90,6 +95,12 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 	if err != nil {
 		return nil, err
 	}
+	if o.ProfileLifetime != 0 {
+		profileBytes, err = boundedProfile(ctx, execute, o, *candidate, profileBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
 	profileDigest := sha256.Sum256(profileBytes)
 	name := "symp-" + hex.EncodeToString(profileDigest[:])[:58]
 	directory := filepath.Join(o.PolicyRoot, "trusted-model-profiles")
@@ -98,6 +109,21 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 	}
 	profilePath := filepath.Join(directory, name+".json")
 	record := IssuerRecord{APIVersion: "sympozium.ai/celln-issuer-record-v1", State: "pending", Profile: name, ProfileSHA256: "sha256:" + hex.EncodeToString(profileDigest[:]), Frozen: frozen, Candidate: *candidate}
+	if o.ProfileLifetime != 0 {
+		previous, readErr := readIssuerRecord(filepath.Join(o.PolicyRoot, "sympozium-issuer-journal", name+".json"))
+		if readErr == nil && previous.State == "withdrawn" {
+			return nil, fmt.Errorf("bounded issuance was withdrawn; retry cannot restore authority")
+		}
+		if readErr == nil && previous.State == "issued" {
+			current, profileErr := readLimit(profilePath, 65536)
+			if profileErr != nil || !bytes.Equal(current, profileBytes) {
+				return nil, fmt.Errorf("bounded issued profile removed or changed; retry cannot restore authority")
+			}
+		}
+		if readErr != nil && !os.IsNotExist(readErr) {
+			return nil, readErr
+		}
+	}
 	if err := l.Revalidate(ctx, frozen, approval); err != nil {
 		return nil, err
 	}
@@ -173,6 +199,11 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 	}
 	if err = verifyComposition(ctx, execute, o, frozen, artifacts.Closure.Hash); err != nil {
 		return nil, err
+	}
+	if o.ProfileLifetime != 0 {
+		if err = checkBoundedProfile(ctx, execute, o, profileBytes); err != nil {
+			return nil, err
+		}
 	}
 	result = &IssuedSelection{APIVersion: "sympozium.ai/celln-issued-selection-v1", Candidate: *candidate, Request: issued.Request, Grant: issued.Grant, Profile: name, ProfileSHA256: record.ProfileSHA256}
 	record.State, record.Issued = "issued", result

--- a/internal/cellnreview/issue_expiry.go
+++ b/internal/cellnreview/issue_expiry.go
@@ -1,0 +1,134 @@
+package cellnreview
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+)
+
+type profileExpiry struct {
+	BootID    string `json:"bootId"`
+	IssuedAt  uint64 `json:"issuedAtBoottimeMs"`
+	ExpiresAt uint64 `json:"expiresAtBoottimeMs"`
+}
+
+type profileClock struct {
+	APIVersion          string `json:"apiVersion"`
+	BootID              string `json:"bootId"`
+	Now                 uint64 `json:"boottimeMs"`
+	MaxLifetime         uint64 `json:"maxLifetimeMs"`
+	ExecutionAuthorized bool   `json:"executionAuthorized"`
+}
+
+var hostBootID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func readProfileClock(ctx context.Context, execute runner, binary string) (profileClock, error) {
+	var clock profileClock
+	if err := verify(ctx, execute, binary, []string{"harness-profile-clock"}, &clock); err != nil {
+		return clock, err
+	}
+	if clock.APIVersion != "celln.dev/model-profile-clock-v1" || clock.MaxLifetime != 300000 || clock.ExecutionAuthorized || !hostBootID.MatchString(clock.BootID) {
+		return clock, fmt.Errorf("invalid host profile clock")
+	}
+	return clock, nil
+}
+
+func (e profileExpiry) check(clock profileClock, lifetime time.Duration) error {
+	if !hostBootID.MatchString(e.BootID) || e.BootID != clock.BootID || e.ExpiresAt <= e.IssuedAt || e.ExpiresAt-e.IssuedAt != uint64(lifetime/time.Millisecond) || e.IssuedAt > clock.Now || clock.Now >= e.ExpiresAt {
+		return fmt.Errorf("bounded profile expired, changed or belongs to another host boot")
+	}
+	return nil
+}
+
+// Called only under the issuer lock. The immutable window survives even a crash
+// before profile publication. A retry cannot mint another start time, including
+// after expiry; independently changed approval produces a different candidate.
+func boundedProfile(ctx context.Context, execute runner, o IssueOptions, candidate cellnauthority.ExecutionCandidate, base []byte) ([]byte, error) {
+	if o.ProfileLifetime < time.Millisecond || o.ProfileLifetime > 5*time.Minute || o.ProfileLifetime%time.Millisecond != 0 {
+		return nil, fmt.Errorf("profile lifetime must be whole milliseconds in 1ms..5m")
+	}
+	clock, err := readProfileClock(ctx, execute, o.Binary)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(struct {
+		Candidate cellnauthority.ExecutionCandidate `json:"candidate"`
+		Profile   json.RawMessage                   `json:"profile"`
+	}{candidate, base})
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(raw)
+	identity := hex.EncodeToString(hash[:])
+	dir := filepath.Join(o.PolicyRoot, "sympozium-issuer-windows")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, err
+	}
+	if err := syncDirectory(o.PolicyRoot); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, identity+".json")
+	var window struct {
+		APIVersion string        `json:"apiVersion"`
+		Identity   string        `json:"identity"`
+		Expiry     profileExpiry `json:"expiry"`
+	}
+	stored, err := readLimit(path, 4096)
+	if os.IsNotExist(err) {
+		lifetime := uint64(o.ProfileLifetime / time.Millisecond)
+		if clock.Now > math.MaxUint64-lifetime {
+			return nil, fmt.Errorf("host profile clock overflow")
+		}
+		window.APIVersion, window.Identity = "sympozium.ai/celln-issuer-window-v1", identity
+		window.Expiry = profileExpiry{clock.BootID, clock.Now, clock.Now + lifetime}
+		data, err := json.Marshal(window)
+		if err != nil {
+			return nil, err
+		}
+		if err := publishProfile(path, data); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	} else {
+		d := json.NewDecoder(bytes.NewReader(stored))
+		d.DisallowUnknownFields()
+		if d.Decode(&window) != nil || d.Decode(new(any)) != io.EOF || window.APIVersion != "sympozium.ai/celln-issuer-window-v1" || window.Identity != identity {
+			return nil, fmt.Errorf("invalid durable issuer window")
+		}
+	}
+	if err := window.Expiry.check(clock, o.ProfileLifetime); err != nil {
+		return nil, err
+	}
+	var profile map[string]any
+	if err := json.Unmarshal(base, &profile); err != nil {
+		return nil, err
+	}
+	profile["apiVersion"], profile["expiry"] = "celln.dev/model-issuer-profile-v2", window.Expiry
+	return json.Marshal(profile)
+}
+
+func checkBoundedProfile(ctx context.Context, execute runner, o IssueOptions, data []byte) error {
+	var profile struct {
+		Expiry profileExpiry `json:"expiry"`
+	}
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return err
+	}
+	clock, err := readProfileClock(ctx, execute, o.Binary)
+	if err != nil {
+		return err
+	}
+	return profile.Expiry.check(clock, o.ProfileLifetime)
+}

--- a/internal/cellnreview/issue_expiry_test.go
+++ b/internal/cellnreview/issue_expiry_test.go
@@ -1,0 +1,129 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func clockRunner(next runner, clock *profileClock, calls *int) runner {
+	return func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		if args[0] == "harness-profile-clock" {
+			*calls++
+			return json.Marshal(clock)
+		}
+		return next(ctx, binary, args...)
+	}
+}
+
+func testProfileClock() profileClock {
+	return profileClock{APIVersion: "celln.dev/model-profile-clock-v1", BootID: "01234567-89ab-cdef-0123-456789abcdef", Now: 1000, MaxLifetime: 300000}
+}
+
+func TestBoundedIssuanceRetryNeverRenewsOrRestoresAuthority(t *testing.T) {
+	for _, mode := range []string{"expiry", "reboot", "withdrawn", "profile-removed", "pending", "changed-lifetime", "corrupt-window"} {
+		t.Run(mode, func(t *testing.T) {
+			f := provisionFixture(t)
+			f.o.ProfileLifetime = time.Minute
+			clock, calls := testProfileClock(), 0
+			runner := clockRunner(f.run, &clock, &calls)
+			ctx := context.Background()
+			issued, err := issue(ctx, f.l, *f.f, *f.a, f.artifacts, f.o, runner)
+			if err != nil {
+				t.Fatal(err)
+			}
+			profilePath := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json")
+			original, err := os.ReadFile(profilePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			clock.Now += 10000
+			again, err := issue(ctx, f.l, *f.f, *f.a, f.artifacts, f.o, runner)
+			if err != nil || again.Profile != issued.Profile || again.Grant != issued.Grant {
+				t.Fatalf("retry changed identity: %+v %v", again, err)
+			}
+			if current, err := os.ReadFile(profilePath); err != nil || string(current) != string(original) {
+				t.Fatal("retry renewed profile")
+			}
+			switch mode {
+			case "expiry":
+				clock.Now = 61000
+			case "reboot":
+				clock.BootID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+			case "withdrawn":
+				if err := Withdraw(f.o.PolicyRoot, *issued); err != nil {
+					t.Fatal(err)
+				}
+			case "profile-removed":
+				if err := os.Remove(profilePath); err != nil {
+					t.Fatal(err)
+				}
+			case "pending":
+				r, err := ReadIssuance(f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256)
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.State = "pending"
+				if err := writeIssuerRecord(f.o.PolicyRoot, r); err != nil {
+					t.Fatal(err)
+				}
+			case "changed-lifetime":
+				f.o.ProfileLifetime = 2 * time.Minute
+			case "corrupt-window":
+				entries, err := os.ReadDir(filepath.Join(f.o.PolicyRoot, "sympozium-issuer-windows"))
+				if err != nil || len(entries) != 1 {
+					t.Fatalf("missing window: %v %v", entries, err)
+				}
+				if err := os.WriteFile(filepath.Join(f.o.PolicyRoot, "sympozium-issuer-windows", entries[0].Name()), []byte("broken"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := issue(ctx, f.l, *f.f, *f.a, f.artifacts, f.o, runner); err == nil {
+				t.Fatal("retry restored or extended authority")
+			}
+			if mode == "withdrawn" || mode == "pending" || mode == "profile-removed" {
+				assertNoProfiles(t, f.o.PolicyRoot)
+			}
+			if calls < 4 {
+				t.Fatal("missing initial/final host clock checks")
+			}
+		})
+	}
+}
+
+func TestBoundedIssuanceRefusesInvalidClockOrWindow(t *testing.T) {
+	for _, mode := range []string{"invalid-clock", "overflow", "negative", "too-long", "fractional", "expiry-during-issuance"} {
+		t.Run(mode, func(t *testing.T) {
+			f := provisionFixture(t)
+			f.o.ProfileLifetime = time.Minute
+			clock, calls := testProfileClock(), 0
+			switch mode {
+			case "invalid-clock":
+				clock.ExecutionAuthorized = true
+			case "overflow":
+				clock.Now = ^uint64(0)
+			case "negative":
+				f.o.ProfileLifetime = -time.Second
+			case "too-long":
+				f.o.ProfileLifetime = 6 * time.Minute
+			case "fractional":
+				f.o.ProfileLifetime = time.Millisecond + time.Nanosecond
+			}
+			next := clockRunner(f.run, &clock, &calls)
+			runner := func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+				out, err := next(ctx, binary, args...)
+				if mode == "expiry-during-issuance" && args[0] == "--root" && args[2] == "harness-grant" {
+					clock.Now = 61000
+				}
+				return out, err
+			}
+			if _, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, runner); err == nil {
+				t.Fatal("invalid bounded issuance accepted")
+			}
+			assertNoProfiles(t, f.o.PolicyRoot)
+		})
+	}
+}

--- a/internal/cellnreview/issue_real_test.go
+++ b/internal/cellnreview/issue_real_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +45,7 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 	if err := os.WriteFile(filepath.Join(o.PolicyRoot, "model-credentials.json"), []byte(`{"apiVersion":"sympozium.ai/celln-host-credentials-v1","profiles":{"public-test-only":"/never-read-catalogue-issuance-credential"}}`), 0600); err != nil {
 		t.Fatal(err)
 	}
-	options := IssueOptions{Binary: o.Binary, PolicyRoot: o.PolicyRoot, ComposerPublisher: publisher}
+	options := IssueOptions{Binary: o.Binary, PolicyRoot: o.PolicyRoot, ComposerPublisher: publisher, ProfileLifetime: 5 * time.Minute}
 	issued, err := Issue(ctx, ml, frozen, *approval, artifacts, options)
 	if err != nil {
 		t.Fatal(err)
@@ -84,5 +85,5 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 		t.Fatal("withdrawal changed retained grant bytes")
 	}
 	assertNoProfiles(t, o.PolicyRoot)
-	t.Logf("PASS real catalogue composition -> independently approved host profile -> real-KVM sealed verification -> identical v3 issuance -> approval deletion -> reconciliation -> host withdrawal refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
+	t.Logf("PASS real catalogue composition -> durable boot-bound expiring profile -> real-KVM sealed verification -> identical v3 issuance without renewal -> approval deletion -> reconciliation -> host withdrawal refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
 }

--- a/internal/cellnreview/issuer_journal_test.go
+++ b/internal/cellnreview/issuer_journal_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestProvisioningCrashHelper(t *testing.T) {
@@ -15,6 +16,9 @@ func TestProvisioningCrashHelper(t *testing.T) {
 		t.Skip("subprocess helper only")
 	}
 	f := provisionFixtureAt(t, root)
+	f.o.ProfileLifetime = 5 * time.Minute
+	clock, calls := testProfileClock(), 0
+	f.run = clockRunner(f.run, &clock, &calls)
 	stage := os.Getenv("CELLN_TEST_ISSUER_CRASH_STAGE")
 	run := func(ctx context.Context, binary string, args ...string) ([]byte, error) {
 		isIssue := args[0] == "--root" && args[2] == "harness-grant"
@@ -68,6 +72,15 @@ func TestIssuerRecoveryAfterActualProcessExit(t *testing.T) {
 				t.Fatalf("missing durable record: %v", entries)
 			}
 			path := filepath.Join(root, "sympozium-issuer-journal", entries[0].Name())
+			windows, err := os.ReadDir(filepath.Join(root, "sympozium-issuer-windows"))
+			if err != nil || len(windows) != 1 {
+				t.Fatalf("lost durable expiry window on process exit: %v %v", windows, err)
+			}
+			windowPath := filepath.Join(root, "sympozium-issuer-windows", windows[0].Name())
+			windowBefore, err := os.ReadFile(windowPath)
+			if err != nil {
+				t.Fatal(err)
+			}
 			record, err := readIssuerRecord(path)
 			if err != nil {
 				t.Fatal(err)
@@ -103,6 +116,9 @@ func TestIssuerRecoveryAfterActualProcessExit(t *testing.T) {
 			}
 			if again, err := RecoverPending(root); err != nil || len(again) != 0 {
 				t.Fatalf("recovery not idempotent: %v %v", again, err)
+			}
+			if after, err := os.ReadFile(windowPath); err != nil || string(after) != string(windowBefore) {
+				t.Fatal("recovery removed or renewed expiry window")
 			}
 		})
 	}


### PR DESCRIPTION
Part of #426. Requires merged celln#93 and follows merged #445.

Local issuance now supports durable boot-bound expiry. The CLI defaults to a five-minute profile lifetime and refuses unsupported hosts; zero is an explicit legacy operator opt-out. Library callers choose ProfileLifetime and future unattended callers must require it.

An immutable private window binds the exact execution candidate and independently mapped profile. Identical retries reuse the original window/profile/grant, including across process restarts. Expiry, reboot identity changes, lifetime changes, corrupt windows, withdrawn records and directly removed profiles cannot be repaired into new authority by retry. A final clock check catches expiry during issuance. Recovery retains windows and never authorizes replay.

Validation: full Go race suite with real NATS, build/vet, targeted retry/deadline/corruption/default tests and abrupt child-process recovery tests passed. Real compositor + boot-bound profile + KVM member verification + identical issuance without renewal + approval deletion/reconciliation + host refusal passed. Fake Kubernetes; no model calls. Evidence is committed.

Limits: local operator provisioning only; autonomous startup/watch/controller dispatch, selected-node readiness, active-cell/fleet revocation and UI/YAML/conversations remain open. Windows require retention with issuance history; automatic compaction is not implemented.