### PR TITLE
feat: freeze exact issued Celln requests for dispatch hand-off

### DIFF
--- a/docs/evidence/celln-issued-dispatch-handoff-2026-09-07.json
+++ b/docs/evidence/celln-issued-dispatch-handoff-2026-09-07.json
@@ -1,0 +1,22 @@
+{
+  "date": "2026-09-07",
+  "scope": "Exact issued-request dispatch journal hand-off; no execution submission",
+  "base": "Sympozium #450, e690186",
+  "checks": {
+    "goRaceAllPackages": "passed with NATS available",
+    "goBuildAndVet": "passed",
+    "exactBytesAndID": "passed normal and lost-commit-acknowledgement retries; no issuer network requests",
+    "refusals": "unissued, retargeted, changed task, withdrawn approval, substituted request/action, terminal run",
+    "realKVM": "actual composition/TLS issuance -> exact dispatch journal -> approval deletion -> hand-off refusal -> managed host withdrawal"
+  },
+  "realKVMGrant": "blake3:d758c5dc7a2d54d3ac0015062a71f9b279aa8fe14d8aaabe928514d6cfe5aaaf",
+  "kubernetesForKVMTest": "fake",
+  "modelCalls": 0,
+  "executionSubmissions": 0,
+  "limitations": [
+    "No route selection, serving prewarm, controller dispatch call site or readiness claim",
+    "Host admission/expiry remains mandatory; saved issuance is not continuing permission",
+    "Legacy dispatch still refuses catalogue issuance",
+    "Full UI/YAML, conversation and release acceptance remain open"
+  ]
+}

--- a/docs/guides/celln-issuer-client.md
+++ b/docs/guides/celln-issuer-client.md
@@ -109,6 +109,24 @@ test exercises durable preparation, actual TLS/host issuance, saved-result resum
 and managed approval withdrawal with fake Kubernetes metadata. Neither test proves
 the final deployed catalogue-backed execution journey.
 
+### Hand-off to the dispatch journal
+
+`FreezeIssuedDispatch(ctx, writer, uncachedReader, runKey, loader)` validates a
+committed issuance against current approval and saves its exact request bytes and
+catalogue-derived execution ID in `status.cellnRequest`/`status.cellnActionId`.
+It requires a pending, live Celln run and has a 15-second ceiling. Prepared-only
+issuance refuses. Conflicting or partially populated dispatch state refuses;
+identical retries reuse the saved outcome without contacting the issuer.
+
+A failed or ambiguous status commit returns no dispatch bytes. Retrying after a
+lost commit acknowledgement verifies and returns the identical saved request.
+The helper does not set Running/StartedAt, choose a route, prewarm a process or
+submit an execution. The legacy dispatch guard remains in force until a dedicated
+catalogue bridge consumes this journal. Host admission and expiry must still be
+checked on submission; a successful hand-off is not a readiness or live grant
+guarantee. In particular, do not replace the catalogue-derived ID with the legacy
+name/UID ID, or remarshal the request through a different wire representation.
+
 ## Evidence
 
 Tests cover verified TLS, token rotation, untrusted certificates, changed

--- a/internal/cellnreview/issue_real_test.go
+++ b/internal/cellnreview/issue_real_test.go
@@ -65,6 +65,11 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 	if again.Grant != issued.Grant || again.Profile != issued.Profile {
 		t.Fatal("actual issuance retry changed identity")
 	}
