### PR TITLE
feat: verify remote Celln issuance with a bounded TLS client

### DIFF
--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -27,8 +27,13 @@ func newCellnSelectionIssueCmd() *cobra.Command {
 	return newCellnSelectionCmd("issue")
 }
 
+func newCellnSelectionRemoteIssueCmd() *cobra.Command {
+	return newCellnSelectionCmd("issue-remote")
+}
+
 func newCellnSelectionCmd(mode string) *cobra.Command {
-	compose, issue := mode == "compose", mode == "issue"
+	remote := mode == "issue-remote"
+	compose, issue := mode == "compose", mode == "issue" || remote
 	var sourceNamespace, operatorSource, runtimeSource, agentSource string
 	var selected []string
 	var imageBytes int64
@@ -37,6 +42,7 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 	var executionMote, executionClosure string
 	var options cellnreview.ComposeOptions
 	var issueOptions cellnreview.IssueOptions
+	var remoteOptions cellnreview.IssuerClientOptions
 	cmd := &cobra.Command{Use: "plan AGENT", Args: cobra.ExactArgs(1), SilenceUsage: true,
 		Short: "Resolve live grants and emit a Celln composition plan without executing",
 		Long:  "Operator-only planning input. Read three independently configured grant ConfigMaps and live Agent/runtime/tool identities. Prints the resolved authority snapshot and exact compositor input; does not grant authority, certify readiness, write resources, compose images or execute. Tenant-facing callers must not accept these source flags from run requests.",
@@ -84,11 +90,28 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 					artifacts := cellnauthority.ExecutionArtifacts{}
 					artifacts.Mote.Hash, artifacts.Closure.Hash = executionMote, executionClosure
 					if issue {
-						issued, err := cellnreview.Issue(cmd.Context(), modelLoader, *frozen, *modelApproval, artifacts, issueOptions)
+						var issued *cellnreview.IssuedSelection
+						if remote {
+							issuerClient, clientErr := cellnreview.NewIssuerClient(remoteOptions)
+							if clientErr != nil {
+								return clientErr
+							}
+							defer issuerClient.CloseIdleConnections()
+							issued, err = issuerClient.Issue(cmd.Context(), modelLoader, *frozen, *modelApproval, artifacts)
+						} else {
+							issued, err = cellnreview.Issue(cmd.Context(), modelLoader, *frozen, *modelApproval, artifacts, issueOptions)
+						}
 						if err != nil {
 							return err
 						}
-						if err := json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-issuance-report-v1", "frozen": frozen, "issued": issued, "executed": false, "artifactReadiness": "not_checked"}); err != nil {
+						version := "sympozium.ai/celln-issuance-report-v1"
+						if remote {
+							version = "sympozium.ai/celln-remote-issuance-report-v1"
+						}
+						if err := json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": version, "frozen": frozen, "issued": issued, "executed": false, "artifactReadiness": "not_checked"}); err != nil {
+							if remote {
+								return err
+							} // Remote durable outcome survives lost output; never mutate a local host root.
 							return errors.Join(err, cellnreview.Withdraw(issueOptions.PolicyRoot, *issued))
 						}
 						return nil
@@ -149,6 +172,22 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 		}
 	}
 	if issue {
+		for _, name := range []string{"run", "model-policy", "execution-mote", "execution-closure"} {
+			_ = cmd.MarkFlagRequired(name)
+		}
+	}
+	if remote {
+		cmd.Use = "issue-remote AGENT"
+		cmd.Short = "Request bounded host issuance over verified controller-authenticated TLS"
+		cmd.Long = "Operator-only remote provisioning: derive and revalidate the frozen request, call the independently configured host issuer once, validate returned identity and recheck live approval. No host policy paths, signing keys or model credentials are accepted. No dispatch, implicit retry or readiness claim. Lost responses require preserving the exact original identity."
+		cmd.Flags().StringVar(&remoteOptions.URL, "issuer-url", "", "Operator-configured HTTPS issuer origin")
+		cmd.Flags().StringVar(&remoteOptions.TokenFile, "issuer-token-file", "", "Absolute controller credential file; reread per call")
+		cmd.Flags().StringVar(&remoteOptions.CAFile, "issuer-ca-file", "", "Absolute issuer CA bundle; omission uses system trust")
+		for _, name := range []string{"issuer-url", "issuer-token-file"} {
+			_ = cmd.MarkFlagRequired(name)
+		}
+	}
+	if issue && !remote {
 		cmd.Use = "issue AGENT"
 		cmd.Short = "Provision a local request-bound host grant from live independent approvals"
 		cmd.Long = "Operator-only local issuance. Verifies exact signed composition sources, resolves an independently configured host credential mapping, performs real sealed member verification, and publishes a request-bound grant. No dispatch or positive readiness. Persist the output and withdraw the profile when approval changes; this is not an autonomous revocation controller."
@@ -156,7 +195,7 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 		cmd.Flags().StringVar(&issueOptions.PolicyRoot, "policy-root", "", "Absolute trusted local host policy/store root")
 		cmd.Flags().StringVar(&issueOptions.ComposerPublisher, "composer-publisher", "", "Exact operator-approved composition publisher key")
 		cmd.Flags().DurationVar(&issueOptions.ProfileLifetime, "profile-lifetime", 5*time.Minute, "Host admission lifetime (1ms..5m); retries reuse original expiry; 0 is legacy explicit-operator mode only")
-		for _, name := range []string{"run", "model-policy", "execution-mote", "execution-closure", "celln-binary", "policy-root", "composer-publisher"} {
+		for _, name := range []string{"celln-binary", "policy-root", "composer-publisher"} {
 			_ = cmd.MarkFlagRequired(name)
 		}
 	}

--- a/cmd/sympozium/celln_selection_cmd_test.go
+++ b/cmd/sympozium/celln_selection_cmd_test.go
@@ -22,6 +22,21 @@ func TestIssuanceDefaultsToBoundedProfileWithExplicitLegacyOptOut(t *testing.T) 
 	}
 }
 
