### PR TITLE
feat: serve managed Celln issuance over authenticated TLS

### DIFF
--- a/cmd/sympozium/celln_issuer_cmd.go
+++ b/cmd/sympozium/celln_issuer_cmd.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type issuerServiceConfig struct {
+	APIVersion        string `json:"apiVersion"`
+	Listen            string `json:"listen"`
+	CertificateFile   string `json:"certificateFile"`
+	PrivateKeyFile    string `json:"privateKeyFile"`
+	TokenFile         string `json:"tokenFile"`
+	Binary            string `json:"cellnBinary"`
+	PolicyRoot        string `json:"policyRoot"`
+	ComposerPublisher string `json:"composerPublisher"`
+	ProfileLifetimeMS uint64 `json:"profileLifetimeMs"`
+	SweepIntervalMS   uint64 `json:"sweepIntervalMs"`
+	Bindings          []struct {
+		Agent          types.NamespacedName `json:"agent"`
+		OperatorGrants types.NamespacedName `json:"operatorGrants"`
+		RuntimeGrants  types.NamespacedName `json:"runtimeGrants"`
+		AgentGrants    types.NamespacedName `json:"agentGrants"`
+		ModelPolicy    types.NamespacedName `json:"modelPolicy"`
+	} `json:"bindings"`
+}
+
+func readIssuerServiceConfig(path string) (issuerServiceConfig, error) {
+	var config issuerServiceConfig
+	if !filepath.IsAbs(path) {
+		return config, fmt.Errorf("absolute operator config path required")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return config, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, (1<<20)+1))
+	if err != nil {
+		return config, err
+	}
+	if len(data) > 1<<20 {
+		return config, fmt.Errorf("issuer config exceeds 1 MiB")
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.DisallowUnknownFields()
+	if err := d.Decode(&config); err != nil {
+		return config, err
+	}
+	if d.Decode(new(any)) != io.EOF {
+		return config, fmt.Errorf("trailing issuer config JSON")
+	}
+	if config.APIVersion != "sympozium.ai/celln-issuer-service-v1" || config.ProfileLifetimeMS < 1 || config.ProfileLifetimeMS > 300000 || config.SweepIntervalMS < 1000 || config.SweepIntervalMS > 30000 || len(config.Bindings) == 0 || len(config.Bindings) > 1024 {
+		return config, fmt.Errorf("invalid bounded issuer configuration")
+	}
+	for _, path := range []string{config.CertificateFile, config.PrivateKeyFile, config.TokenFile, config.Binary, config.PolicyRoot} {
+		if !filepath.IsAbs(path) {
+			return config, fmt.Errorf("absolute operator paths required")
+		}
+	}
+	if _, _, err := net.SplitHostPort(config.Listen); err != nil {
+		return config, fmt.Errorf("explicit issuer host:port required")
+	}
+	seen := make(map[types.NamespacedName]bool)
+	for _, b := range config.Bindings {
+		if b.Agent.Namespace == "" || b.Agent.Name == "" || seen[b.Agent] {
+			return config, fmt.Errorf("distinct namespaced Agent bindings required")
+		}
+		seen[b.Agent] = true
+		sources := make(map[types.NamespacedName]bool)
+		for _, source := range []types.NamespacedName{b.OperatorGrants, b.RuntimeGrants, b.AgentGrants, b.ModelPolicy} {
+			if source.Namespace == "" || source.Name == "" || sources[source] {
+				return config, fmt.Errorf("four distinct configured authority sources required")
+			}
+			sources[source] = true
+		}
+	}
+	return config, nil
+}
+
+func newCellnIssuerServiceCmd() *cobra.Command {
+	var configFile string
+	cmd := &cobra.Command{Use: "serve-issuer", Args: cobra.NoArgs, SilenceUsage: true,
+		Short: "Run the TLS-authenticated host-local issuer with startup recovery and periodic withdrawal",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			config, err := readIssuerServiceConfig(configFile)
+			if err != nil {
+				return err
+			}
+			loaders := make(map[types.NamespacedName]cellnauthority.ModelLoader)
+			for _, binding := range config.Bindings {
+				if _, duplicate := loaders[binding.Agent]; duplicate {
+					return fmt.Errorf("duplicate Agent issuer binding")
+				}
+				loaders[binding.Agent] = cellnauthority.ModelLoader{Selection: cellnauthority.Loader{Reader: k8sClient, OperatorSource: binding.OperatorGrants, RuntimeSource: binding.RuntimeGrants, AgentSource: binding.AgentGrants}, Source: binding.ModelPolicy}
+			}
+			managed, err := cellnreview.NewManagedIssuer(cellnreview.IssueOptions{Binary: config.Binary, PolicyRoot: config.PolicyRoot, ComposerPublisher: config.ComposerPublisher, ProfileLifetime: time.Duration(config.ProfileLifetimeMS) * time.Millisecond}, loaders, time.Duration(config.SweepIntervalMS)*time.Millisecond)
+			if err != nil {
+				return err
+			}
+			listener, err := net.Listen("tcp", config.Listen)
+			if err != nil {
+				return err
+			}
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return cellnreview.ServeIssuer(ctx, listener, managed, config.TokenFile, config.CertificateFile, config.PrivateKeyFile)
+		}}
+	cmd.Flags().StringVar(&configFile, "config", "", "Absolute operator-owned issuer service JSON configuration")
+	_ = cmd.MarkFlagRequired("config")
+	return cmd
+}

