### PR TITLE
feat: freeze serving route before Celln issuance

### DIFF
--- a/docs/guides/celln-issuer-client.md
+++ b/docs/guides/celln-issuer-client.md
@@ -127,6 +127,29 @@ checked on submission; a successful hand-off is not a readiness or live grant
 guarantee. In particular, do not replace the catalogue-derived ID with the legacy
 name/UID ID, or remarshal the request through a different wire representation.
 
+### Frozen serving route
+
+`IssuerClientOptions.Route` optionally takes operator-selected `routerURL` and
+`backend` origins. The router URL must be HTTPS; the backend must be an exact HTTP
+origin from that router's configured list, matching the router's current backend
+transport contract. No paths (including trailing slash), URL credentials, query,
+fragment, whitespace or invalid ports are accepted. The constructor copies this
+configuration so changing the input object cannot retarget the client.
+
+The route is included in the existing immutable, hashed Prepared payload before
+provisioning. Both `IssueForRun` and `FreezeIssuedDispatch` compare it to current
+operator configuration. A changed router/backend, adding a route to historical
+unrouted issuance, or removing an existing route refuses. These are identity
+changes, not retry configuration. Existing nil-route provisioning callers remain
+compatible; that compatibility does not authorize routed submission.
+
+This freezes names, not network identity: it does not verify that the issuer and
+serving endpoint are the same host, qualify DNS/load-balancer failover, contact
+the router, or claim that artifacts are warm. The forthcoming controller bridge
+must require a configured route, use a separately scoped router credential,
+verify prewarm responses and send `X-Celln-Backend` only from this frozen operator
+configuration. Ordinary tenant task/spec data must never supply that header.
+
 ## Evidence
 
 Tests cover verified TLS, token rotation, untrusted certificates, changed