+func TestRemoteIssuanceHasNoLocalHostAuthorityFlags(t *testing.T) {
+	cmd := newCellnSelectionRemoteIssueCmd()
+	for _, name := range []string{"policy-root", "celln-binary", "composer-publisher", "profile-lifetime", "key-file"} {
+		if cmd.Flags().Lookup(name) != nil {
+			t.Fatalf("remote command accepts host authority flag %s", name)
+		}
+	}
+	for _, name := range []string{"issuer-url", "issuer-token-file", "run", "model-policy", "execution-mote", "execution-closure"} {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil || len(flag.Annotations["cobra_annotation_bash_completion_one_required_flag"]) == 0 {
+			t.Fatalf("missing required remote input %s", name)
+		}
+	}
+}
+
 func TestSelectionPlanRequiresExplicitSourcesAndWellFormedSelections(t *testing.T) {
 	for _, args := range [][]string{
 		{"agent"},

--- a/cmd/sympozium/celln_tool_cmd.go
+++ b/cmd/sympozium/celln_tool_cmd.go
@@ -50,6 +50,7 @@ func newCellnToolCmd() *cobra.Command {
 	cmd.AddCommand(newCellnSelectionPlanCmd())
 	cmd.AddCommand(newCellnSelectionComposeCmd())
 	cmd.AddCommand(newCellnSelectionIssueCmd())
+	cmd.AddCommand(newCellnSelectionRemoteIssueCmd())
 	cmd.AddCommand(newCellnWithdrawGrantCmd())
 	cmd.AddCommand(newCellnRecoverGrantsCmd())
 	cmd.AddCommand(newCellnIssuerServiceCmd())

--- a/docs/evidence/celln-issuer-client-2026-09-07.json
+++ b/docs/evidence/celln-issuer-client-2026-09-07.json
@@ -1,0 +1,39 @@
+{
+  "date": "2026-09-07",
+  "scope": "verified remote provisioning client and operator command, not AgentRun reconciler dispatch",
+  "base": "455cb4c92a9dc3a788416fbafce4cc1b811a84b1",
+  "checks": {
+    "fullGoRace": "passed with real NATS available",
+    "goBuildAll": "passed",
+    "goVetAll": "passed",
+    "targetedRace": "passed",
+    "cases": [
+      "verified TLS and rotating controller credential preserve retry identity",
+      "untrusted TLS identity refuses",
+      "task, caller, tool, candidate, profile and grant substitution refuse",
+      "unknown fields, missing negative execution assertion and false readiness refuse",
+      "trailing or oversized response refuses",
+      "redirect is not followed; no application retry occurs",
+      "lost response is classified as ambiguous and preserves frozen identity",
+      "post-response approval deletion refuses local acceptance",
+      "unsafe URLs and local host-authority flags refuse"
+    ],
+    "reviewCorrection": "tool substitution fixture now asserts that the replacement hash differs from the original"
+  },
+  "realKVM": {
+    "test": "TestComposeRealCellnArtifacts with CELLN_ISSUANCE_KVM=1",
+    "result": "passed",
+    "sequence": "signed composition -> verified client -> TLS issuer -> bounded profile -> actual KVM member verification -> identical retry -> approval deletion -> periodic withdrawal -> host refusal",
+    "grant": "blake3:c1205176cb9628eb859612cb1f510d0241dd18ace8113bbb1df72a92e3d5d46e",
+    "closure": "blake3:868dd5df064e198610329da6bc27ab5d5e306c075adcabdc130916d9cad0d046",
+    "toolfs": "blake3:7d23584dcbb0be5055f3bbd1a9e9067732ae518107be6b902e3af80d56519c16",
+    "kubernetes": "fake client",
+    "modelCalls": 0
+  },
+  "notProven": [
+    "durable controller pre-issuance state and AgentRun reconciler wiring",
+    "serving-node prewarm and catalogue-backed dispatch",
+    "deployed Kubernetes/RBAC/TLS/fleet qualification",
+    "UI/YAML selection, conversations and final real-model release acceptance"
+  ]
+}

--- a/docs/guides/celln-issuer-client.md
+++ b/docs/guides/celln-issuer-client.md
@@ -1,0 +1,77 @@
+# Verified remote issuer client
+
+`cellnreview.NewIssuerClient` is the controller-side client for the
+[host issuer service](celln-issuer-service.md). It is also available through the
+operator `celln-tool issue-remote AGENT` command. It is not yet called by the
+AgentRun reconciler and does not dispatch an execution.
+
+The client takes operator configuration only: an HTTPS origin, absolute controller
+bearer-token file, and an optional absolute CA bundle. Omitting the CA bundle uses
+system trust; supplying one restricts trust to that bundle. TLS 1.3, certificate
+chain and hostname verification are mandatory. URL credentials, path prefixes,
+queries, fragments and plaintext origins refuse. Ambient HTTP proxies are not
+used, redirects are not followed, and there is no skip-verification option.
+Recreate the client to reload a changed CA bundle. Token contents are reread for
+each request so mounted-file rotation does not require recreation.
+
+## Identity and retry contract
+
+`Issue(ctx, loader, frozen, approval, artifacts)` builds the expected execution
+candidate independently from the caller's live, uncached API reader and trusted
+authority sources. It sends one provisioning POST, with no application-level
+retry. Requests and responses are bounded to 1 MiB; requests embedded in returned
+issuance records are bounded to 64 KiB. The response must explicitly say that
+execution was not performed and readiness was not checked.
+The complete operation has a 100-second context ceiling (or the caller's earlier
+deadline), including API revalidation; the API reader must honor cancellation.
+
+Before returning, the client checks the candidate's approval, profile identity,
+grant hash and complete returned execution request, then revalidates live approval
+again. Only the grant self-reference and three known Rust serialization defaults
+are normalized: absent `forge` to null, absent `inputs` to an empty array and
+absent invocation `args` to an empty array. Unknown fields and any changed task,
+persona, caller, execution ID, tools, schemas, artifact or resource ceiling
+refuse. JSON numbers retain their exact representation; they are not rounded
+through floating-point conversion.
+
+Transport/read failures return `ErrIssuerOutcomeUnknown`. A lost response can
+mean the host has durably issued a profile. Preserve the original frozen request,
+approval, artifact identities and candidate before the call; retry only those
+same values. Other refusal/validation errors also do not authorize changing
+identity or bypassing host replay rules. The client neither renews expiry nor
+creates another run/attempt, withdraws local files, executes a task or claims
+that a serving node is warm.
+
+## Operator command
+
+`issue-remote` uses the existing independent grant-source, `--run`,
+`--model-policy`, explicit `--tool NAME@REVISION`, `--execution-mote` and
+`--execution-closure` flags, plus:
+
+```sh
+--issuer-url https://issuer.example.internal:8788 \
+--issuer-token-file /etc/sympozium/controller-issuer-token \
+--issuer-ca-file /etc/sympozium/issuer-ca.pem
+```
+
+There are no local policy-root, Celln binary, signing-key, composer or lifetime
+flags: those remain host service configuration. The output is labelled
+`sympozium.ai/celln-remote-issuance-report-v1`, not a local withdrawal report.
+Loss of output does not trigger local filesystem withdrawal; the remote durable
+window and periodic host reconciliation remain in force.
+
+This command is an explicit operator provisioning invocation and resolves the
+current plan each time. Do not blindly rerun it after an ambiguous outcome if
+approval or run state may have changed. Durable controller retry must instead
+reuse its saved `frozen`/`approval`/`artifacts` through the client API. Persisting
+that state and wiring the AgentRun reconciler remain the next integration gate.
+
+## Evidence
+
+Tests cover verified TLS, token rotation, untrusted certificates, changed
+responses, malformed/oversized results, redirects, a lost response, post-response
+approval withdrawal and refusal of unsafe configuration. The explicit real-KVM
+test uses this client against the real TLS issuer service and actual Celln
+compositor/member verifier; identical retry keeps profile/grant identity and
+periodic approval withdrawal refuses further issuance. Kubernetes is a fake
+client, no model calls are made, and this is not a deployed controller proof.

--- a/docs/guides/celln-issuer-service.md
+++ b/docs/guides/celln-issuer-service.md
@@ -103,7 +103,9 @@ real signed composition → TLS request → managed provisioning → actual seal
 member verification → identical retry → approval deletion → periodic withdrawal
 → host refusal. Kubernetes is still a fake client and no model calls are made.
 
-Next: configure and test the controller client, selection-specific serving-node
-prewarm, catalogue-backed AgentRun dispatch and correlated results. Deployed
+The [verified client](celln-issuer-client.md) now provides strict remote response
+validation and an operator `issue-remote` command. Next: wire durable controller
+issuance, selection-specific serving-node prewarm, catalogue-backed AgentRun
+dispatch and correlated results. Deployed
 Kubernetes/RBAC/network/TLS qualification, UI/YAML selection, conversational
 lifecycle and final real-model release acceptance remain open.

--- a/internal/cellnreview/issue_real_test.go
+++ b/internal/cellnreview/issue_real_test.go
@@ -51,21 +51,14 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 	if err != nil {
 		t.Fatal(err)
 	}
-	url, httpClient, _ := serveTestIssuer(t, managed)
-	remoteRequest, err := json.Marshal(IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: frozen, Approval: *approval, Artifacts: artifacts})
-	if err != nil {
-		t.Fatal(err)
-	}
+	url, _, tokenPath := serveTestIssuer(t, managed)
+	issuerClient := testIssuerClient(t, url, tokenPath, filepath.Join(filepath.Dir(tokenPath), "cert.pem"))
 	remoteIssue := func() *IssuedSelection {
-		status, body := issuerHTTP(t, httpClient, "POST", url+"/v1/issuances", testIssuerToken, remoteRequest)
-		if status != 200 {
-			t.Fatalf("real remote issuance refused: %d", status)
+		issued, err := issuerClient.Issue(ctx, ml, frozen, *approval, artifacts)
+		if err != nil {
+			t.Fatalf("verified remote client refused real issuance: %v", err)
 		}
-		var response IssuerResponse
-		if err := json.Unmarshal(body, &response); err != nil || response.Issued == nil || response.Executed {
-			t.Fatalf("invalid remote result: %v", err)
-		}
-		return response.Issued
+		return issued
 	}
 	issued, again := remoteIssue(), remoteIssue()
 	if again.Grant != issued.Grant || again.Profile != issued.Profile {
@@ -95,5 +88,5 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 		t.Fatal("withdrawal changed retained grant bytes")
 	}
 	assertNoProfiles(t, o.PolicyRoot)
-	t.Logf("PASS real catalogue composition -> authenticated TLS issuer service -> managed startup recovery gate -> durable boot-bound expiring profile -> real-KVM sealed verification -> identical v3 issuance without renewal -> approval deletion -> periodic managed withdrawal -> host refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
+	t.Logf("PASS real catalogue composition -> verified issuer client -> authenticated TLS issuer service -> managed startup recovery gate -> durable boot-bound expiring profile -> real-KVM sealed verification -> identical v3 issuance without renewal -> approval deletion -> periodic managed withdrawal -> host refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
 }

--- a/internal/cellnreview/issuer_client.go
+++ b/internal/cellnreview/issuer_client.go
@@ -1,0 +1,193 @@
+package cellnreview
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+)
+
+// ErrIssuerOutcomeUnknown requires retaining the exact frozen identity. It is
+// not permission to renew approval, create another execution or dispatch twice.
+var ErrIssuerOutcomeUnknown = errors.New("issuer outcome unknown; preserve frozen identity")
+
+type IssuerClientOptions struct{ URL, TokenFile, CAFile string }
+
+type IssuerClient struct {
+	endpoint  string
+	tokenFile string
+	http      *http.Client
+}
+
+func NewIssuerClient(o IssuerClientOptions) (*IssuerClient, error) {
+	u, err := url.Parse(o.URL)
+	if err != nil || u.Scheme != "https" || u.Hostname() == "" || u.User != nil || u.Opaque != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || (u.Path != "" && u.Path != "/") || !filepath.IsAbs(o.TokenFile) {
+		return nil, fmt.Errorf("issuer requires an explicit HTTPS origin and absolute controller credential path")
+	}
+	var roots *x509.CertPool
+	if o.CAFile != "" {
+		if !filepath.IsAbs(o.CAFile) {
+			return nil, fmt.Errorf("absolute issuer CA path required")
+		}
+		pem, err := readLimit(o.CAFile, 1<<20)
+		if err != nil {
+			return nil, fmt.Errorf("issuer CA unavailable")
+		}
+		roots = x509.NewCertPool()
+		if !roots.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("invalid issuer CA bundle")
+		}
+	}
+	transport := &http.Transport{
+		// Do not send controller credentials through ambient proxy settings.
+		Proxy: nil, DialContext: (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS13, RootCAs: roots},
+		TLSHandshakeTimeout: 10 * time.Second, ResponseHeaderTimeout: 95 * time.Second,
+		IdleConnTimeout: 30 * time.Second, MaxIdleConns: 2, MaxConnsPerHost: 2, DisableCompression: true,
+	}
+	client := &http.Client{Transport: transport, Timeout: 95 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	return &IssuerClient{endpoint: strings.TrimRight(u.String(), "/") + "/v1/issuances", tokenFile: o.TokenFile, http: client}, nil
+}
+
+func (c *IssuerClient) CloseIdleConnections() { c.http.CloseIdleConnections() }
+
+// Issue independently constructs the expected request from current API approval,
+// sends exactly one provisioning POST, validates its entire returned identity,
+// and rechecks approval before returning. It never executes or retries a task.
+func (c *IssuerClient) Issue(ctx context.Context, loader cellnauthority.ModelLoader, frozen cellnauthority.FrozenSelection, approval cellnauthority.ModelApproval, artifacts cellnauthority.ExecutionArtifacts) (*IssuedSelection, error) {
+	ctx, cancel := context.WithTimeout(ctx, 100*time.Second)
+	defer cancel()
+	expected, err := loader.BuildExecution(ctx, frozen, approval, artifacts)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: frozen, Approval: approval, Artifacts: artifacts})
+	if err != nil || len(body) > 1<<20 {
+		return nil, fmt.Errorf("remote issuance request exceeds supported encoding bound")
+	}
+	token, err := issuerToken(c.tokenFile)
+	if err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("cannot construct issuer request")
+	}
+	request.Header.Set("Authorization", "Bearer "+string(token))
+	request.Header.Set("Content-Type", "application/json")
+	response, err := c.http.Do(request)
+	if err != nil {
+		return nil, ErrIssuerOutcomeUnknown
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("issuer refused provisioning (HTTP %d); do not change frozen identity", response.StatusCode)
+	}
+	media, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || media != "application/json" || response.Header.Get("Content-Encoding") != "" {
+		return nil, fmt.Errorf("issuer response must be uncompressed JSON")
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, (1<<20)+1))
+	if err != nil {
+		return nil, ErrIssuerOutcomeUnknown
+	}
+	if len(raw) > 1<<20 {
+		return nil, fmt.Errorf("issuer response exceeds 1 MiB")
+	}
+	var report struct {
+		APIVersion        string           `json:"apiVersion"`
+		Issued            *IssuedSelection `json:"issued"`
+		Executed          *bool            `json:"executed"`
+		ArtifactReadiness string           `json:"artifactReadiness"`
+	}
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if d.Decode(&report) != nil || d.Decode(new(any)) != io.EOF {
+		return nil, fmt.Errorf("invalid issuer response")
+	}
+	if report.APIVersion != "sympozium.ai/celln-issuer-response-v1" || report.Executed == nil || *report.Executed || report.ArtifactReadiness != "not_checked" || report.Issued == nil {
+		return nil, fmt.Errorf("invalid issuer response contract")
+	}
+	if err := validateRemoteIssuance(*expected, *report.Issued); err != nil {
+		return nil, err
+	}
+	if err := loader.Revalidate(ctx, frozen, approval); err != nil {
+		return nil, fmt.Errorf("approval changed after remote provisioning: %w", err)
+	}
+	return report.Issued, nil
+}
+
+func validateRemoteIssuance(expected cellnauthority.ExecutionCandidate, issued IssuedSelection) error {
+	if issued.APIVersion != "sympozium.ai/celln-issued-selection-v1" || issued.Candidate.APIVersion != expected.APIVersion || !reflect.DeepEqual(issued.Candidate.Approval, expected.Approval) || !artifactHash(issued.Grant) {
+		return fmt.Errorf("issuer substituted candidate or grant identity")
+	}
+	if err := validProfileIdentity(issued.Profile, issued.ProfileSHA256); err != nil {
+		return err
+	}
+	placeholder := "blake3:" + strings.Repeat("0", 64)
+	want, err := comparableIssuedRequest(expected.Request, placeholder)
+	if err != nil {
+		return err
+	}
+	observed, err := comparableIssuedRequest(issued.Candidate.Request, placeholder)
+	if err != nil || !bytes.Equal(want, observed) {
+		return fmt.Errorf("issuer changed the frozen candidate request")
+	}
+	actual, err := comparableIssuedRequest(issued.Request, issued.Grant)
+	if err != nil || !bytes.Equal(want, actual) {
+		return fmt.Errorf("issuer changed the reviewed execution request")
+	}
+	return nil
+}
+
+// These are the three explicit serde defaults emitted by the current Rust
+// declared-request contract. Do not discard arbitrary unknown fields: comparison
+// rejects every difference except the grant self-reference and these defaults.
+func comparableIssuedRequest(raw []byte, grant string) ([]byte, error) {
+	if len(raw) > 65536 {
+		return nil, fmt.Errorf("execution request exceeds 64 KiB")
+	}
+	var value map[string]any
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.UseNumber()
+	if d.Decode(&value) != nil || d.Decode(new(any)) != io.EOF || value == nil {
+		return nil, fmt.Errorf("invalid execution request")
+	}
+	harness, ok := value["harness"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("missing Harness")
+	}
+	ref, ok := harness["modelGrant"].(map[string]any)
+	if !ok || len(ref) != 1 || ref["hash"] != grant {
+		return nil, fmt.Errorf("issued model grant mismatch")
+	}
+	ref["hash"] = "<bound-self-reference>"
+	if _, exists := value["forge"]; !exists {
+		value["forge"] = nil
+	}
+	if _, exists := value["inputs"]; !exists {
+		value["inputs"] = []any{}
+	}
+	invocation, ok := value["invocation"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("missing invocation")
+	}
+	if _, exists := invocation["args"]; !exists {
+		invocation["args"] = []any{}
+	}
+	return json.Marshal(value)
+}