--- a/cmd/sympozium/celln_issuer_cmd_test.go
+++ b/cmd/sympozium/celln_issuer_cmd_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIssuerServiceConfigRequiresExplicitBoundedAuthority(t *testing.T) {
+	for _, mode := range []string{"valid", "unknown", "legacy", "too-long", "relative", "duplicate-agent", "duplicate-source", "missing-source", "trailing"} {
+		t.Run(mode, func(t *testing.T) {
+			ref := func(name string) map[string]string { return map[string]string{"namespace": "operators", "name": name} }
+			binding := map[string]any{"agent": ref("agent"), "operatorGrants": ref("operator"), "runtimeGrants": ref("runtime"), "agentGrants": ref("agent-grants"), "modelPolicy": ref("model")}
+			config := map[string]any{"apiVersion": "sympozium.ai/celln-issuer-service-v1", "listen": "127.0.0.1:8788", "certificateFile": "/operator/cert", "privateKeyFile": "/operator/key", "tokenFile": "/operator/token", "cellnBinary": "/operator/celln", "policyRoot": "/operator/root", "composerPublisher": "unused-by-config-parse", "profileLifetimeMs": 300000, "sweepIntervalMs": 5000, "bindings": []any{binding}}
+			switch mode {
+			case "unknown":
+				config["allowInsecure"] = true
+			case "legacy":
+				config["profileLifetimeMs"] = 0
+			case "too-long":
+				config["profileLifetimeMs"] = 300001
+			case "relative":
+				config["tokenFile"] = "token"
+			case "duplicate-agent":
+				config["bindings"] = []any{binding, binding}
+			case "duplicate-source":
+				binding["modelPolicy"] = ref("operator")
+			case "missing-source":
+				delete(binding, "runtimeGrants")
+			}
+			data, err := json.Marshal(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "trailing" {
+				data = append(data, []byte(" {}")...)
+			}
+			path := filepath.Join(t.TempDir(), "issuer.json")
+			if err := os.WriteFile(path, data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, err = readIssuerServiceConfig(path)
+			if (err == nil) != (mode == "valid") {
+				t.Fatalf("wrong configuration acceptance: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/sympozium/celln_tool_cmd.go
+++ b/cmd/sympozium/celln_tool_cmd.go
@@ -52,5 +52,6 @@ func newCellnToolCmd() *cobra.Command {
 	cmd.AddCommand(newCellnSelectionIssueCmd())
 	cmd.AddCommand(newCellnWithdrawGrantCmd())
 	cmd.AddCommand(newCellnRecoverGrantsCmd())
+	cmd.AddCommand(newCellnIssuerServiceCmd())
 	return cmd
 }

--- a/docs/evidence/celln-issuer-service-2026-09-07.json
+++ b/docs/evidence/celln-issuer-service-2026-09-07.json
@@ -1,0 +1,39 @@
+{
+  "date": "2026-09-07",
+  "scope": "authenticated host issuer service, not deployed AgentRun controller integration",
+  "base": "e2d9d6a20f381d34160b1d551d250285ce070e10",
+  "checks": {
+    "fullGoRace": "passed with real NATS on PATH",
+    "goBuildAll": "passed",
+    "goVetAll": "passed",
+    "targetedRace": "passed",
+    "cases": [
+      "actual HTTPS server issues and repeats the same bounded profile",
+      "missing, wrong, duplicate, rotated or removed bearer credentials refuse",
+      "plaintext handler use refuses even with a valid bearer",
+      "unknown fields, trailing JSON and over-limit bodies refuse",
+      "unconfigured Agent substitution refuses",
+      "host credential path and token do not appear in response",
+      "third concurrent authenticated handler refuses with 429",
+      "strict service config rejects insecure/legacy/ambiguous authority configuration",
+      "service joins server and managed lifecycle on cancellation"
+    ]
+  },
+  "realKVM": {
+    "test": "TestComposeRealCellnArtifacts with CELLN_ISSUANCE_KVM=1",
+    "result": "passed",
+    "sequence": "real signed composition -> authenticated TLS service -> managed startup -> bounded profile -> real sealed member verification -> identical retry -> approval deletion -> periodic withdrawal -> host refusal",
+    "grant": "blake3:8d224730d745e5c13318c02002bd8aa2bbd9d86a4102dbb57ec20c5275a184a3",
+    "closure": "blake3:1c26cc7edcf9d3ba8da03086ab469e8378d607f40b9debb4d9991892ddeff1ba",
+    "toolfs": "blake3:86fe54378d07a015be1868cab52cc7d08b9da43094abf21bf10c0ce70270caa3",
+    "kubernetes": "fake client",
+    "tlsIdentity": "Go public test certificate trusted by test client",
+    "modelCalls": 0
+  },
+  "notProven": [
+    "deployed CLI plus real Kubernetes/RBAC/network/TLS provisioning",
+    "AgentRun controller client and catalogue-backed dispatch",
+    "serving-node prewarm/readiness and fleet lifecycle",
+    "UI/YAML selection, conversations and final real-model release acceptance"
+  ]
+}

--- a/docs/guides/celln-issuer-service.md
+++ b/docs/guides/celln-issuer-service.md
@@ -1,0 +1,109 @@
+# Authenticated Celln host issuer service
+
+`sympozium celln-tool serve-issuer --config /absolute/issuer.json` runs the
+managed issuer on the Celln host. The controller can request bounded provisioning
+over TLS without mounting the host's profile store or provider credential files.
+This is a controller-only service, not a tenant API or an execution endpoint.
+It is not yet wired into the AgentRun controller, Helm or node distribution.
+
+## Operator configuration
+
+Supply an explicit kubeconfig with read-only access to the configured approval
+ConfigMaps, Agents, AgentRuns, AgentRuntimes and CellnTools. The client is uncached;
+tenant RBAC must deny writes to approval sources. No Kubernetes Secrets are read
+by the issuance protocol. Run on the host with the independently managed Celln
+policy/artifact root, credential mapping and Celln binary described in
+[local issuance](celln-local-issuance.md).
+
+```json
+{
+  "apiVersion": "sympozium.ai/celln-issuer-service-v1",
+  "listen": "127.0.0.1:8788",
+  "certificateFile": "/etc/sympozium-issuer/tls.crt",
+  "privateKeyFile": "/etc/sympozium-issuer/tls.key",
+  "tokenFile": "/etc/sympozium-issuer/controller-token",
+  "cellnBinary": "/usr/local/bin/celln",
+  "policyRoot": "/var/lib/celln",
+  "composerPublisher": "<64-hex independently approved composer key>",
+  "profileLifetimeMs": 300000,
+  "sweepIntervalMs": 5000,
+  "bindings": [{
+    "agent": {"namespace": "team-a", "name": "assistant"},
+    "operatorGrants": {"namespace": "operators", "name": "team-a-operator"},
+    "runtimeGrants": {"namespace": "operators", "name": "team-a-runtime"},
+    "agentGrants": {"namespace": "operators", "name": "team-a-agent"},
+    "modelPolicy": {"namespace": "operators", "name": "team-a-model"}
+  }]
+}
+```
+
+The composer value is a placeholder, not a test trust root. Four distinct
+authority sources and a distinct Agent binding are required. Configuration is
+strict JSON bounded to 1 MiB; paths must be absolute. Lifetime must be 1–300000 ms
+and sweep interval 1000–30000 ms. There is no legacy/non-expiring service mode.
+Changing the configuration requires a controlled service restart.
+
+```sh
+sympozium --kubeconfig /etc/sympozium-issuer/kubeconfig \
+  celln-tool serve-issuer --config /etc/sympozium-issuer/issuer.json
+```
+
+TLS 1.3 is mandatory even on loopback; there is no plaintext or skip-verification
+flag. Supply a certificate trusted by the controller with the correct hostname
+or IP SAN. Restrict host/firewall/cluster ingress to the controller. NetworkPolicy,
+certificate issuance/rotation and production installation remain deployment
+qualification work, not a guarantee supplied by this command.
+
+The separate controller bearer credential must be an independently generated
+high-entropy token, 24–4096 visible ASCII bytes, in an operator-only file. It is
+not the Celln dispatch credential or model API key. The service rereads it per
+request; rotate by atomically replacing the file. Missing, malformed, duplicate
+or wrong credentials refuse. TLS key/certificate reload requires restart.
+
+## Protocol
+
+Both endpoints require `Authorization: Bearer ...` over TLS, with no query
+parameters. Responses carry `Cache-Control: no-store`.
+
+- `GET /v1/issuer/status`: `sympozium.ai/celln-issuer-status-v1`, local
+  `provisioningGateOpen`, `executionAuthorized: false`, and
+  `artifactReadiness: not_checked`. A closed gate returns 503. An open gate is
+  not Kubernetes availability, selection readiness or permission to dispatch.
+- `POST /v1/issuances`: JSON `sympozium.ai/celln-issuer-request-v1` containing
+  `frozen`, `approval` and actual materialized `artifacts` from catalogue planning.
+  Unknown fields, trailing JSON, non-JSON/compressed bodies and bodies exceeding
+  1 MiB refuse. Host paths, tokens, authority-source configuration, runtime
+  commands and certificate/readiness assertions are not accepted request fields.
+
+The host revalidates every observation against its own configured live sources,
+authenticates signed artifacts, performs KVM sealed member verification and
+creates the bounded profile/grant through the managed lifecycle gate. A caller
+cannot authorize a different Agent or substitute approval sources through the
+request. The response is `sympozium.ai/celln-issuer-response-v1`, with `issued`,
+`executed: false` and `artifactReadiness: not_checked`. Model credentials and host
+credential paths do not appear in the result. Errors are deliberately generic.
+
+At most two authenticated handlers proceed concurrently; excess work returns
+429. Managed issuance itself serializes with reconciliation. Request work has a
+90-second context budget, with bounded HTTP header/body/idle/write timeouts.
+Signals close the listener/gate and cancel in-flight issuance before joining
+the service and reconciler. Host expiry remains the admission bound after a crash.
+
+A lost response is an ambiguous delivery of a durably journaled outcome, not
+permission to refresh expiry or execute again. Retry only the identical frozen
+request; the original profile/grant/window identity remains fixed. Never mint a
+new run or execution ID merely to resolve a network error. There is no upload,
+signing, provider-call, dispatch or automatic replay endpoint here.
+
+## Evidence and remaining integration
+
+Tests exercise the actual HTTPS server, credential rotation/refusal, strict
+request handling, bounded concurrency and shutdown. The explicit KVM test uses
+real signed composition → TLS request → managed provisioning → actual sealed
+member verification → identical retry → approval deletion → periodic withdrawal
+→ host refusal. Kubernetes is still a fake client and no model calls are made.
+
+Next: configure and test the controller client, selection-specific serving-node
+prewarm, catalogue-backed AgentRun dispatch and correlated results. Deployed
+Kubernetes/RBAC/network/TLS qualification, UI/YAML selection, conversational
+lifecycle and final real-model release acceptance remain open.

--- a/docs/guides/celln-local-issuance.md
+++ b/docs/guides/celln-local-issuance.md
@@ -176,9 +176,10 @@ process crash, host expiry remains the admission bound; clean shutdown closes th
 gate and cancels in-flight issuance but does not promise immediate fleet/live-cell
 revocation of already issued authority.
 
-This lifecycle component is tested in-process but is **not yet registered in the
-shipped controller or exposed as a host RPC service**. The next integration must
-start it on the correct host, route catalogue provisioning through its gate,
+The [TLS host issuer service](celln-issuer-service.md) now exposes this lifecycle
+through `celln-tool serve-issuer`, but it is **not yet wired into the AgentRun
+controller or Helm**. The next integration must configure it on the correct host,
+route catalogue provisioning through its gate,
 prewarm that serving node and retain dispatch/replay identity. Existing CLI
 operator commands remain explicit local operations, not a bypass-safe deployment
 of the final automated user journey.

--- a/internal/cellnreview/issue_real_test.go
+++ b/internal/cellnreview/issue_real_test.go
@@ -51,19 +51,23 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 	if err != nil {
 		t.Fatal(err)
 	}
-	managedCtx, cancelManaged := context.WithCancel(ctx)
-	done := make(chan error, 1)
-	go func() { done <- managed.Start(managedCtx) }()
-	defer func() { cancelManaged(); <-done }()
-	eventuallyManaged(t, func() bool { ready, _ := managed.Status(); return ready })
-	issued, err := managed.Issue(ctx, frozen, *approval, artifacts)
+	url, httpClient, _ := serveTestIssuer(t, managed)
+	remoteRequest, err := json.Marshal(IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: frozen, Approval: *approval, Artifacts: artifacts})
 	if err != nil {
 		t.Fatal(err)
 	}
-	again, err := managed.Issue(ctx, frozen, *approval, artifacts)
-	if err != nil {
-		t.Fatal(err)
+	remoteIssue := func() *IssuedSelection {
+		status, body := issuerHTTP(t, httpClient, "POST", url+"/v1/issuances", testIssuerToken, remoteRequest)
+		if status != 200 {
+			t.Fatalf("real remote issuance refused: %d", status)
+		}
+		var response IssuerResponse
+		if err := json.Unmarshal(body, &response); err != nil || response.Issued == nil || response.Executed {
+			t.Fatalf("invalid remote result: %v", err)
+		}
+		return response.Issued
 	}
+	issued, again := remoteIssue(), remoteIssue()
 	if again.Grant != issued.Grant || again.Profile != issued.Profile {
 		t.Fatal("actual issuance retry changed identity")
 	}
@@ -91,5 +95,5 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 		t.Fatal("withdrawal changed retained grant bytes")
 	}
 	assertNoProfiles(t, o.PolicyRoot)
-	t.Logf("PASS real catalogue composition -> managed startup recovery gate -> durable boot-bound expiring profile -> real-KVM sealed verification -> identical v3 issuance without renewal -> approval deletion -> periodic managed withdrawal -> host refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
+	t.Logf("PASS real catalogue composition -> authenticated TLS issuer service -> managed startup recovery gate -> durable boot-bound expiring profile -> real-KVM sealed verification -> identical v3 issuance without renewal -> approval deletion -> periodic managed withdrawal -> host refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
 }

--- a/internal/cellnreview/issuer_http.go
+++ b/internal/cellnreview/issuer_http.go
@@ -1,0 +1,190 @@
+package cellnreview
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+)
+
+type IssuerRequest struct {
+	APIVersion string                            `json:"apiVersion"`
+	Frozen     cellnauthority.FrozenSelection    `json:"frozen"`
+	Approval   cellnauthority.ModelApproval      `json:"approval"`
+	Artifacts  cellnauthority.ExecutionArtifacts `json:"artifacts"`
+}
+
+type IssuerResponse struct {
+	APIVersion        string           `json:"apiVersion"`
+	Issued            *IssuedSelection `json:"issued"`
+	Executed          bool             `json:"executed"`
+	ArtifactReadiness string           `json:"artifactReadiness"`
+}
+
+func issuerToken(path string) ([]byte, error) {
+	raw, err := readLimit(path, 4096)
+	if err != nil {
+		return nil, fmt.Errorf("issuer credential unavailable")
+	}
+	token := strings.TrimSpace(string(raw))
+	if len(token) < 24 {
+		return nil, fmt.Errorf("invalid issuer credential")
+	}
+	for _, b := range []byte(token) {
+		if b < 33 || b > 126 {
+			return nil, fmt.Errorf("invalid issuer credential")
+		}
+	}
+	return []byte(token), nil
+}
+
+// NewIssuerHandler is a controller-only host boundary, never a tenant endpoint.
+// It accepts immutable selection observations, not host paths, approval-source
+// configuration, credentials, executables to run or a readiness assertion.
+func NewIssuerHandler(m *ManagedIssuer, tokenFile string) (http.Handler, error) {
+	if m == nil || !filepath.IsAbs(tokenFile) {
+		return nil, fmt.Errorf("managed issuer and absolute token file required")
+	}
+	if _, err := issuerToken(tokenFile); err != nil {
+		return nil, err
+	}
+	slots := make(chan struct{}, 2)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		// Refuse plaintext even if accidentally mounted on an HTTP listener.
+		if r.TLS == nil {
+			http.Error(w, "TLS required", http.StatusUpgradeRequired)
+			return
+		}
+		credentials := r.Header.Values("Authorization")
+		if len(credentials) != 1 || !strings.HasPrefix(credentials[0], "Bearer ") {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		token, err := issuerToken(tokenFile)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		want, got := sha256.Sum256(token), sha256.Sum256([]byte(strings.TrimPrefix(credentials[0], "Bearer ")))
+		if subtle.ConstantTimeCompare(want[:], got[:]) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		select {
+		case slots <- struct{}{}:
+			defer func() { <-slots }()
+		default:
+			http.Error(w, "issuer busy", http.StatusTooManyRequests)
+			return
+		}
+		if r.URL.RawQuery != "" {
+			http.Error(w, "query parameters unsupported", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Path == "/v1/issuer/status" && r.Method == http.MethodGet {
+			ready, _ := m.Status()
+			w.Header().Set("Content-Type", "application/json")
+			if !ready {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-issuer-status-v1", "provisioningGateOpen": ready, "executionAuthorized": false, "artifactReadiness": "not_checked"})
+			return
+		}
+		if r.URL.Path != "/v1/issuances" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			http.Error(w, "method unsupported", http.StatusMethodNotAllowed)
+			return
+		}
+		media, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil || media != "application/json" || r.Header.Get("Content-Encoding") != "" {
+			http.Error(w, "JSON required", http.StatusUnsupportedMediaType)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		defer r.Body.Close()
+		var request IssuerRequest
+		d := json.NewDecoder(r.Body)
+		d.DisallowUnknownFields()
+		if d.Decode(&request) != nil || d.Decode(new(any)) != io.EOF || request.APIVersion != "sympozium.ai/celln-issuer-request-v1" {
+			http.Error(w, "invalid bounded issuance request", http.StatusBadRequest)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 90*time.Second)
+		defer cancel()
+		issued, err := m.Issue(ctx, request.Frozen, request.Approval, request.Artifacts)
+		if err != nil {
+			http.Error(w, "issuance refused", http.StatusConflict)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// A lost response is an ambiguous delivery, not authority to renew or
+		// dispatch. The durable outcome permits an identical bounded retry.
+		_ = json.NewEncoder(w).Encode(IssuerResponse{APIVersion: "sympozium.ai/celln-issuer-response-v1", Issued: issued, ArtifactReadiness: "not_checked"})
+	}), nil
+}
+
+// ServeIssuer owns the supplied listener and joins both lifecycle goroutines.
+// TLS is mandatory; controller credentials rotate via the operator token file.
+func ServeIssuer(ctx context.Context, listener net.Listener, m *ManagedIssuer, tokenFile, certificateFile, privateKeyFile string) error {
+	defer listener.Close()
+	handler, err := NewIssuerHandler(m, tokenFile)
+	if err != nil {
+		return err
+	}
+	certificate, err := tls.LoadX509KeyPair(certificateFile, privateKeyFile)
+	if err != nil {
+		return fmt.Errorf("issuer TLS identity unavailable: %w", err)
+	}
+	serveCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	server := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 10 * time.Second, WriteTimeout: 100 * time.Second, IdleTimeout: 30 * time.Second, MaxHeaderBytes: 8192,
+		TLSConfig:   &tls.Config{MinVersion: tls.VersionTLS13, Certificates: []tls.Certificate{certificate}},
+		BaseContext: func(net.Listener) context.Context { return serveCtx },
+	}
+	managedDone, serverDone := make(chan error, 1), make(chan error, 1)
+	go func() { managedDone <- m.Start(serveCtx) }()
+	go func() { serverDone <- server.ServeTLS(listener, "", "") }()
+	var managedErr, serverErr error
+	var managedStopped, serverStopped bool
+	select {
+	case <-ctx.Done():
+	case managedErr = <-managedDone:
+		managedStopped = true
+	case serverErr = <-serverDone:
+		serverStopped = true
+	}
+	cancel()
+	shutdownCtx, stop := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownErr := server.Shutdown(shutdownCtx)
+	stop()
+	if shutdownErr != nil {
+		_ = server.Close()
+	}
+	if !managedStopped {
+		managedErr = <-managedDone
+	}
+	if !serverStopped {
+		serverErr = <-serverDone
+	}
+	if errors.Is(serverErr, http.ErrServerClosed) {
+		serverErr = nil
+	}
+	return errors.Join(managedErr, serverErr, shutdownErr)
+}

--- a/internal/cellnreview/issuer_http_test.go
+++ b/internal/cellnreview/issuer_http_test.go
@@ -1,0 +1,227 @@
+package cellnreview
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testIssuerToken = "public-test-only-controller-token-0001"
+
+func serveTestIssuer(t *testing.T, m *ManagedIssuer) (string, *http.Client, string) {
+	t.Helper()
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "controller-token")
+	if err := os.WriteFile(tokenPath, []byte(testIssuerToken), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Reuse Go's public test certificate, not a deployment credential.
+	fixture := httptest.NewTLSServer(http.NotFoundHandler())
+	cert := fixture.TLS.Certificates[0]
+	fixture.Close()
+	key, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath, keyPath := filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	roots := x509.NewCertPool()
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots.AddCert(parsed)
+	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS13}}
+	client := &http.Client{Transport: transport, Timeout: 30 * time.Second}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- ServeIssuer(ctx, listener, m, tokenPath, certPath, keyPath) }()
+	t.Cleanup(func() {
+		cancel()
+		transport.CloseIdleConnections()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("issuer shutdown failed: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("issuer server did not stop")
+		}
+	})
+	eventuallyManaged(t, func() bool { ready, _ := m.Status(); return ready })
+	return "https://" + listener.Addr().String(), client, tokenPath
+}
+
+func issuerHTTP(t *testing.T, client *http.Client, method, url, token string, data []byte) (int, []byte) {
+	t.Helper()
+	r, err := http.NewRequest(method, url, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	r.Header.Set("Content-Type", "application/json")
+	response, err := client.Do(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, (1<<20)+1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response.StatusCode, body
+}
+
+func TestIssuerTLSServiceAuthenticationIssuanceAndRotation(t *testing.T) {
+	f, m, _ := managedFixture(t)
+	url, client, tokenPath := serveTestIssuer(t, m)
+	for _, token := range []string{"", "wrong"} {
+		if code, _ := issuerHTTP(t, client, "GET", url+"/v1/issuer/status", token, nil); code != http.StatusUnauthorized {
+			t.Fatalf("unauthenticated status: %d", code)
+		}
+	}
+	request := IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *f.f, Approval: *f.a, Artifacts: f.artifacts}
+	data, _ := json.Marshal(request)
+	var identity string
+	for i := 0; i < 2; i++ {
+		code, body := issuerHTTP(t, client, "POST", url+"/v1/issuances", testIssuerToken, data)
+		if code != http.StatusOK {
+			t.Fatalf("issuance refused: %d", code)
+		}
+		var report IssuerResponse
+		if err := json.Unmarshal(body, &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.APIVersion != "sympozium.ai/celln-issuer-response-v1" || report.Issued == nil || report.Executed || report.ArtifactReadiness != "not_checked" {
+			t.Fatal("invalid remote issuance report")
+		}
+		if i == 1 && report.Issued.Profile != identity {
+			t.Fatal("remote retry renewed authority")
+		}
+		identity = report.Issued.Profile
+		if bytes.Contains(body, []byte("never-read-host-credential")) || bytes.Contains(body, []byte(testIssuerToken)) {
+			t.Fatal("host credentials leaked")
+		}
+	}
+	newToken := "public-test-only-controller-token-0002"
+	if err := os.WriteFile(tokenPath, []byte(newToken), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if code, _ := issuerHTTP(t, client, "GET", url+"/v1/issuer/status", testIssuerToken, nil); code != http.StatusUnauthorized {
+		t.Fatal("old credential survived rotation")
+	}
+	if code, _ := issuerHTTP(t, client, "GET", url+"/v1/issuer/status", newToken, nil); code != http.StatusOK {
+		t.Fatal("new credential refused")
+	}
+	if err := os.Remove(tokenPath); err != nil {
+		t.Fatal(err)
+	}
+	if code, _ := issuerHTTP(t, client, "GET", url+"/v1/issuer/status", newToken, nil); code != http.StatusUnauthorized {
+		t.Fatal("missing credential failed open")
+	}
+}
+
+func TestIssuerTLSServiceRefusesMalformedOrSubstitutedAuthority(t *testing.T) {
+	f, m, _ := managedFixture(t)
+	url, client, tokenPath := serveTestIssuer(t, m)
+	for _, body := range []string{`{}`, `{"apiVersion":"sympozium.ai/celln-issuer-request-v1","policyRoot":"/tenant"}`, `{} {}`, `{"padding":"` + strings.Repeat("x", 1<<20) + `"}`} {
+		if code, _ := issuerHTTP(t, client, "POST", url+"/v1/issuances", testIssuerToken, []byte(body)); code != http.StatusBadRequest {
+			t.Fatalf("malformed request accepted: %d", code)
+		}
+	}
+	r := IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *f.f, Approval: *f.a, Artifacts: f.artifacts}
+	r.Frozen.Snapshot.Agent.Namespace = "other-tenant"
+	data, _ := json.Marshal(r)
+	if code, _ := issuerHTTP(t, client, "POST", url+"/v1/issuances", testIssuerToken, data); code != http.StatusConflict {
+		t.Fatal("unconfigured Agent accepted")
+	}
+	if code, _ := issuerHTTP(t, client, "GET", url+"/v1/issuer/status?token=ignored", testIssuerToken, nil); code != http.StatusBadRequest {
+		t.Fatal("query accepted")
+	}
+	handler, err := NewIssuerHandler(m, tokenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	plain := httptest.NewRequest("GET", "/v1/issuer/status", nil)
+	plain.Header.Set("Authorization", "Bearer "+testIssuerToken)
+	handler.ServeHTTP(recorder, plain)
+	if recorder.Code != http.StatusUpgradeRequired {
+		t.Fatal("plaintext accepted")
+	}
+	duplicate := httptest.NewRequest("GET", "/v1/issuer/status", nil)
+	duplicate.TLS = &tls.ConnectionState{}
+	duplicate.Header.Add("Authorization", "Bearer "+testIssuerToken)
+	duplicate.Header.Add("Authorization", "Bearer "+testIssuerToken)
+	recorder = httptest.NewRecorder()
+	handler.ServeHTTP(recorder, duplicate)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatal("duplicate credentials accepted")
+	}
+	assertNoProfiles(t, f.o.PolicyRoot)
+}
+
+func TestIssuerHandlerBoundsConcurrentAuthenticatedWork(t *testing.T) {
+	_, m, _ := managedFixture(t)
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte(testIssuerToken), 0600); err != nil {
+		t.Fatal(err)
+	}
+	handler, err := NewIssuerHandler(m, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := func() int {
+		r := httptest.NewRequest("GET", "/v1/issuer/status", nil)
+		r.TLS = &tls.ConnectionState{}
+		r.Header.Set("Authorization", "Bearer "+testIssuerToken)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		return w.Code
+	}
+	// Hold the lifecycle mutex so the two admitted status requests cannot exit.
+	m.mu.Lock()
+	done := make(chan int, 3)
+	for i := 0; i < 3; i++ {
+		go func() { done <- request() }()
+	}
+	var code int
+	select {
+	case code = <-done:
+	case <-time.After(5 * time.Second):
+		m.mu.Unlock()
+		t.Fatal("concurrency limit did not refuse excess work")
+	}
+	m.mu.Unlock()
+	if code != http.StatusTooManyRequests {
+		t.Fatalf("unexpected excess request result: %d", code)
+	}
+	for i := 0; i < 2; i++ {
+		if code := <-done; code != http.StatusServiceUnavailable {
+			t.Fatalf("closed gate reported ready: %d", code)
+		}
+	}
+}


### PR DESCRIPTION
Part of #426; follows merged #447.

Adds celln-tool serve-issuer with strict operator configuration, mandatory TLS 1.3, a separately provisioned rotating controller bearer credential and the managed startup/withdrawal lifecycle. The controller-only protocol accepts frozen selection, approval observation and immutable artifact identities; never host paths, credential contents, approval-source locations or readiness assertions. Every issuance revalidates independent host-configured authority.

Request bodies, headers, time and concurrent authenticated work are bounded. Missing/wrong/duplicate/rotated credentials, plaintext, malformed bodies and unconfigured Agent substitution refuse. The response is a durable bounded issuance result, not execution authorization; lost delivery only permits identical retry, never expiry renewal or task replay.

Validation: full Go race suite with real NATS, build/vet, actual HTTPS/auth/config/concurrency tests, and real signed composition -> TLS service -> managed bounded issuance -> actual KVM sealed verification -> identical retry -> approval deletion -> periodic withdrawal -> host refusal passed. Fake Kubernetes, public test TLS identity, zero model calls. Evidence and deployment guide committed.

Remaining: real deployed CLI/Kubernetes/RBAC/network qualification, controller client and catalogue-backed dispatch, selected-node readiness, UI/YAML, conversations and final real-model release acceptance. Not Helm-wired or a tenant API.