--- a/internal/cellnreview/issuer_client.go
+++ b/internal/cellnreview/issuer_client.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,15 +26,37 @@ import (
 // not permission to renew approval, create another execution or dispatch twice.
 var ErrIssuerOutcomeUnknown = errors.New("issuer outcome unknown; preserve frozen identity")
 
-type IssuerClientOptions struct{ URL, TokenFile, CAFile string }
+type IssuerClientOptions struct {
+	URL, TokenFile, CAFile string
+	// Route is operator configuration, frozen before remote provisioning.
+	// Nil supports provisioning-only callers, not routed execution.
+	Route *DispatchRoute
+}
+
+// DispatchRoute binds a protected router origin to one of its exact configured
+// host endpoints. Neither URL is accepted from AgentRun/task data. These names
+// do not establish cryptographic host identity or authorize DNS retargeting.
+type DispatchRoute struct {
+	RouterURL string `json:"routerURL"`
+	Backend   string `json:"backend"`
+}
 
 type IssuerClient struct {
 	endpoint  string
 	tokenFile string
 	http      *http.Client
+	route     *DispatchRoute
 }
 
 func NewIssuerClient(o IssuerClientOptions) (*IssuerClient, error) {
+	var route *DispatchRoute
+	if o.Route != nil {
+		copy := *o.Route
+		if !routeOrigin(copy.RouterURL, "https", 2048) || !routeOrigin(copy.Backend, "http", 1024) {
+			return nil, fmt.Errorf("route requires an HTTPS router origin and exact HTTP backend origin")
+		}
+		route = &copy
+	}
 	u, err := url.Parse(o.URL)
 	if err != nil || u.Scheme != "https" || u.Hostname() == "" || u.User != nil || u.Opaque != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || (u.Path != "" && u.Path != "/") || !filepath.IsAbs(o.TokenFile) {
 		return nil, fmt.Errorf("issuer requires an explicit HTTPS origin and absolute controller credential path")
@@ -60,7 +83,24 @@ func NewIssuerClient(o IssuerClientOptions) (*IssuerClient, error) {
 		IdleConnTimeout: 30 * time.Second, MaxIdleConns: 2, MaxConnsPerHost: 2, DisableCompression: true,
 	}
 	client := &http.Client{Transport: transport, Timeout: 95 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
-	return &IssuerClient{endpoint: strings.TrimRight(u.String(), "/") + "/v1/issuances", tokenFile: o.TokenFile, http: client}, nil
+	return &IssuerClient{endpoint: strings.TrimRight(u.String(), "/") + "/v1/issuances", tokenFile: o.TokenFile, http: client, route: route}, nil
+}
+
+func routeOrigin(raw, scheme string, maxBytes int) bool {
+	if len(raw) > maxBytes || strings.ContainsAny(raw, "\r\n\t ?#") {
+		return false
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != scheme || u.Hostname() == "" || u.User != nil || u.Opaque != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || u.Path != "" || strings.HasSuffix(u.Host, ":") {
+		return false
+	}
+	if u.Port() != "" {
+		port, err := strconv.Atoi(u.Port())
+		if err != nil || port < 1 || port > 65535 {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *IssuerClient) CloseIdleConnections() { c.http.CloseIdleConnections() }

--- a/internal/cellnreview/issuer_dispatch.go
+++ b/internal/cellnreview/issuer_dispatch.go
@@ -38,6 +38,9 @@ func (c *IssuerClient) FreezeIssuedDispatch(ctx context.Context, writer client.C
 		if err != nil {
 			return err
 		}
+		if !reflect.DeepEqual(payload.Route, c.route) {
+			return fmt.Errorf("configured serving route differs from durable issuance")
+		}
 		if issued == nil {
 			return fmt.Errorf("issuance has no committed outcome")
 		}

--- a/internal/cellnreview/issuer_route_test.go
+++ b/internal/cellnreview/issuer_route_test.go
@@ -1,0 +1,105 @@
+package cellnreview
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestIssuerServingRouteIsFrozenBeforeProvisioningAndCannotChange(t *testing.T) {
+	for _, mode := range []string{"same", "router", "backend", "remove", "add"} {
+		t.Run(mode, func(t *testing.T) {
+			f, m, _ := managedFixture(t)
+			endpoint, _, tokenPath := serveTestIssuer(t, m)
+			route := &DispatchRoute{RouterURL: "https://router.example:443", Backend: "http://host-a:8787"}
+			o := IssuerClientOptions{URL: endpoint, TokenFile: tokenPath, CAFile: filepath.Join(filepath.Dir(tokenPath), "cert.pem"), Route: route}
+			if mode == "add" {
+				o.Route = nil
+			}
+			issuer, err := NewIssuerClient(o)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(issuer.CloseIdleConnections)
+			// Mutating the constructor input must not retarget a live client.
+			route.Backend = "http://mutated-input:8787"
+			ctx := context.Background()
+			key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+			seed := &IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *f.f, Approval: *f.a, Artifacts: f.artifacts}
+			if _, err := issuer.IssueForRun(ctx, issuanceStatusFault{Client: f.c, phase: "Prepared", afterCommit: true}, f.c, key, f.l, seed); err == nil {
+				t.Fatal("lost preparation acknowledgement should refuse")
+			}
+			var current api.AgentRun
+			if err := f.c.Get(ctx, key, &current); err != nil {
+				t.Fatal(err)
+			}
+			payload, _, err := decodeRunIssuance(current.Status.CellnIssuance, issuer.endpoint)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode != "add" && (payload.Route == nil || payload.Route.Backend != "http://host-a:8787") {
+				t.Fatal("prepared route was absent or constructor input mutation changed it")
+			}
+			assertNoProfiles(t, f.o.PolicyRoot)
+			o.Route = &DispatchRoute{RouterURL: "https://router.example:443", Backend: "http://host-a:8787"}
+			switch mode {
+			case "router":
+				o.Route.RouterURL = "https://other-router.example:443"
+			case "backend":
+				o.Route.Backend = "http://host-b:8787"
+			case "remove":
+				o.Route = nil
+			}
+			restarted, err := NewIssuerClient(o)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(restarted.CloseIdleConnections)
+			_, err = restarted.IssueForRun(ctx, f.c, f.c, key, f.l, nil)
+			if mode == "same" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := restarted.FreezeIssuedDispatch(ctx, f.c, f.c, key, f.l); err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("changed route resumed provisioning")
+			}
+			assertNoProfiles(t, f.o.PolicyRoot)
+			// Commit the outcome with the original configuration, then ensure
+			// changed routing cannot consume that already-issued outcome either.
+			if _, err := issuer.IssueForRun(ctx, f.c, f.c, key, f.l, nil); err != nil {
+				t.Fatal(err)
+			}
+			if bytes, err := restarted.FreezeIssuedDispatch(ctx, f.c, f.c, key, f.l); err == nil || len(bytes) != 0 {
+				t.Fatal("changed route returned an issued request")
+			}
+		})
+	}
+}
+
+func TestIssuerRouteRefusesUnsafeOrigins(t *testing.T) {
+	for _, route := range []DispatchRoute{
+		{RouterURL: "http://router.example", Backend: "http://host:8787"},
+		{RouterURL: "https://router.example/", Backend: "http://host:8787"},
+		{RouterURL: "https://user:secret@router.example", Backend: "http://host:8787"},
+		{RouterURL: "https://router.example?", Backend: "http://host:8787"},
+		{RouterURL: "https://router.example", Backend: "https://host:8787"},
+		{RouterURL: "https://router.example", Backend: "http://host:8787/path"},
+		{RouterURL: "https://router.example", Backend: "http://host:8787\r\nHeader: injected"},
+		{RouterURL: "https://router.example", Backend: "http://host:"},
+		{RouterURL: "https://router.example#", Backend: "http://host:8787"},
+		{RouterURL: "https://router.example", Backend: "http://host:65536"},
+		{RouterURL: "https://router.example", Backend: "http://host:0"},
+	} {
+		if _, err := NewIssuerClient(IssuerClientOptions{URL: "https://issuer.example", TokenFile: "/not-read", Route: &route}); err == nil {
+			t.Fatalf("unsafe route accepted: %+v", route)
+		}
+	}
+}

--- a/internal/cellnreview/issuer_run.go
+++ b/internal/cellnreview/issuer_run.go
@@ -22,6 +22,7 @@ type runIssuancePayload struct {
 	APIVersion string                            `json:"apiVersion"`
 	Request    IssuerRequest                     `json:"request"`
 	Candidate  cellnauthority.ExecutionCandidate `json:"candidate"`
+	Route      *DispatchRoute                    `json:"route,omitempty"`
 }
 
 func payloadHash(raw string) string {
@@ -58,7 +59,7 @@ func (c *IssuerClient) IssueForRun(ctx context.Context, writer client.Client, re
 		if err != nil {
 			return nil, err
 		}
-		body, err := json.Marshal(runIssuancePayload{APIVersion: "sympozium.ai/celln-run-issuance-v1", Request: *seed, Candidate: *expected})
+		body, err := json.Marshal(runIssuancePayload{APIVersion: "sympozium.ai/celln-run-issuance-v1", Request: *seed, Candidate: *expected, Route: c.route})
 		if err != nil || len(body) > 393216 || len(c.endpoint) > 2048 {
 			return nil, fmt.Errorf("issuance payload exceeds status bound")
 		}
@@ -92,6 +93,9 @@ func (c *IssuerClient) IssueForRun(ctx context.Context, writer client.Client, re
 	payload, issued, err := decodeRunIssuance(wanted, c.endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if !reflect.DeepEqual(payload.Route, c.route) {
+		return nil, fmt.Errorf("configured serving route differs from durable issuance")
 	}
 	if err := sameIssuanceRun(&run, payload.Request.Frozen.Run); err != nil {
 		return nil, err


### PR DESCRIPTION
Part of #426; pairs with merged sympozium-ai/celln#94. Freezes the operator router origin and exact configured serving backend in the existing immutable issuance payload before host provisioning. Constructor input is copied; resume and dispatch hand-off refuse changed/added/removed routes. Existing provisioning-only callers remain compatible and are not implicitly authorized for routed execution.

Validation: full Go race suite with NATS, build/vet, targeted route/restart/refusal tests including final URL validation. No new schema fields or migration. Documentation distinguishes endpoint pinning from cryptographic host identity, readiness and actual dispatch. Controller prewarm/submission wiring remains next; this does not close the epic.