### PR TITLE
feat: manage local issuer startup recovery and periodic withdrawal

### DIFF
--- a/docs/evidence/celln-managed-issuer-2026-09-07.json
+++ b/docs/evidence/celln-managed-issuer-2026-09-07.json
@@ -1,0 +1,37 @@
+{
+  "date": "2026-09-07",
+  "scope": "in-process managed host-local issuer lifecycle, not deployed controller dispatch",
+  "prerequisite": "#446 bounded issuance, tested parent d00df95c3e3051dd973010620d2fd26d474c7097",
+  "checks": {
+    "fullGoRace": "passed with real NATS available",
+    "goBuildAll": "passed",
+    "goVetAll": "passed",
+    "targetedRace": "passed",
+    "cases": [
+      "issuance refuses before successful startup and after shutdown",
+      "periodic approval deletion withdraws issued profile",
+      "startup recovers pending authority and withdraws legacy, expired, unconfigured and API-unavailable profiles",
+      "clock failure withdraws tracked authority and closes gate",
+      "untracked or changed host authority blocks gate without unrelated deletion",
+      "removing a startup fault permits a later successful sweep",
+      "duplicate lifecycle owner refuses",
+      "shutdown cancels in-flight issuance and removes incomplete profile"
+    ]
+  },
+  "realKVM": {
+    "test": "TestComposeRealCellnArtifacts with CELLN_ISSUANCE_KVM=1",
+    "result": "passed",
+    "sequence": "signed catalogue composition -> managed startup -> bounded issuance -> KVM sealed member verification -> identical retry -> approval deletion -> periodic managed withdrawal -> host refusal",
+    "grant": "blake3:e470457b651f55e72539043edbed3e8207eb83c6b4b9f6c00ff5bd828678cb38",
+    "closure": "blake3:9396a711103e50ed91979d1a5123eac38165a15701904f0adec2223652fc85f0",
+    "toolfs": "blake3:82aeb37a54685cda83f18e540be6ce03c32afb41a54f307de3cb257f7105ef29",
+    "kubernetes": "fake client",
+    "modelCalls": 0
+  },
+  "notProven": [
+    "shipped controller registration, host RPC transport or catalogue-backed dispatch",
+    "selection-specific serving prewarm/readiness",
+    "active-cell cancellation or fleet revocation",
+    "UI/YAML selection, conversations and final real-model release acceptance"
+  ]
+}

--- a/docs/guides/celln-local-issuance.md
+++ b/docs/guides/celln-local-issuance.md
@@ -144,6 +144,45 @@ controller path. Continuous reconciliation, startup gates, selected-node prewarm
 single dispatch and result correlation still need integration. Expiry gates new
 issuance/resolution, not active-cell cancellation or fleet revocation.
 
+### Managed host-local issuer lifecycle
+
+`NewManagedIssuer` adds a lifecycle around bounded issuance. Deployment code
+supplies a private host root, trusted Celln binary/composer, positive profile
+lifetime, a 1–30 second sweep interval, and an explicit map from Agent identity
+to independently configured authority loaders with uncached API readers. The
+map is copied; journal contents never supply their own authority-source locations.
+
+`Start(ctx)` recovers pending records and sweeps existing issuance before opening
+the local provisioning gate. Sweeps repeat, with a 30-second context budget.
+They withdraw tracked legacy, expired, wrong-boot or no-longer-configured profiles
+and revalidate current tool/model approvals and host credential mapping for the
+rest. Unknown profiles, changed bytes, corrupt history, clock failures or failed
+filesystem operations close the gate and require a successful later sweep.
+Unrelated profile bytes are never deleted. Each scanned directory is bounded to
+1024 entries; automatic retention remains an operator follow-up.
+
+`ManagedIssuer.Issue` only uses the configured loader for the frozen Agent and
+always requires bounded issuance. It serializes with sweeps, refuses before
+startup/after shutdown or stale sweep observation, and links in-flight issuance
+to lifecycle cancellation. Duplicate lifecycle owners on the same instance are
+refused. The existing OS issuer lock also excludes concurrent local CLI writes
+during each managed operation. The host root must be reserved for this managed
+scope; unrelated operator profiles are not silently adopted.
+
+`Status` reports only the **local provisioning gate**, not Kubernetes availability,
+selection readiness, execution permission or conformance. Every issuance still
+revalidates live authority. No positive status renews profile expiry. During a
+process crash, host expiry remains the admission bound; clean shutdown closes the
+gate and cancels in-flight issuance but does not promise immediate fleet/live-cell
+revocation of already issued authority.
+
+This lifecycle component is tested in-process but is **not yet registered in the
+shipped controller or exposed as a host RPC service**. The next integration must
+start it on the correct host, route catalogue provisioning through its gate,
+prewarm that serving node and retain dispatch/replay identity. Existing CLI
+operator commands remain explicit local operations, not a bypass-safe deployment
+of the final automated user journey.
+
 ### One-pass current-approval reconciliation
 
 `cellnreview.ReconcileIssued` is the controller integration primitive for checking