+	runKey := types.NamespacedName{Namespace: frozen.Run.Namespace, Name: frozen.Run.Name}
+	dispatchBytes, err := issuerClient.FreezeIssuedDispatch(ctx, c, c, runKey, ml)
+	if err != nil || string(dispatchBytes) != string(issued.Request) {
+		t.Fatalf("durable dispatch hand-off changed real issued request: %v", err)
+	}
 	grantPath := filepath.Join(o.PolicyRoot, "trusted-harness", issued.Grant[7:]+".json")
 	before, err := os.ReadFile(grantPath)
 	if err != nil {
@@ -72,6 +77,9 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 	}
 	if err := c.Delete(ctx, cm); err != nil {
 		t.Fatal(err)
+	}
+	if bytes, err := issuerClient.FreezeIssuedDispatch(ctx, c, c, runKey, ml); err == nil || len(bytes) != 0 {
+		t.Fatal("withdrawn approval still returned dispatch bytes")
 	}
 	eventuallyManaged(t, func() bool {
 		_, err := os.Stat(filepath.Join(o.PolicyRoot, "trusted-model-profiles", issued.Profile+".json"))
@@ -89,5 +97,5 @@ func proveCatalogueIssuance(t *testing.T, ctx context.Context, l cellnauthority.
 		t.Fatal("withdrawal changed retained grant bytes")
 	}
 	assertNoProfiles(t, o.PolicyRoot)
-	t.Logf("PASS real catalogue composition -> durable AgentRun preparation -> verified issuer client -> authenticated TLS issuer service -> managed startup recovery gate -> durable boot-bound expiring profile -> real-KVM sealed verification -> committed AgentRun outcome -> saved outcome resume without renewal -> approval deletion -> periodic managed withdrawal -> host refusal; grant=%s; Kubernetes=fake, modelCalls=0", issued.Grant)
+	t.Logf("PASS real catalogue composition -> durable AgentRun preparation -> verified issuer client -> authenticated TLS issuer service -> managed startup recovery gate -> durable boot-bound expiring profile -> real-KVM sealed verification -> committed AgentRun outcome -> saved outcome resume without renewal -> exact dispatch journal hand-off -> approval deletion -> hand-off refusal -> periodic managed withdrawal -> host refusal; grant=%s; Kubernetes=fake, modelCalls=0, executionSubmissions=0", issued.Grant)
 }

--- a/internal/cellnreview/issuer_dispatch.go
+++ b/internal/cellnreview/issuer_dispatch.go
@@ -1,0 +1,82 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FreezeIssuedDispatch commits the exact verified outcome to the existing
+// dispatch journal before submission. It makes no host requests, chooses no
+// route, and asserts neither readiness nor continuing host authorization.
+// Callers must submit these exact bytes/ID to the owning serving process and
+// never fall back to forge, regenerate identity, or fail over an ambiguous task.
+func (c *IssuerClient) FreezeIssuedDispatch(ctx context.Context, writer client.Client, reader client.Reader, key types.NamespacedName, loader cellnauthority.ModelLoader) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if writer == nil || reader == nil || key.Namespace == "" || key.Name == "" {
+		return nil, fmt.Errorf("status writer, uncached reader and run key required")
+	}
+	var result json.RawMessage
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var run api.AgentRun
+		if err := reader.Get(ctx, key, &run); err != nil {
+			return err
+		}
+		if run.Spec.Backend != "celln" || run.DeletionTimestamp != nil || (run.Status.Phase != "" && run.Status.Phase != api.AgentRunPhasePending) || run.Status.CellnIssuance == nil {
+			return fmt.Errorf("run is not pending catalogue dispatch")
+		}
+		payload, issued, err := decodeRunIssuance(run.Status.CellnIssuance, c.endpoint)
+		if err != nil {
+			return err
+		}
+		if issued == nil {
+			return fmt.Errorf("issuance has no committed outcome")
+		}
+		if err := sameIssuanceRun(&run, payload.Request.Frozen.Run); err != nil {
+			return err
+		}
+		expected, err := loader.BuildExecution(ctx, payload.Request.Frozen, payload.Request.Approval, payload.Request.Artifacts)
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(*expected, payload.Candidate) {
+			return fmt.Errorf("saved candidate differs from independently derived request")
+		}
+		// Full request shape and identity have already been checked by
+		// decodeRunIssuance against the independently derived candidate.
+		var identity struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(issued.Request, &identity); err != nil || identity.ID == "" {
+			return fmt.Errorf("verified request has no execution identity")
+		}
+		if run.Status.CellnRequest != "" || run.Status.CellnActionID != "" {
+			if run.Status.CellnRequest != string(issued.Request) || run.Status.CellnActionID != identity.ID {
+				return fmt.Errorf("dispatch journal differs from issued outcome")
+			}
+			result = append(json.RawMessage(nil), issued.Request...)
+			return nil
+		}
+		run.Status.CellnRequest = string(issued.Request)
+		run.Status.CellnActionID = identity.ID
+		if err := writer.Status().Update(ctx, &run); err != nil {
+			return err
+		}
+		result = append(json.RawMessage(nil), issued.Request...)
+		return nil
+	})
+	if err != nil {
+		// Never return dispatchable bytes after an ambiguous status write.
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/cellnreview/issuer_dispatch_test.go
+++ b/internal/cellnreview/issuer_dispatch_test.go
@@ -1,0 +1,118 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type forbiddenDispatchTransport struct{ t *testing.T }
+
+func (f forbiddenDispatchTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	f.t.Error("dispatch hand-off contacted issuer")
+	return nil, fmt.Errorf("network forbidden in hand-off")
+}
+
+func TestFreezeIssuedDispatchExactOutcomeAndLostCommit(t *testing.T) {
+	for _, lostCommit := range []bool{false, true} {
+		t.Run(map[bool]string{false: "normal", true: "lost-commit"}[lostCommit], func(t *testing.T) {
+			f, m, _ := managedFixture(t)
+			endpoint, _, tokenPath := serveTestIssuer(t, m)
+			issuer := testIssuerClient(t, endpoint, tokenPath, filepath.Join(filepath.Dir(tokenPath), "cert.pem"))
+			key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+			ctx := context.Background()
+			seed := &IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *f.f, Approval: *f.a, Artifacts: f.artifacts}
+			issued, err := issuer.IssueForRun(ctx, f.c, f.c, key, f.l, seed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// No hand-off path may provision again.
+			issuer.CloseIdleConnections()
+			issuer.http = &http.Client{Transport: forbiddenDispatchTransport{t}}
+			if lostCommit {
+				bytes, err := issuer.FreezeIssuedDispatch(ctx, issuanceStatusFault{Client: f.c, phase: "Issued", afterCommit: true}, f.c, key, f.l)
+				if err == nil || len(bytes) != 0 {
+					t.Fatal("ambiguous status commit returned dispatch bytes")
+				}
+			}
+			for i := 0; i < 2; i++ {
+				bytes, err := issuer.FreezeIssuedDispatch(ctx, f.c, f.c, key, f.l)
+				if err != nil || string(bytes) != string(issued.Request) {
+					t.Fatalf("hand-off changed bytes: %v", err)
+				}
+			}
+			var current api.AgentRun
+			if err := f.c.Get(ctx, key, &current); err != nil {
+				t.Fatal(err)
+			}
+			var request struct {
+				ID string `json:"id"`
+			}
+			if err := json.Unmarshal(issued.Request, &request); err != nil {
+				t.Fatal(err)
+			}
+			if current.Status.CellnActionID != request.ID || current.Status.Phase == api.AgentRunPhaseRunning || current.Status.StartedAt != nil {
+				t.Fatal("hand-off replaced identity or asserted submission")
+			}
+		})
+	}
+}
+
+func TestFreezeIssuedDispatchRefusesChangedState(t *testing.T) {
+	for _, mode := range []string{"unissued", "target", "task", "withdrawn", "request", "action", "terminal"} {
+		t.Run(mode, func(t *testing.T) {
+			f, m, _ := managedFixture(t)
+			endpoint, _, tokenPath := serveTestIssuer(t, m)
+			issuer := testIssuerClient(t, endpoint, tokenPath, filepath.Join(filepath.Dir(tokenPath), "cert.pem"))
+			key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+			ctx := context.Background()
+			seed := &IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *f.f, Approval: *f.a, Artifacts: f.artifacts}
+			if _, err := issuer.IssueForRun(ctx, f.c, f.c, key, f.l, seed); err != nil {
+				t.Fatal(err)
+			}
+			var current api.AgentRun
+			if err := f.c.Get(ctx, key, &current); err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "unissued":
+				current.Status.CellnIssuance.Phase = "Prepared"
+				current.Status.CellnIssuance.Result = ""
+			case "target":
+				issuer.endpoint = "https://other-host/v1/issuances"
+			case "task":
+				current.Spec.Task = api.NewStringTask("substituted")
+				if err := f.c.Update(ctx, &current); err != nil {
+					t.Fatal(err)
+				}
+			case "withdrawn":
+				var policy corev1.ConfigMap
+				if err := f.c.Get(ctx, f.l.Source, &policy); err != nil {
+					t.Fatal(err)
+				}
+				if err := f.c.Delete(ctx, &policy); err != nil {
+					t.Fatal(err)
+				}
+			case "request":
+				current.Status.CellnRequest = "{}"
+			case "action":
+				current.Status.CellnActionID = "legacy-id"
+			case "terminal":
+				current.Status.Phase = api.AgentRunPhaseFailed
+			}
+			if err := f.c.Status().Update(ctx, &current); err != nil {
+				t.Fatal(err)
+			}
+			if bytes, err := issuer.FreezeIssuedDispatch(ctx, f.c, f.c, key, f.l); err == nil || len(bytes) != 0 {
+				t.Fatal("changed state returned dispatch bytes")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #426. Revalidates committed catalogue issuance and durably hands its exact bytes and catalogue-derived ID to the existing dispatch journal. No returned dispatch bytes after an ambiguous status write; retries preserve identity. Rejects changed approval, run, target or substituted journal state. No network calls or execution submission in this helper; dedicated controller routing remains next.

Passed full Go race suite with NATS, build/vet, lost-commit and refusal tests, and separate real-KVM composition/TLS issuance/exact hand-off/withdrawal proof. KVM test uses fake Kubernetes metadata; no model calls. Documentation and scoped evidence included. Does not close the epic.