--- a/internal/cellnreview/issuer_client_test.go
+++ b/internal/cellnreview/issuer_client_test.go
@@ -1,0 +1,167 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func testIssuerClient(t *testing.T, endpoint, tokenPath, caPath string) *IssuerClient {
+	t.Helper()
+	c, err := NewIssuerClient(IssuerClientOptions{URL: endpoint, TokenFile: tokenPath, CAFile: caPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(c.CloseIdleConnections)
+	return c
+}
+
+func TestIssuerClientUsesVerifiedTLSAndRotatingCredential(t *testing.T) {
+	f, m, _ := managedFixture(t)
+	endpoint, _, tokenPath := serveTestIssuer(t, m)
+	c := testIssuerClient(t, endpoint, tokenPath, filepath.Join(filepath.Dir(tokenPath), "cert.pem"))
+	ctx := context.Background()
+	first, err := c.Issue(ctx, f.l, *f.f, *f.a, f.artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tokenPath, []byte("public-test-only-controller-token-rotated"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := c.Issue(ctx, f.l, *f.f, *f.a, f.artifacts)
+	if err != nil || second.Profile != first.Profile || second.Grant != first.Grant {
+		t.Fatalf("rotation/retry changed identity: %v", err)
+	}
+	untrusted := testIssuerClient(t, endpoint, tokenPath, "")
+	if _, err := untrusted.Issue(ctx, f.l, *f.f, *f.a, f.artifacts); !errors.Is(err, ErrIssuerOutcomeUnknown) {
+		t.Fatal("untrusted TLS identity accepted")
+	}
+}
+
+func TestIssuerClientRefusesResponseSubstitutionAndNeverFollowsRedirects(t *testing.T) {
+	for _, mode := range []string{"valid", "task", "caller", "tool", "extra", "grant", "candidate", "profile", "executed", "missing-executed", "ready", "trailing", "oversized", "redirect", "lost-response", "withdrawal"} {
+		t.Run(mode, func(t *testing.T) {
+			f := provisionFixture(t)
+			ctx := context.Background()
+			issued, err := issue(ctx, f.l, *f.f, *f.a, f.artifacts, f.o, f.run)
+			if err != nil {
+				t.Fatal(err)
+			}
+			value := IssuerResponse{APIVersion: "sympozium.ai/celln-issuer-response-v1", Issued: issued, ArtifactReadiness: "not_checked"}
+			var request map[string]any
+			if err := json.Unmarshal(issued.Request, &request); err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "task":
+				request["harness"].(map[string]any)["task"] = "changed"
+			case "caller":
+				request["workload"].(map[string]any)["caller"] = "other"
+			case "tool":
+				tool := request["tools"].([]any)[0].(map[string]any)
+				original := tool["hash"].(string)
+				replacement := "blake3:" + strings.Repeat("f", 64)
+				if original == replacement {
+					t.Fatal("substitution fixture must change the tool hash")
+				}
+				tool["hash"] = replacement
+			case "extra":
+				request["unexpectedAuthority"] = true
+			case "grant":
+				issued.Grant = "blake3:" + strings.Repeat("a", 64)
+			case "candidate":
+				issued.Candidate.Approval.Caller = "other"
+			case "profile":
+				issued.Profile = "../other"
+			case "executed":
+				value.Executed = true
+			case "ready":
+				value.ArtifactReadiness = "ready"
+			}
+			issued.Request, _ = json.Marshal(request)
+			body, _ := json.Marshal(value)
+			if mode == "missing-executed" {
+				var fields map[string]any
+				_ = json.Unmarshal(body, &fields)
+				delete(fields, "executed")
+				body, _ = json.Marshal(fields)
+			}
+			if mode == "trailing" {
+				body = append(body, []byte(" {}")...)
+			}
+			if mode == "oversized" {
+				body = append(body, []byte(strings.Repeat(" ", 1<<20))...)
+			}
+			var hits atomic.Int32
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				hits.Add(1)
+				if r.Header.Get("Authorization") != "Bearer "+testIssuerToken {
+					w.WriteHeader(401)
+					return
+				}
+				if mode == "redirect" {
+					http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+					return
+				}
+				if mode == "lost-response" {
+					conn, _, err := w.(http.Hijacker).Hijack()
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					_ = conn.Close()
+					return
+				}
+				if mode == "withdrawal" {
+					var cm corev1.ConfigMap
+					if err := f.c.Get(ctx, f.l.Source, &cm); err != nil {
+						t.Error(err)
+					}
+					if err := f.c.Delete(ctx, &cm); err != nil {
+						t.Error(err)
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(body)
+			}))
+			defer server.Close()
+			dir := t.TempDir()
+			tokenPath, caPath := filepath.Join(dir, "token"), filepath.Join(dir, "ca.pem")
+			if err := os.WriteFile(tokenPath, []byte(testIssuerToken), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(caPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}), 0600); err != nil {
+				t.Fatal(err)
+			}
+			client := testIssuerClient(t, server.URL, tokenPath, caPath)
+			_, err = client.Issue(ctx, f.l, *f.f, *f.a, f.artifacts)
+			if (err == nil) != (mode == "valid") {
+				t.Fatalf("wrong response acceptance: %v", err)
+			}
+			if mode == "lost-response" && !errors.Is(err, ErrIssuerOutcomeUnknown) {
+				t.Fatal("lost response was not classified as ambiguous")
+			}
+			if hits.Load() != 1 {
+				t.Fatal("client automatically retried or followed redirect")
+			}
+		})
+	}
+}
+
+func TestIssuerClientRejectsUnsafeOperatorConfiguration(t *testing.T) {
+	for _, endpoint := range []string{"http://127.0.0.1:8788", "https://user:password@host", "https://host/path", "https://host?", "https://host?token=secret", "https://host#fragment"} {
+		if _, err := NewIssuerClient(IssuerClientOptions{URL: endpoint, TokenFile: "/operator/token"}); err == nil {
+			t.Fatalf("accepted unsafe endpoint %q", endpoint)
+		}
+	}
+}


### PR DESCRIPTION
Part of #426; follows merged #448.

Adds a controller-side issuer client with mandatory TLS 1.3 chain/hostname verification, independently configured CA/rotating credential, no ambient proxy, redirects or application retries, and bounded operation/request/response time and size. It independently builds the expected candidate, checks complete returned request/approval/profile/grant identity and revalidates live approval after the response. Only the grant self-reference and three known Rust defaults are normalized. Lost delivery is explicitly ambiguous and never permits identity renewal or replay.

Adds operator issue-remote command without host filesystem/signing/lifetime authority flags. It is an explicit current-plan provisioning command, not durable controller retry; documentation distinguishes that boundary.

Validation: final full Go race suite with real NATS, build/vet, response-substitution/TLS/rotation/redirect/lost-response tests and real client -> TLS issuer -> actual KVM sealed verification -> identical retry -> periodic withdrawal proof passed. Negative fixture review corrected a supposed tool mutation that originally reused the same hash. Fake Kubernetes, no model calls. Evidence committed.

Not yet wired into AgentRun reconciliation. Durable pre-issuance state, selected-node readiness/catalogue-backed dispatch, deployed fleet qualification and full UI/YAML/conversation acceptance remain open.