--- a/internal/cellnreview/issue_real_test.go
+++ b/internal/cellnreview/issue_real_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -46,11 +47,20 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 		t.Fatal(err)
 	}
 	options := IssueOptions{Binary: o.Binary, PolicyRoot: o.PolicyRoot, ComposerPublisher: publisher, ProfileLifetime: 5 * time.Minute}
-	issued, err := Issue(ctx, ml, frozen, *approval, artifacts, options)
+	managed, err := NewManagedIssuer(options, map[types.NamespacedName]cellnauthority.ModelLoader{{Namespace: frozen.Snapshot.Agent.Namespace, Name: frozen.Snapshot.Agent.Name}: ml}, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	again, err := Issue(ctx, ml, frozen, *approval, artifacts, options)
+	managedCtx, cancelManaged := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- managed.Start(managedCtx) }()
+	defer func() { cancelManaged(); <-done }()
+	eventuallyManaged(t, func() bool { ready, _ := managed.Status(); return ready })
+	issued, err := managed.Issue(ctx, frozen, *approval, artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := managed.Issue(ctx, frozen, *approval, artifacts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,17 +72,13 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 	if err != nil {
 		t.Fatal(err)
 	}
-	observed, err := ReconcileIssued(ctx, o.PolicyRoot, issued.Profile, issued.ProfileSHA256, ml)
-	if err != nil || observed.State != "issued" {
-		t.Fatalf("current approval refused: %+v %v", observed, err)
-	}
 	if err := c.Delete(ctx, cm); err != nil {
 		t.Fatal(err)
 	}
-	observed, err = ReconcileIssued(ctx, o.PolicyRoot, issued.Profile, issued.ProfileSHA256, ml)
-	if err != nil || observed.State != "withdrawn" || observed.Reason != "approval-changed-or-unavailable" {
-		t.Fatalf("withdrawn approval retained authority: %+v %v", observed, err)
-	}
+	eventuallyManaged(t, func() bool {
+		_, err := os.Stat(filepath.Join(o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json"))
+		return os.IsNotExist(err)
+	})
 	requestFile := filepath.Join(o.PolicyRoot, "withdrawn-request.json")
 	if err := os.WriteFile(requestFile, issued.Request, 0600); err != nil {
 		t.Fatal(err)
@@ -85,5 +91,5 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 		t.Fatal("withdrawal changed retained grant bytes")
 	}
 	assertNoProfiles(t, o.PolicyRoot)
-	t.Logf("PASS real catalogue composition -> durable boot-bound expiring profile -> real-KVM sealed verification -> identical v3 issuance without renewal -> approval deletion -> reconciliation -> host withdrawal refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
+	t.Logf("PASS real catalogue composition -> managed startup recovery gate -> durable boot-bound expiring profile -> real-KVM sealed verification -> identical v3 issuance without renewal -> approval deletion -> periodic managed withdrawal -> host refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
 }

--- a/internal/cellnreview/issuer_managed.go
+++ b/internal/cellnreview/issuer_managed.go
@@ -1,0 +1,231 @@
+package cellnreview
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ManagedIssuer is a host-local lifecycle component, not a readiness or dispatch
+// service. Trusted deployment configuration supplies each Agent's authority
+// sources and an uncached reader. Journal contents never select authority.
+type ManagedIssuer struct {
+	mu        sync.Mutex
+	options   IssueOptions
+	loaders   map[types.NamespacedName]cellnauthority.ModelLoader
+	interval  time.Duration
+	execute   runner
+	started   bool
+	ready     bool
+	ctx       context.Context
+	lastSweep time.Time
+	lastError error
+}
+
+func NewManagedIssuer(options IssueOptions, loaders map[types.NamespacedName]cellnauthority.ModelLoader, interval time.Duration) (*ManagedIssuer, error) {
+	if !filepath.IsAbs(options.PolicyRoot) || !filepath.IsAbs(options.Binary) || options.ProfileLifetime < time.Millisecond || options.ProfileLifetime > 5*time.Minute || options.ProfileLifetime%time.Millisecond != 0 || interval < time.Second || interval > 30*time.Second {
+		return nil, fmt.Errorf("managed issuer requires absolute host paths, bounded profiles and a 1s..30s sweep interval")
+	}
+	if len(options.ComposerPublisher) != 64 {
+		return nil, fmt.Errorf("exact composer publisher required")
+	}
+	if _, err := hex.DecodeString(options.ComposerPublisher); err != nil {
+		return nil, err
+	}
+	if len(loaders) == 0 || len(loaders) > 1024 {
+		return nil, fmt.Errorf("1..1024 configured Agent authority bindings required")
+	}
+	m := &ManagedIssuer{options: options, interval: interval, loaders: make(map[types.NamespacedName]cellnauthority.ModelLoader)}
+	for key, loader := range loaders {
+		if key.Namespace == "" || key.Name == "" || loader.Selection.Reader == nil {
+			return nil, fmt.Errorf("invalid configured Agent authority binding")
+		}
+		m.loaders[key] = loader
+	}
+	m.execute = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		return runBudget(ctx, 45*time.Second, binary, args...)
+	}
+	return m, nil
+}
+
+// Start runs recovery before opening the local provisioning gate. Failed sweeps
+// close it and retry on the next tick. Cancellation closes it permanently; host
+// expiry remains enforced if this process dies and cannot perform cleanup.
+func (m *ManagedIssuer) Start(ctx context.Context) error {
+	m.mu.Lock()
+	if m.started {
+		m.mu.Unlock()
+		return fmt.Errorf("managed issuer already started")
+	}
+	m.started, m.ctx = true, ctx
+	m.mu.Unlock()
+	defer func() { m.mu.Lock(); m.ready = false; m.mu.Unlock() }()
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		m.mu.Lock()
+		m.ready = false
+		checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		err := m.sweep(checkCtx)
+		cancel()
+		m.lastError = err
+		if err == nil && ctx.Err() == nil {
+			m.ready, m.lastSweep = true, time.Now()
+		}
+		m.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+// Status describes the local provisioning gate only, not artifact or runtime
+// readiness. Bound sweep freshness even if an embedding scheduler is stalled.
+func (m *ManagedIssuer) Status() (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.available(), m.lastError
+}
+
+func (m *ManagedIssuer) available() bool {
+	return m.ready && m.ctx != nil && m.ctx.Err() == nil && time.Since(m.lastSweep) <= m.interval+30*time.Second
+}
+
+func (m *ManagedIssuer) Issue(ctx context.Context, frozen cellnauthority.FrozenSelection, approval cellnauthority.ModelApproval, artifacts cellnauthority.ExecutionArtifacts) (*IssuedSelection, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.available() {
+		return nil, fmt.Errorf("managed issuer provisioning gate is closed")
+	}
+	key := types.NamespacedName{Namespace: frozen.Snapshot.Agent.Namespace, Name: frozen.Snapshot.Agent.Name}
+	loader, ok := m.loaders[key]
+	if !ok {
+		return nil, fmt.Errorf("Agent has no configured issuer authority binding")
+	}
+	issueCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stop := context.AfterFunc(m.ctx, cancel)
+	defer stop()
+	return issue(issueCtx, loader, frozen, approval, artifacts, m.options, m.execute)
+}
+
+func boundedEntries(dir string) ([]os.DirEntry, error) {
+	f, err := os.Open(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	entries, err := f.ReadDir(1025)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(entries) > 1024 {
+		return nil, fmt.Errorf("managed issuer directory exceeds 1024 entries")
+	}
+	return entries, nil
+}
+
+// Caller serializes managed operations. The OS lock also excludes operator CLI
+// issuance while the complete sweep observes and shrinks local authority.
+func (m *ManagedIssuer) sweep(ctx context.Context) error {
+	root := m.options.PolicyRoot
+	unlock, err := lockIssuer(root)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if _, err := recoverPending(root); err != nil {
+		return err
+	}
+	entries, err := boundedEntries(filepath.Join(root, "sympozium-issuer-journal"))
+	if err != nil {
+		return err
+	}
+	clock, clockErr := readProfileClock(ctx, m.execute, m.options.Binary)
+	errs := []error{clockErr}
+	tracked := make(map[string]bool)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".record-") {
+			continue
+		}
+		r, err := readIssuerRecord(filepath.Join(root, "sympozium-issuer-journal", entry.Name()))
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if r.State != "issued" {
+			continue
+		}
+		tracked[r.Profile+".json"] = true
+		data, readErr := readLimit(filepath.Join(root, "trusted-model-profiles", r.Profile+".json"), 65536)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			errs = append(errs, readErr)
+			continue
+		}
+		if readErr == nil {
+			h := sha256.Sum256(data)
+			if "sha256:"+hex.EncodeToString(h[:]) != r.ProfileSHA256 {
+				errs = append(errs, fmt.Errorf("tracked profile bytes changed"))
+				continue
+			}
+		}
+		var p struct {
+			APIVersion string        `json:"apiVersion"`
+			Expiry     profileExpiry `json:"expiry"`
+		}
+		decodeErr := json.Unmarshal(data, &p)
+		lifetime := p.Expiry.ExpiresAt - p.Expiry.IssuedAt
+		bounded := decodeErr == nil && p.APIVersion == "celln.dev/model-issuer-profile-v2" && lifetime > 0 && lifetime <= 300000
+		key := types.NamespacedName{Namespace: r.Frozen.Snapshot.Agent.Namespace, Name: r.Frozen.Snapshot.Agent.Name}
+		loader, configured := m.loaders[key]
+		if !bounded || clockErr != nil || !configured || p.Expiry.check(clock, time.Duration(lifetime)*time.Millisecond) != nil {
+			r.State = "withdrawing"
+			if err := writeIssuerRecord(root, r); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if err := withdrawProfile(root, *r.Issued); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			r.State = "withdrawn"
+			if err := writeIssuerRecord(root, r); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		if _, err := reconcileIssued(ctx, root, r.Profile, r.ProfileSHA256, loader); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	profiles, err := boundedEntries(filepath.Join(root, "trusted-model-profiles"))
+	if err != nil {
+		errs = append(errs, err)
+	}
+	for _, p := range profiles {
+		if !tracked[p.Name()] {
+			errs = append(errs, fmt.Errorf("untracked host profile requires operator reconciliation"))
+		}
+	}
+	if ctx.Err() != nil {
+		errs = append(errs, ctx.Err())
+	}
+	return errors.Join(errs...)
+}

--- a/internal/cellnreview/issuer_managed_test.go
+++ b/internal/cellnreview/issuer_managed_test.go
@@ -1,0 +1,212 @@
+package cellnreview
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func managedFixture(t *testing.T) (issuerFixture, *ManagedIssuer, *profileClock) {
+	t.Helper()
+	f := provisionFixture(t)
+	f.o.ProfileLifetime = time.Minute
+	m, err := NewManagedIssuer(f.o, map[types.NamespacedName]cellnauthority.ModelLoader{{Namespace: f.f.Snapshot.Agent.Namespace, Name: f.f.Snapshot.Agent.Name}: f.l}, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock, calls := testProfileClock(), 0
+	m.execute = clockRunner(f.run, &clock, &calls)
+	return f, m, &clock
+}
+
+func eventuallyManaged(t *testing.T, check func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for !check() {
+		if time.Now().After(deadline) {
+			t.Fatal("managed issuer observation timed out")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestManagedIssuerStartupIssuePeriodicWithdrawalAndShutdown(t *testing.T) {
+	f, m, _ := managedFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	if _, err := m.Issue(ctx, *f.f, *f.a, f.artifacts); err == nil {
+		t.Fatal("issued before startup")
+	}
+	go func() { done <- m.Start(ctx) }()
+	defer func() { cancel(); <-done }()
+	eventuallyManaged(t, func() bool { ready, _ := m.Status(); return ready })
+	issued, err := m.Issue(ctx, *f.f, *f.a, f.artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cm corev1.ConfigMap
+	if err := f.c.Get(ctx, f.l.Source, &cm); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.c.Delete(ctx, &cm); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json")
+	eventuallyManaged(t, func() bool { _, err := os.Stat(path); return os.IsNotExist(err) })
+	if _, err := m.Issue(ctx, *f.f, *f.a, f.artifacts); err == nil {
+		t.Fatal("issued after approval withdrawal")
+	}
+	cancel()
+	if ready, _ := m.Status(); ready {
+		t.Fatal("gate open after cancellation")
+	}
+	if _, err := m.Issue(context.Background(), *f.f, *f.a, f.artifacts); err == nil {
+		t.Fatal("issued after shutdown")
+	}
+}
+
+func TestManagedStartupSweepsLegacyExpiredUnknownAndInterruptedAuthority(t *testing.T) {
+	for _, mode := range []string{"legacy", "expired", "unconfigured", "pending", "api-unavailable", "clock-unavailable"} {
+		t.Run(mode, func(t *testing.T) {
+			f, m, clock := managedFixture(t)
+			options := f.o
+			if mode == "legacy" {
+				options.ProfileLifetime = 0
+			}
+			issued, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, options, m.execute)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "expired":
+				clock.Now = 61000
+			case "unconfigured":
+				m.loaders = nil
+			case "clock-unavailable":
+				clock.ExecutionAuthorized = true
+			case "pending":
+				r, err := ReadIssuance(f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256)
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.State = "pending"
+				if err := writeIssuerRecord(f.o.PolicyRoot, r); err != nil {
+					t.Fatal(err)
+				}
+			case "api-unavailable":
+				for key, loader := range m.loaders {
+					loader.Selection.Reader = unavailableApprovalReader{f.c}
+					m.loaders[key] = loader
+				}
+			}
+			err = m.sweep(context.Background())
+			if mode == "clock-unavailable" {
+				if err == nil {
+					t.Fatal("clock failure did not close gate")
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			assertNoProfiles(t, f.o.PolicyRoot)
+			r, err := ReadIssuance(f.o.PolicyRoot, issued.Profile, issued.ProfileSHA256)
+			if err != nil || r.State != "withdrawn" {
+				t.Fatalf("withdrawal not durable: %+v %v", r, err)
+			}
+		})
+	}
+}
+
+func TestManagedIssuerRefusesUntrackedOrChangedHostAuthority(t *testing.T) {
+	for _, mode := range []string{"untracked", "changed"} {
+		t.Run(mode, func(t *testing.T) {
+			f, m, _ := managedFixture(t)
+			issued, err := issue(context.Background(), f.l, *f.f, *f.a, f.artifacts, f.o, m.execute)
+			if err != nil {
+				t.Fatal(err)
+			}
+			name := "unrelated.json"
+			if mode == "changed" {
+				name = issued.Profile + ".json"
+			}
+			path := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles", name)
+			if err := os.WriteFile(path, []byte("unrelated"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := m.sweep(context.Background()); err == nil {
+				t.Fatal("unsafe startup accepted")
+			}
+			if data, err := os.ReadFile(path); err != nil || string(data) != "unrelated" {
+				t.Fatal("deleted unrelated authority")
+			}
+		})
+	}
+}
+
+func TestManagedGateStaysClosedUntilStartupFaultIsRemoved(t *testing.T) {
+	f, m, _ := managedFixture(t)
+	dir := filepath.Join(f.o.PolicyRoot, "trusted-model-profiles")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "untracked.json")
+	if err := os.WriteFile(path, []byte("unrelated"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- m.Start(ctx) }()
+	defer func() { cancel(); <-done }()
+	eventuallyManaged(t, func() bool { ready, err := m.Status(); return !ready && err != nil })
+	if _, err := m.Issue(ctx, *f.f, *f.a, f.artifacts); err == nil {
+		t.Fatal("issued through failed startup gate")
+	}
+	if err := m.Start(ctx); err == nil {
+		t.Fatal("accepted duplicate lifecycle owner")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyManaged(t, func() bool { ready, err := m.Status(); return ready && err == nil })
+}
+
+func TestManagedShutdownCancelsInflightIssuance(t *testing.T) {
+	f, m, _ := managedFixture(t)
+	entered := make(chan struct{})
+	next := m.execute
+	m.execute = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		if args[0] == "--root" && args[2] == "harness-grant" {
+			close(entered)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return next(ctx, binary, args...)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- m.Start(ctx) }()
+	defer func() { cancel(); <-done }()
+	eventuallyManaged(t, func() bool { ready, _ := m.Status(); return ready })
+	issued := make(chan error, 1)
+	go func() { _, err := m.Issue(context.Background(), *f.f, *f.a, f.artifacts); issued <- err }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("issuer did not start")
+	}
+	cancel()
+	select {
+	case err := <-issued:
+		if err == nil {
+			t.Fatal("issuance survived shutdown")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown did not cancel issuance")
+	}
+	assertNoProfiles(t, f.o.PolicyRoot)
+}

--- a/internal/cellnreview/issuer_reconcile.go
+++ b/internal/cellnreview/issuer_reconcile.go
@@ -40,6 +40,11 @@ func ReconcileIssued(ctx context.Context, root, profile, digest string, loader c
 	if _, err := recoverPending(root); err != nil {
 		return nil, err
 	}
+	return reconcileIssued(ctx, root, profile, digest, loader)
+}
+
+// Caller holds the issuer lock and has completed recovery.
+func reconcileIssued(ctx context.Context, root, profile, digest string, loader cellnauthority.ModelLoader) (*IssuerReconciliation, error) {
 	record, err := readIssuerRecord(filepath.Join(root, "sympozium-issuer-journal", profile+".json"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Part of #426; follows #446.

Adds a managed host-local issuer lifecycle with trusted per-Agent authority bindings. Startup recovery and a full bounded sweep must succeed before the local provisioning gate opens. Periodic sweeps withdraw stale/expired/legacy/unconfigured profiles, refuse unknown or changed authority, and close the gate on failures. Managed issuance requires bounded profiles and links in-flight work to shutdown cancellation. No status renews expiry or grants permission to dispatch.

Validation: full Go race suite with real NATS, build/vet, targeted startup/gate recovery/periodic withdrawal/shutdown tests, and real signed composition -> managed startup -> actual KVM issuance/retry -> approval deletion -> periodic withdrawal -> host refusal passed. Fake Kubernetes, zero model calls. Evidence and limits committed.

Scope: in-process lifecycle component, not registered in the shipped controller and not exposed as a host RPC service yet. Selected-node prewarm/catalogue dispatch, active-cell/fleet revocation and the final UI/YAML/conversation journey remain open. Local gate status is not artifact readiness or execution authorization.