### PR TITLE
feat: connect frozen catalogue issuance to controller execution lifecycle

### DIFF
--- a/charts/celln_catalogue_test.go
+++ b/charts/celln_catalogue_test.go
@@ -1,0 +1,73 @@
+package charts
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestControllerCatalogueOptInRendering(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm required for chart rendering")
+	}
+	for _, mode := range []string{"disabled", "legacy", "catalogue"} {
+		t.Run(mode, func(t *testing.T) {
+			args := []string{"template", "test", "sympozium", "--show-only", "templates/controller-deployment.yaml"}
+			set := func(v string) { args = append(args, "--set", v) }
+			if mode != "disabled" {
+				for _, v := range []string{"celln.enabled=true", "celln.routerUrl=https://router.example", "celln.tokenSecret=client-token", "celln.capabilityTokenSecret=read-token", "celln.router.clientTokenSecret=client-token", "celln.router.backendTokenSecret=backend-token", "celln.router.capabilityTokenSecret=read-token", "celln.router.ownershipClaim=owners", "celln.router.backends[0]=http://host-a:8787", "celln.router.allowInsecureBackends=true", "celln.router.image.digest=sha256:" + strings.Repeat("a", 64)} {
+					set(v)
+				}
+			}
+			if mode == "catalogue" {
+				set("celln.catalogueConfigSecret=catalogue-config")
+				set("celln.harnessEnabled=true")
+			}
+			raw, err := exec.Command("helm", args...).CombinedOutput()
+			if err != nil {
+				t.Fatalf("render failed: %v: %s", err, raw)
+			}
+			var deployment appsv1.Deployment
+			if err := yaml.Unmarshal(raw, &deployment); err != nil {
+				t.Fatal(err)
+			}
+			if len(deployment.Spec.Template.Spec.Containers) != 1 {
+				t.Fatal("unexpected controller pod")
+			}
+			container := deployment.Spec.Template.Spec.Containers[0]
+			env := map[string]string{}
+			for _, v := range container.Env {
+				env[v.Name] = v.Value
+			}
+			if mode == "catalogue" {
+				if env["CELLN_CATALOGUE_CONFIG"] != "/etc/sympozium/celln-catalogue/config.json" || env["CELLN_HARNESS_ENABLED"] != "true" {
+					t.Fatal("catalogue opt-in env missing")
+				}
+				mountOK, secretOK := false, false
+				for _, m := range container.VolumeMounts {
+					if m.Name == "celln-catalogue-config" {
+						mountOK = m.ReadOnly && m.MountPath == "/etc/sympozium/celln-catalogue"
+					}
+				}
+				for _, v := range deployment.Spec.Template.Spec.Volumes {
+					if v.Name == "celln-catalogue-config" {
+						secretOK = v.Secret != nil && v.Secret.SecretName == "catalogue-config"
+					}
+				}
+				if !mountOK || !secretOK {
+					t.Fatal("catalogue configuration is not mounted read-only")
+				}
+			} else {
+				if env["CELLN_CATALOGUE_CONFIG"] != "" {
+					t.Fatal("catalogue configuration enabled implicitly")
+				}
+				if mode == "legacy" && env["CELLN_HARNESS_ENABLED"] != "false" {
+					t.Fatal("Harness enabled implicitly")
+				}
+			}
+		})
+	}
+}

--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -129,6 +129,12 @@ spec:
               value: {{ .Values.celln.routerUrl | quote }}
             - name: CELLN_ALLOW_INSECURE_HTTP
               value: {{ .Values.celln.allowInsecureHttp | quote }}
+            - name: CELLN_HARNESS_ENABLED
+              value: {{ .Values.celln.harnessEnabled | default false | quote }}
+            {{- if .Values.celln.catalogueConfigSecret }}
+            - name: CELLN_CATALOGUE_CONFIG
+              value: /etc/sympozium/celln-catalogue/config.json
+            {{- end }}
             {{- if .Values.celln.tokenSecret }}
             - name: CELLN_TOKEN_FILE
               value: /etc/sympozium/celln/token
@@ -163,20 +169,34 @@ spec:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          {{- if and .Values.celln.enabled .Values.celln.tokenSecret }}
+          {{- if and .Values.celln.enabled (or .Values.celln.tokenSecret .Values.celln.catalogueConfigSecret) }}
           volumeMounts:
+            {{- if .Values.celln.tokenSecret }}
             - name: celln-token
               mountPath: /etc/sympozium/celln
               readOnly: true
+            {{- end }}
+            {{- if .Values.celln.catalogueConfigSecret }}
+            - name: celln-catalogue-config
+              mountPath: /etc/sympozium/celln-catalogue
+              readOnly: true
+            {{- end }}
           {{- end }}
-      {{- if and .Values.celln.enabled .Values.celln.tokenSecret }}
+      {{- if and .Values.celln.enabled (or .Values.celln.tokenSecret .Values.celln.catalogueConfigSecret) }}
       volumes:
+        {{- if .Values.celln.tokenSecret }}
         - name: celln-token
           secret:
             secretName: {{ .Values.celln.tokenSecret | quote }}
             items:
               - key: token
                 path: token
+        {{- end }}
+        {{- if .Values.celln.catalogueConfigSecret }}
+        - name: celln-catalogue-config
+          secret:
+            secretName: {{ .Values.celln.catalogueConfigSecret | quote }}
+        {{- end }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -453,6 +453,13 @@ celln:
   # the router CLIENT bearer credential (at least 24 bytes). No token is generated
   # or inferred from model credentials. Missing configuration refuses dispatch.
   tokenSecret: ""
+  # -- Explicitly allow new native Harness submissions; recovery/cancel remains
+  # available when false. Does not establish catalogue readiness.
+  harnessEnabled: false
+  # -- Existing operator-owned Secret mounted at /etc/sympozium/celln-catalogue.
+  # Include config.json and separately scoped issuer/router token and CA files.
+  # No credential is generated or taken from tenant AgentRun fields.
+  catalogueConfigSecret: ""
   # -- Read-only discovery token Secret in the API-server namespace (key token).
   # Must differ from execution credentials and match router.capabilityTokenSecret.
   capabilityTokenSecret: ""

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -23,6 +23,7 @@ import (
 	llmfitv1alpha1 "github.com/sympozium-ai/llmfit-dra/api/v1alpha1"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
 	"github.com/sympozium-ai/sympozium/internal/controller"
 	"github.com/sympozium-ai/sympozium/internal/dra"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
@@ -183,6 +184,16 @@ func main() {
 		DelegationControllerExecutor: delegationControllerExecutor,
 		DynamicClient:                dynamicClient,
 		Pricing:                      pricingLoader,
+	}
+	if configPath := os.Getenv("CELLN_CATALOGUE_CONFIG"); configPath != "" {
+		dispatcher, closeDispatcher, err := cellnreview.LoadRunDispatcher(configPath, mgr.GetClient(), mgr.GetAPIReader())
+		if err != nil {
+			setupLog.Error(err, "invalid Celln catalogue controller configuration")
+			os.Exit(1)
+		}
+		defer closeDispatcher()
+		agentRunReconciler.CatalogueDispatcher = dispatcher
+		setupLog.Info("Celln catalogue execution recovery enabled; new submission requires CELLN_HARNESS_ENABLED=true")
 	}
 	if err := agentRunReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgentRun")

--- a/docs/evidence/celln-catalogue-controller-bridge-2026-09-08.json
+++ b/docs/evidence/celln-catalogue-controller-bridge-2026-09-08.json
@@ -10,7 +10,7 @@
     "config": "valid configuration and version/empty/duplicate/source/credential-path/plaintext/unknown/trailing refusals passed",
     "submissionSequence": "first submission, 404 recovery, unavailable owner, both admission gates, post-prewarm approval deletion, missing gate and lost-submit recovery passed",
     "recovery": "lookup/cancel after approval deletion without prewarm or execution replay passed",
-    "controllerLifecycle": "catalogue ID retained; OCI prerequisites bypassed for recovery; Cancelling not treated as teardown; concurrent terminal state preserved"
+    "controllerLifecycle": "full Reconcile entry point: catalogue ID retained; OCI prerequisites bypassed for recovery; finalizer added; zero Jobs; Cancelling retains deletion finalizer until terminal cancellation; concurrent terminal state preserved"
   },
   "limitations": [
     "New tests use HTTPS protocol and fake Kubernetes/service fixtures, not a single deployed controller-model journey",

--- a/docs/evidence/celln-catalogue-controller-bridge-2026-09-08.json
+++ b/docs/evidence/celln-catalogue-controller-bridge-2026-09-08.json
@@ -1,0 +1,21 @@
+{
+  "date": "2026-09-08",
+  "base": "6bc9246 (Sympozium #453)",
+  "scope": "Controller integration and explicit registration for already-issued catalogue runs",
+  "checks": {
+    "fullGoRaceSuite": "passed with real NATS binary available",
+    "buildAndVet": "passed",
+    "helmLintBothCharts": "passed",
+    "actualHelmRender": "disabled, legacy and catalogue opt-in passed; read-only Secret mount and explicit flags verified",
+    "config": "valid configuration and version/empty/duplicate/source/credential-path/plaintext/unknown/trailing refusals passed",
+    "submissionSequence": "first submission, 404 recovery, unavailable owner, both admission gates, post-prewarm approval deletion, missing gate and lost-submit recovery passed",
+    "recovery": "lookup/cancel after approval deletion without prewarm or execution replay passed",
+    "controllerLifecycle": "catalogue ID retained; OCI prerequisites bypassed for recovery; Cancelling not treated as teardown; concurrent terminal state preserved"
+  },
+  "limitations": [
+    "New tests use HTTPS protocol and fake Kubernetes/service fixtures, not a single deployed controller-model journey",
+    "Real TLS/router/KVM prewarm proof is the separate merged #453 evidence, not new full-system acceptance",
+    "Initial catalogue selection-to-issuance orchestration remains outstanding",
+    "No new user UI/YAML selectors, conversations, fleet recovery or release qualification claimed"
+  ]
+}

--- a/docs/guides/celln-catalogue-controller-bridge.md
+++ b/docs/guides/celln-catalogue-controller-bridge.md
@@ -1,0 +1,43 @@
+# Catalogue controller bridge — integration in progress
+
+The AgentRun reconciler has an explicitly injected `CatalogueDispatcher` path
+for runs with saved `status.cellnIssuance`. Nil configuration refuses rather than
+falling through to forge or OCI. This branch runs before mutable Agent/OCI task
+normalization so previously issued work can still be observed without those
+prerequisites. It does not yet create initial catalogue issuance or expose new
+selection fields. Controller executable/Helm registration remains outstanding.
+
+`cellnreview.RunDispatcher` consumes independently verified, committed issuance.
+Its bounded per-Agent bindings contain an issuer, router and trusted model/grant
+loader using an uncached reader. A frozen route is mandatory; the issuer and
+router use separate configured credential paths. Operators must also provision
+distinct scoped credential contents. The route names are not physical-host
+attestation. Existing work resolves its binding from frozen history, not a later
+mutable Agent reference.
+
+For a pending run with a dispatch journal, recovery first looks up the original
+execution. A returned record can be processed even when approval has since been
+withdrawn. Only a 404 allows considering the identical request for submission;
+other uncertain outcomes retain the journal and refuse to choose a new identity
+or host. Router/dispatcher journals remain the replay boundary; losing their
+storage is not a supported reset/retry operation.
+
+Before submitting, the service requires a controller admission callback, checks
+current policy/gates/token budget and the experimental Harness flag, revalidates
+frozen catalogue/model approval, persists exact dispatch bytes, prewarms the
+pinned serving process, then repeats admission and approval checks before one
+submission. A prewarm observation is never authority. Poll and cancel do not
+need fresh approval or the feature flag to remain enabled.
+
+The controller refreshes status through its uncached reader and refuses to
+overwrite a concurrently terminal/deleting/recreated run. It retains the issued
+ID and uses the existing strict terminal receipt validation for results and
+cleanup. `Cancelling` retains cleanup obligations. No Job or OCI task is created
+on this branch.
+
+Current tests separately cover the real TLS/KVM prewarm transport, HTTPS
+submission/refusal behavior, service-level lookup/cancel after approval deletion,
+and controller lifecycle using an injected service fixture. Those are not yet a
+single deployed controller-to-model journey. Remaining work includes positive
+service submission/404 tests, operator configuration/registration, initial
+selection-to-issuance orchestration and deployed regression/real-model proof.

--- a/docs/guides/celln-catalogue-controller-bridge.md
+++ b/docs/guides/celln-catalogue-controller-bridge.md
@@ -40,7 +40,9 @@ Current tests separately cover real TLS/KVM prewarm, HTTPS submission/refusal,
 first submission and 404 recovery, unavailable owners, both admission gates,
 approval withdrawal during prewarm, lost submission acknowledgement without
 replay, service lookup/cancel after approval deletion, and controller lifecycle
-using an injected service fixture. Config refusal and default/legacy/catalogue
+through the full Reconcile entry point using an injected service fixture. Recovery
+adds the cleanup finalizer without creating a Job, and deletion retains it until
+terminal cancellation. Config refusal and default/legacy/catalogue
 Helm renders are also tested. Those are not yet a single deployed
 controller-to-model journey. Initial selection-to-issuance orchestration and
 deployed regression/real-model proof remain outstanding.

--- a/docs/guides/celln-catalogue-controller-bridge.md
+++ b/docs/guides/celln-catalogue-controller-bridge.md
@@ -5,7 +5,8 @@ for runs with saved `status.cellnIssuance`. Nil configuration refuses rather tha
 falling through to forge or OCI. This branch runs before mutable Agent/OCI task
 normalization so previously issued work can still be observed without those
 prerequisites. It does not yet create initial catalogue issuance or expose new
-selection fields. Controller executable/Helm registration remains outstanding.
+selection fields. Controller executable/Helm registration is explicit and disabled
+by default; see the operator configuration below.
 
 `cellnreview.RunDispatcher` consumes independently verified, committed issuance.
 Its bounded per-Agent bindings contain an issuer, router and trusted model/grant
@@ -35,9 +36,71 @@ ID and uses the existing strict terminal receipt validation for results and
 cleanup. `Cancelling` retains cleanup obligations. No Job or OCI task is created
 on this branch.
 
-Current tests separately cover the real TLS/KVM prewarm transport, HTTPS
-submission/refusal behavior, service-level lookup/cancel after approval deletion,
-and controller lifecycle using an injected service fixture. Those are not yet a
-single deployed controller-to-model journey. Remaining work includes positive
-service submission/404 tests, operator configuration/registration, initial
-selection-to-issuance orchestration and deployed regression/real-model proof.
+Current tests separately cover real TLS/KVM prewarm, HTTPS submission/refusal,
+first submission and 404 recovery, unavailable owners, both admission gates,
+approval withdrawal during prewarm, lost submission acknowledgement without
+replay, service lookup/cancel after approval deletion, and controller lifecycle
+using an injected service fixture. Config refusal and default/legacy/catalogue
+Helm renders are also tested. Those are not yet a single deployed
+controller-to-model journey. Initial selection-to-issuance orchestration and
+deployed regression/real-model proof remain outstanding.
+
+## Operator configuration
+
+Set `CELLN_CATALOGUE_CONFIG` to an absolute JSON file path in the controller.
+Invalid/oversized/unknown-field configuration fails startup. The file is read
+once; restart the controller to reload bindings or CA bundles. Token file
+contents are read per operation. Configuration loading makes no network calls
+and does not provision a run or assert readiness.
+
+Example `config.json` (replace all example names with approved deployment values):
+
+```json
+{
+  "apiVersion": "sympozium.ai/celln-catalogue-controller-v1",
+  "bindings": [{
+    "agent": {"namespace": "tenant", "name": "my-agent"},
+    "issuer": {
+      "url": "https://issuer-host-a.example.internal",
+      "tokenFile": "/etc/sympozium/celln-catalogue/issuer-token",
+      "caFile": "/etc/sympozium/celln-catalogue/issuer-ca.pem"
+    },
+    "router": {
+      "url": "https://router.example.internal",
+      "tokenFile": "/etc/sympozium/celln-catalogue/router-token",
+      "caFile": "/etc/sympozium/celln-catalogue/router-ca.pem"
+    },
+    "backend": "http://host-a:8787",
+    "operatorSource": {"namespace": "operators", "name": "operator-grants"},
+    "runtimeSource": {"namespace": "operators", "name": "runtime-grants"},
+    "agentSource": {"namespace": "operators", "name": "agent-grants"},
+    "modelSource": {"namespace": "operators", "name": "model-policy"}
+  }]
+}
+```
+
+Bindings must be unique per namespaced Agent and specify four distinct authority
+sources. Protect these sources and the configuration Secret from tenant writes;
+configuration names alone do not prove ownership. The controller needs read
+access to the sources and status-write access to the run, not provider Secrets.
+The issuer retains host provider credential mapping and grant issuance authority.
+
+With the existing complete Celln router deployment values configured, Helm adds:
+
+```yaml
+celln:
+  enabled: true
+  catalogueConfigSecret: celln-catalogue-controller
+  harnessEnabled: true
+```
+
+Create that Secret in the controller namespace with `config.json` and the token/CA
+files referenced above. It is mounted read-only at
+`/etc/sympozium/celln-catalogue`; the chart generates no credentials. The router
+token must match the configured router's execution credential, and issuer token
+must match its host service credential. The existing legacy/discovery Secret and
+router ownership/transport requirements still apply; these three values alone
+are not a complete Celln installation. Disabling `harnessEnabled` refuses new
+submission while leaving configured recovery/cancellation available. Removing
+the configuration or retargeting endpoints while runs are active prevents their
+recovery and is not a safe drain operation.

--- a/docs/guides/celln-router-execution-client.md
+++ b/docs/guides/celln-router-execution-client.md
@@ -1,0 +1,33 @@
+# Frozen-route execution transport
+
+`RouterClient.Submit(ctx, route, issuedRequest)` sends the exact previously
+verified and durably saved issuance bytes once, with the frozen backend pin.
+The client copies its input, limits requests to 64 KiB and never remarshal-normalizes
+the execution payload. The caller must complete current approval checks and the
+durable dispatch hand-off first; this transport is not an authorization service.
+
+`Lookup(ctx, route, id)` and `Cancel(ctx, route, id)` use the same frozen router
+origin but omit the backend header. Polling/cancellation follow the router's
+durable owner; they cannot select a replacement host. IDs are bounded ASCII path
+components, and cancellation sends no body. `Cancelling` is a nonterminal phase:
+the dispatcher still holds the reservation until its worker finishes cleanup.
+
+Every operation uses the separately scoped rotating router token, verified TLS,
+no ambient proxy, no redirects, no application retry and a 40-second ceiling.
+Responses must be bounded uncompressed JSON, have no unknown wrapper fields or
+trailing data, match the original request ID and use a known dispatcher phase.
+Unusable HTTP/transport/protocol outcomes return `ErrExecutionOutcomeUnknown`;
+HTTP refusal diagnostics expose only the status code, not arbitrary response
+bodies. This error never permits regenerating an execution ID, changing request
+bytes, rerouting or replaying work outside the router's ownership contract.
+
+`RouterExecution` is bookkeeping, **not terminal receipt validation**. Its raw
+receipt remains available for the controller to validate against the frozen
+request before accepting output, terminal status, identity or cleanup. A
+successful POST or cancellation acknowledgement is not proof of guest teardown.
+
+HTTPS fixture tests cover exact bytes and target credential, owner-based lookup
+and cancellation, `Cancelling`, lost responses, redirects, mismatched IDs,
+unknown phases/fields, trailing/oversized responses, refusal-body redaction and
+invalid path IDs. This transport is not yet called by the AgentRun reconciler;
+these tests are not a deployed model-execution or receipt proof.

--- a/internal/cellnreview/controller_config.go
+++ b/internal/cellnreview/controller_config.go
@@ -1,0 +1,97 @@
+package cellnreview
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ControllerEndpoint struct {
+	URL       string `json:"url"`
+	TokenFile string `json:"tokenFile"`
+	CAFile    string `json:"caFile,omitempty"`
+}
+type ControllerDispatchBinding struct {
+	Agent          types.NamespacedName `json:"agent"`
+	Issuer         ControllerEndpoint   `json:"issuer"`
+	Router         ControllerEndpoint   `json:"router"`
+	Backend        string               `json:"backend"`
+	OperatorSource types.NamespacedName `json:"operatorSource"`
+	RuntimeSource  types.NamespacedName `json:"runtimeSource"`
+	AgentSource    types.NamespacedName `json:"agentSource"`
+	ModelSource    types.NamespacedName `json:"modelSource"`
+}
+type ControllerDispatchConfig struct {
+	APIVersion string                      `json:"apiVersion"`
+	Bindings   []ControllerDispatchBinding `json:"bindings"`
+}
+
+// LoadRunDispatcher reads only operator deployment configuration. It performs
+// no network call, provisioning, readiness assertion or Kubernetes mutation.
+// Recreate on config/CA changes; token file contents are reread per operation.
+func LoadRunDispatcher(path string, writer client.Client, reader client.Reader) (*RunDispatcher, func(), error) {
+	if !filepath.IsAbs(path) {
+		return nil, nil, fmt.Errorf("absolute catalogue controller config path required")
+	}
+	raw, err := readLimit(path, 1<<20)
+	if err != nil {
+		return nil, nil, fmt.Errorf("catalogue controller config unavailable or oversized")
+	}
+	var config ControllerDispatchConfig
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if d.Decode(&config) != nil || d.Decode(new(any)) != io.EOF || config.APIVersion != "sympozium.ai/celln-catalogue-controller-v1" || len(config.Bindings) == 0 || len(config.Bindings) > 1024 {
+		return nil, nil, fmt.Errorf("invalid catalogue controller config")
+	}
+	bindings := make(map[types.NamespacedName]RunDispatchBinding, len(config.Bindings))
+	var closers []func()
+	closeAll := func() {
+		for _, close := range closers {
+			close()
+		}
+	}
+	success := false
+	defer func() {
+		if !success {
+			closeAll()
+		}
+	}()
+	for _, b := range config.Bindings {
+		if b.Agent.Name == "" || b.Agent.Namespace == "" {
+			return nil, nil, fmt.Errorf("namespaced Agent binding required")
+		}
+		if _, ok := bindings[b.Agent]; ok {
+			return nil, nil, fmt.Errorf("duplicate Agent binding")
+		}
+		seen := map[types.NamespacedName]bool{}
+		for _, ref := range []types.NamespacedName{b.OperatorSource, b.RuntimeSource, b.AgentSource, b.ModelSource} {
+			if ref.Namespace == "" || ref.Name == "" || seen[ref] {
+				return nil, nil, fmt.Errorf("four distinct namespaced authority sources required")
+			}
+			seen[ref] = true
+		}
+		issuer, err := NewIssuerClient(IssuerClientOptions{URL: b.Issuer.URL, TokenFile: b.Issuer.TokenFile, CAFile: b.Issuer.CAFile, Route: &DispatchRoute{RouterURL: b.Router.URL, Backend: b.Backend}})
+		if err != nil {
+			return nil, nil, err
+		}
+		closers = append(closers, issuer.CloseIdleConnections)
+		router, err := NewRouterClient(b.Router.URL, b.Router.TokenFile, b.Router.CAFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		closers = append(closers, router.CloseIdleConnections)
+		bindings[b.Agent] = RunDispatchBinding{Issuer: issuer, Router: router, Loader: cellnauthority.ModelLoader{Selection: cellnauthority.Loader{Reader: reader, OperatorSource: b.OperatorSource, RuntimeSource: b.RuntimeSource, AgentSource: b.AgentSource}, Source: b.ModelSource}}
+	}
+	result, err := NewRunDispatcher(writer, reader, bindings)
+	if err != nil {
+		return nil, nil, err
+	}
+	success = true
+	return result, closeAll, nil
+}

--- a/internal/cellnreview/controller_config_test.go
+++ b/internal/cellnreview/controller_config_test.go
@@ -1,0 +1,59 @@
+package cellnreview
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestLoadRunDispatcherConfig(t *testing.T) {
+	for _, mode := range []string{"valid", "version", "empty", "duplicate", "sources", "shared-token", "plaintext", "unknown", "trailing"} {
+		t.Run(mode, func(t *testing.T) {
+			f := provisionFixture(t)
+			config := ControllerDispatchConfig{APIVersion: "sympozium.ai/celln-catalogue-controller-v1", Bindings: []ControllerDispatchBinding{{Agent: types.NamespacedName{Namespace: "tenant", Name: "agent"}, Issuer: ControllerEndpoint{URL: "https://issuer.example", TokenFile: "/operator/issuer-token"}, Router: ControllerEndpoint{URL: "https://router.example", TokenFile: "/operator/router-token"}, Backend: "http://host-a:8787", OperatorSource: f.l.Selection.OperatorSource, RuntimeSource: f.l.Selection.RuntimeSource, AgentSource: f.l.Selection.AgentSource, ModelSource: f.l.Source}}}
+			switch mode {
+			case "version":
+				config.APIVersion = "bad"
+			case "empty":
+				config.Bindings = nil
+			case "duplicate":
+				config.Bindings = append(config.Bindings, config.Bindings[0])
+			case "sources":
+				config.Bindings[0].ModelSource = config.Bindings[0].OperatorSource
+			case "shared-token":
+				config.Bindings[0].Router.TokenFile = config.Bindings[0].Issuer.TokenFile
+			case "plaintext":
+				config.Bindings[0].Router.URL = "http://router.example"
+			}
+			raw, err := json.Marshal(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "unknown" {
+				raw = append(raw[:len(raw)-1], []byte(`,"extra":true}`)...)
+			}
+			if mode == "trailing" {
+				raw = append(raw, []byte(`{}`)...)
+			}
+			path := filepath.Join(t.TempDir(), "config.json")
+			if err := os.WriteFile(path, raw, 0600); err != nil {
+				t.Fatal(err)
+			}
+			d, close, err := LoadRunDispatcher(path, f.c, f.c)
+			if mode == "valid" {
+				if err != nil || d == nil || close == nil {
+					t.Fatalf("valid config refused: %v", err)
+				}
+				close()
+			} else if err == nil || d != nil {
+				if close != nil {
+					close()
+				}
+				t.Fatal("invalid config accepted")
+			}
+		})
+	}
+}

--- a/internal/cellnreview/router_execution.go
+++ b/internal/cellnreview/router_execution.go
@@ -1,0 +1,135 @@
+package cellnreview
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"time"
+)
+
+// ErrExecutionOutcomeUnknown never permits regenerating an ID or failing over.
+// Retain the frozen request and reconcile the original router ownership record.
+var ErrExecutionOutcomeUnknown = errors.New("execution outcome unknown; retain original request and owner")
+
+// RouterHTTPError retains a status for recovery policy without exposing the
+// response body. Even a 404 does not authorize changing request identity.
+type RouterHTTPError struct{ StatusCode int }
+
+func (e *RouterHTTPError) Error() string {
+	return fmt.Sprintf("router HTTP %d: %v", e.StatusCode, ErrExecutionOutcomeUnknown)
+}
+func (e *RouterHTTPError) Unwrap() error { return ErrExecutionOutcomeUnknown }
+
+// RouterExecution is transport bookkeeping, not a validated terminal receipt.
+// The controller must validate Receipt against the frozen request before using
+// terminal output, status or provenance. Raw bytes preserve that full contract.
+type RouterExecution struct {
+	RequestID string          `json:"requestId"`
+	Phase     string          `json:"phase"`
+	Reason    string          `json:"reason,omitempty"`
+	Output    string          `json:"output,omitempty"`
+	Receipt   json.RawMessage `json:"receipt,omitempty"`
+}
+
+func executionPathID(id string) bool {
+	if len(id) == 0 || len(id) > 512 || id == "." || id == ".." {
+		return false
+	}
+	for _, c := range []byte(id) {
+		if !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-' || c == '_' || c == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+// Submit sends the exact previously persisted, independently verified issuance
+// bytes once. The router owns deduplication/ambiguity; this client never retries
+// or redirects. A prewarm observation is not used as authorization.
+func (c *RouterClient) Submit(ctx context.Context, route DispatchRoute, issued json.RawMessage) (*RouterExecution, error) {
+	if len(issued) == 0 || len(issued) > 65536 {
+		return nil, fmt.Errorf("execution request exceeds bound")
+	}
+	body := append([]byte(nil), issued...)
+	var identity struct {
+		ID string `json:"id"`
+	}
+	if json.Unmarshal(body, &identity) != nil || !executionPathID(identity.ID) {
+		return nil, fmt.Errorf("invalid execution identity")
+	}
+	return c.execution(ctx, route, http.MethodPost, "/v1/executions", identity.ID, body, true)
+}
+
+// Lookup uses durable router ownership, not a newly selected backend. A missing
+// or unreachable owner never authorizes another submission with a new identity.
+func (c *RouterClient) Lookup(ctx context.Context, route DispatchRoute, id string) (*RouterExecution, error) {
+	if !executionPathID(id) {
+		return nil, fmt.Errorf("invalid execution identity")
+	}
+	return c.execution(ctx, route, http.MethodGet, "/v1/executions/"+id, id, nil, false)
+}
+
+// Cancel asks the recorded owner to cancel; its response is not itself proof
+// of guest teardown. Terminal receipt/cleanup validation remains mandatory.
+func (c *RouterClient) Cancel(ctx context.Context, route DispatchRoute, id string) (*RouterExecution, error) {
+	if !executionPathID(id) {
+		return nil, fmt.Errorf("invalid execution identity")
+	}
+	return c.execution(ctx, route, http.MethodPost, "/v1/executions/"+id+"/cancel", id, nil, false)
+}
+
+func (c *RouterClient) execution(ctx context.Context, route DispatchRoute, method, path, id string, body []byte, pin bool) (*RouterExecution, error) {
+	ctx, cancel := context.WithTimeout(ctx, 40*time.Second)
+	defer cancel()
+	if route.RouterURL != c.origin || !routeOrigin(route.Backend, "http", 1024) {
+		return nil, fmt.Errorf("router differs from frozen serving route")
+	}
+	token, err := issuerToken(c.transport.tokenFile)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.origin+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+string(token))
+	req.Header.Set("Content-Type", "application/json")
+	if pin {
+		req.Header.Set("X-Celln-Backend", route.Backend)
+	}
+	response, err := c.transport.http.Do(req)
+	if err != nil {
+		return nil, ErrExecutionOutcomeUnknown
+	}
+	defer response.Body.Close()
+	// Even an explicit refusal does not authorize switching identity. Retain
+	// HTTP status for diagnostics without exposing arbitrary response bodies.
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusAccepted {
+		return nil, &RouterHTTPError{StatusCode: response.StatusCode}
+	}
+	media, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || media != "application/json" || response.Header.Get("Content-Encoding") != "" {
+		return nil, ErrExecutionOutcomeUnknown
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, 262145))
+	if err != nil || len(raw) > 262144 {
+		return nil, ErrExecutionOutcomeUnknown
+	}
+	var record RouterExecution
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if d.Decode(&record) != nil || d.Decode(new(any)) != io.EOF || record.RequestID != id {
+		return nil, ErrExecutionOutcomeUnknown
+	}
+	switch record.Phase {
+	case "Admitting", "Forging", "Resolving", "Running", "Cancelling", "Succeeded", "Failed", "Refused", "Cancelled":
+		return &record, nil
+	default:
+		return nil, ErrExecutionOutcomeUnknown
+	}
+}

--- a/internal/cellnreview/router_execution_test.go
+++ b/internal/cellnreview/router_execution_test.go
@@ -1,0 +1,139 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRouterExecutionPreservesBytesAndOwnershipAndRefusesAmbiguity(t *testing.T) {
+	for _, mode := range []string{"submit", "lookup", "cancel", "wrong-id", "unknown-phase", "extra", "trailing", "oversized", "redirect", "lost", "refused"} {
+		t.Run(mode, func(t *testing.T) {
+			body := `{"id":"catalogue-123", "preserve":"exact wire bytes"}`
+			var calls atomic.Int32
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.Header.Get("Authorization") != "Bearer public-execution-router-token" {
+					t.Error("wrong router credential")
+				}
+				got, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+				}
+				switch mode {
+				case "lookup":
+					if r.Method != "GET" || r.URL.Path != "/v1/executions/catalogue-123" || len(got) != 0 || r.Header.Get("X-Celln-Backend") != "" {
+						t.Error("lookup attempted to reselect owner")
+					}
+				case "cancel":
+					if r.Method != "POST" || r.URL.Path != "/v1/executions/catalogue-123/cancel" || len(got) != 0 || r.Header.Get("X-Celln-Backend") != "" {
+						t.Error("cancel attempted to reselect owner")
+					}
+				default:
+					if r.Method != "POST" || r.URL.Path != "/v1/executions" || string(got) != body || r.Header.Get("X-Celln-Backend") != "http://host-a:8787" {
+						t.Error("submission changed bytes or route")
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				response := `{"requestId":"catalogue-123","phase":"Running"}`
+				switch mode {
+				case "cancel":
+					response = `{"requestId":"catalogue-123","phase":"Cancelling"}`
+				case "wrong-id":
+					response = `{"requestId":"other","phase":"Running"}`
+				case "unknown-phase":
+					response = `{"requestId":"catalogue-123","phase":"Ready"}`
+				case "extra":
+					response = `{"requestId":"catalogue-123","phase":"Running","extra":true}`
+				case "trailing":
+					response += `{}`
+				case "oversized":
+					response = strings.Repeat(" ", 262145)
+				case "redirect":
+					w.Header().Set("Location", "/redirected")
+					w.WriteHeader(http.StatusTemporaryRedirect)
+					return
+				case "refused":
+					w.WriteHeader(http.StatusConflict)
+					_, _ = io.WriteString(w, "private diagnostic must not surface")
+					return
+				case "lost":
+					conn, _, err := w.(http.Hijacker).Hijack()
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					_ = conn.Close()
+					return
+				}
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = io.WriteString(w, response)
+			}))
+			defer server.Close()
+			dir := t.TempDir()
+			ca, token := filepath.Join(dir, "ca.pem"), filepath.Join(dir, "token")
+			if err := os.WriteFile(ca, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(token, []byte("public-execution-router-token"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			client, err := NewRouterClient(server.URL, token, ca)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.CloseIdleConnections()
+			route := DispatchRoute{RouterURL: server.URL, Backend: "http://host-a:8787"}
+			var record *RouterExecution
+			switch mode {
+			case "lookup":
+				record, err = client.Lookup(context.Background(), route, "catalogue-123")
+			case "cancel":
+				record, err = client.Cancel(context.Background(), route, "catalogue-123")
+			default:
+				record, err = client.Submit(context.Background(), route, []byte(body))
+			}
+			if mode == "submit" || mode == "lookup" || mode == "cancel" {
+				if err != nil || record == nil {
+					t.Fatalf("valid response refused: %v", err)
+				}
+				if mode == "cancel" && record.Phase != "Cancelling" {
+					t.Fatal("cancel response implied teardown")
+				}
+			} else if !errors.Is(err, ErrExecutionOutcomeUnknown) || record != nil {
+				t.Fatalf("ambiguous outcome accepted: %v", err)
+			}
+			if err != nil && strings.Contains(err.Error(), "private diagnostic") {
+				t.Fatal("response body leaked")
+			}
+			if mode == "refused" {
+				var refused *RouterHTTPError
+				if !errors.As(err, &refused) || refused.StatusCode != http.StatusConflict {
+					t.Fatal("HTTP refusal lost its structured status")
+				}
+			}
+			if calls.Load() != 1 {
+				t.Fatalf("unexpected replay/redirect: %d", calls.Load())
+			}
+			for _, id := range []string{"", ".", "..", "x/cancel", "x?query", "x\r\nheader", strings.Repeat("a", 513)} {
+				if _, err := client.Lookup(context.Background(), route, id); err == nil {
+					t.Fatal("invalid path identity accepted")
+				}
+				if _, err := client.Cancel(context.Background(), route, id); err == nil {
+					t.Fatal("invalid cancel identity accepted")
+				}
+			}
+			if calls.Load() != 1 {
+				t.Fatal("invalid identity reached router")
+			}
+		})
+	}
+}

--- a/internal/cellnreview/run_dispatcher.go
+++ b/internal/cellnreview/run_dispatcher.go
@@ -1,0 +1,148 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type RunDispatchBinding struct {
+	Issuer *IssuerClient
+	Router *RouterClient
+	Loader cellnauthority.ModelLoader
+}
+
+// RunDispatcher consumes durable catalogue issuance. Bindings are trusted
+// deployment configuration, never fields copied from a tenant's run.
+type RunDispatcher struct {
+	writer   client.Client
+	reader   client.Reader
+	bindings map[types.NamespacedName]RunDispatchBinding
+}
+
+func NewRunDispatcher(writer client.Client, reader client.Reader, bindings map[types.NamespacedName]RunDispatchBinding) (*RunDispatcher, error) {
+	if writer == nil || reader == nil || len(bindings) == 0 || len(bindings) > 1024 {
+		return nil, fmt.Errorf("writer, uncached reader and bounded bindings required")
+	}
+	copy := make(map[types.NamespacedName]RunDispatchBinding, len(bindings))
+	for key, b := range bindings {
+		if key.Namespace == "" || key.Name == "" || b.Issuer == nil || b.Router == nil || b.Issuer.route == nil || b.Issuer.route.RouterURL != b.Router.origin || b.Issuer.tokenFile == b.Router.transport.tokenFile {
+			return nil, fmt.Errorf("binding requires matching frozen route and separate issuer/router credentials")
+		}
+		b.Loader.Selection.Reader = reader
+		copy[key] = b
+	}
+	return &RunDispatcher{writer, reader, copy}, nil
+}
+
+func (d *RunDispatcher) history(ctx context.Context, key types.NamespacedName) (*api.AgentRun, RunDispatchBinding, *IssuedSelection, error) {
+	var run api.AgentRun
+	if err := d.reader.Get(ctx, key, &run); err != nil {
+		return nil, RunDispatchBinding{}, nil, err
+	}
+	if run.Status.CellnIssuance == nil || len(run.Status.CellnIssuance.Payload) > 393216 {
+		return nil, RunDispatchBinding{}, nil, fmt.Errorf("no catalogue issuance history")
+	}
+	var index runIssuancePayload
+	if json.Unmarshal([]byte(run.Status.CellnIssuance.Payload), &index) != nil || index.Request.Frozen.Snapshot.Agent.Namespace != key.Namespace {
+		return nil, RunDispatchBinding{}, nil, fmt.Errorf("invalid catalogue binding index")
+	}
+	b, ok := d.bindings[types.NamespacedName{Namespace: key.Namespace, Name: index.Request.Frozen.Snapshot.Agent.Name}]
+	if !ok || run.Spec.Backend != "celln" {
+		return nil, b, nil, fmt.Errorf("no configured catalogue issuance binding")
+	}
+	payload, issued, err := decodeRunIssuance(run.Status.CellnIssuance, b.Issuer.endpoint)
+	if err != nil {
+		return nil, b, nil, err
+	}
+	if issued == nil || !reflect.DeepEqual(payload.Route, b.Issuer.route) || payload.Request.Frozen.Run.Namespace != run.Namespace || payload.Request.Frozen.Run.Name != run.Name || payload.Request.Frozen.Run.UID != run.UID {
+		return nil, b, nil, fmt.Errorf("issued history does not bind this run and serving route")
+	}
+	if run.Status.CellnRequest != "" || run.Status.CellnActionID != "" {
+		var request struct {
+			ID string `json:"id"`
+		}
+		if json.Unmarshal(issued.Request, &request) != nil || !executionPathID(request.ID) || run.Status.CellnRequest != string(issued.Request) || run.Status.CellnActionID != request.ID {
+			return nil, b, nil, fmt.Errorf("dispatch journal differs from issued history")
+		}
+	}
+	return &run, b, issued, nil
+}
+
+func (d *RunDispatcher) ReconcilePending(ctx context.Context, key types.NamespacedName, admit func(context.Context, *api.AgentRun) error) (*RouterExecution, error) {
+	run, b, _, err := d.history(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if run.DeletionTimestamp != nil || (run.Status.Phase != "" && run.Status.Phase != api.AgentRunPhasePending) {
+		return nil, fmt.Errorf("run is not pending dispatch")
+	}
+	if run.Status.CellnRequest != "" {
+		// Observation is deliberately independent of fresh approval: work may
+		// already exist and must remain recoverable after approval withdrawal.
+		record, err := b.Router.Lookup(ctx, *b.Issuer.route, run.Status.CellnActionID)
+		if err == nil {
+			return record, nil
+		}
+		var status *RouterHTTPError
+		if !errors.As(err, &status) || status.StatusCode != 404 {
+			return nil, err
+		}
+	}
+	if admit == nil {
+		return nil, fmt.Errorf("controller admission checks required before submission")
+	}
+	if err := admit(ctx, run); err != nil {
+		return nil, err
+	}
+	body, err := b.Issuer.FreezeIssuedDispatch(ctx, d.writer, d.reader, key, b.Loader)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := b.Router.Prewarm(ctx, *b.Issuer.route, body); err != nil {
+		return nil, err
+	}
+	var current api.AgentRun
+	if err := d.reader.Get(ctx, key, &current); err != nil {
+		return nil, err
+	}
+	if err := admit(ctx, &current); err != nil {
+		return nil, err
+	}
+	// The prewarm observation is not authority. Revalidate the exact approved
+	// outcome again before submission; never regenerate a candidate here.
+	body, err = b.Issuer.FreezeIssuedDispatch(ctx, d.writer, d.reader, key, b.Loader)
+	if err != nil {
+		return nil, err
+	}
+	return b.Router.Submit(ctx, *b.Issuer.route, body)
+}
+
+func (d *RunDispatcher) Lookup(ctx context.Context, key types.NamespacedName) (*RouterExecution, error) {
+	run, b, _, err := d.history(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if run.Status.CellnActionID == "" {
+		return nil, fmt.Errorf("catalogue execution has no saved dispatch identity")
+	}
+	return b.Router.Lookup(ctx, *b.Issuer.route, run.Status.CellnActionID)
+}
+
+func (d *RunDispatcher) Cancel(ctx context.Context, key types.NamespacedName) (*RouterExecution, error) {
+	run, b, _, err := d.history(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if run.Status.CellnActionID == "" {
+		return nil, fmt.Errorf("catalogue execution has no saved dispatch identity")
+	}
+	return b.Router.Cancel(ctx, *b.Issuer.route, run.Status.CellnActionID)
+}

--- a/internal/cellnreview/run_dispatcher_submit_test.go
+++ b/internal/cellnreview/run_dispatcher_submit_test.go
@@ -1,0 +1,180 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/zeebo/blake3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func dispatchSubmissionFixture(t *testing.T, handler func(issuerFixture, http.ResponseWriter, *http.Request)) (*RunDispatcher, issuerFixture, *IssuerClient) {
+	t.Helper()
+	f, m, _ := managedFixture(t)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handler(f, w, r) }))
+	t.Cleanup(server.Close)
+	dir := t.TempDir()
+	ca, token := filepath.Join(dir, "ca.pem"), filepath.Join(dir, "router-token")
+	if err := os.WriteFile(ca, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(token, []byte("public-submit-router-credential"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	router, err := NewRouterClient(server.URL, token, ca)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(router.CloseIdleConnections)
+	endpoint, _, issuerToken := serveTestIssuer(t, m)
+	issuer, err := NewIssuerClient(IssuerClientOptions{URL: endpoint, TokenFile: issuerToken, CAFile: filepath.Join(filepath.Dir(issuerToken), "cert.pem"), Route: &DispatchRoute{RouterURL: server.URL, Backend: "http://host-a:8787"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(issuer.CloseIdleConnections)
+	key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+	seed := &IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *f.f, Approval: *f.a, Artifacts: f.artifacts}
+	if _, err := issuer.IssueForRun(context.Background(), f.c, f.c, key, f.l, seed); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewRunDispatcher(f.c, f.c, map[types.NamespacedName]RunDispatchBinding{{Namespace: f.f.Snapshot.Agent.Namespace, Name: f.f.Snapshot.Agent.Name}: {Issuer: issuer, Router: router, Loader: f.l}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d, f, issuer
+}
+
+func TestRunDispatcherSubmissionGatesAndAmbiguousRecovery(t *testing.T) {
+	for _, mode := range []string{"first", "404", "503", "gate-first", "gate-after", "withdraw-after", "missing-gate", "lost-submit"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			var gets, warms, posts, gates atomic.Int32
+			d, f, issuer := dispatchSubmissionFixture(t, func(f issuerFixture, w http.ResponseWriter, r *http.Request) {
+				key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+				var current api.AgentRun
+				if err := f.c.Get(ctx, key, &current); err != nil {
+					t.Error(err)
+					return
+				}
+				if current.Status.CellnRequest == "" || current.Status.CellnActionID == "" {
+					t.Error("network effect preceded durable dispatch journal")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" {
+					gets.Add(1)
+					if mode == "lost-submit" && posts.Load() == 1 {
+						_ = json.NewEncoder(w).Encode(RouterExecution{RequestID: current.Status.CellnActionID, Phase: "Running"})
+						return
+					}
+					if mode == "503" {
+						w.WriteHeader(503)
+					} else {
+						w.WriteHeader(404)
+					}
+					return
+				}
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				switch r.URL.Path {
+				case "/v1/artifacts/prewarm":
+					warms.Add(1)
+					h := blake3.Sum256(body)
+					hash := "blake3:" + strings.Repeat("a", 64)
+					yes, no := true, false
+					report := PrewarmObservation{APIVersion: "celln.dev/artifact-prewarm-v1", Node: "host-a", ProcessEpoch: hash, RequestHash: "blake3:" + hex.EncodeToString(h[:]), WarmState: "present-at-observation", Validity: "observation-only", ExecutionAuthorized: &no, Conformance: "not_checked", ArtifactReadiness: "not_checked", Verification: MemberObservation{APIVersion: "celln.dev/sealed-members-verification-v1", Scope: "sealed-member-identities-only", Mote: f.artifacts.Mote.Hash, Closure: f.artifacts.Closure.Hash, Publisher: strings.Repeat("a", 64), Toolfs: hash, Kernel: hash, Initrd: hash, MemberCount: 3, RequestHash: hash, Challenge: hash, MemberIntegrity: "verified-in-sealed-cell", ToolExecution: &no, CellDissolved: &yes, Conformance: "not_checked", ArtifactReadiness: "not_checked"}}
+					if mode == "withdraw-after" {
+						var policy corev1.ConfigMap
+						if err := f.c.Get(ctx, f.l.Source, &policy); err != nil {
+							t.Error(err)
+						} else if err := f.c.Delete(ctx, &policy); err != nil {
+							t.Error(err)
+						}
+					}
+					_ = json.NewEncoder(w).Encode(report)
+				case "/v1/executions":
+					posts.Add(1)
+					if string(body) != current.Status.CellnRequest || gates.Load() != 2 {
+						t.Error("submission changed bytes or skipped admission recheck")
+					}
+					if mode == "lost-submit" {
+						conn, _, err := w.(http.Hijacker).Hijack()
+						if err != nil {
+							t.Error(err)
+						} else {
+							_ = conn.Close()
+						}
+						return
+					}
+					w.WriteHeader(202)
+					_ = json.NewEncoder(w).Encode(RouterExecution{RequestID: current.Status.CellnActionID, Phase: "Running"})
+				default:
+					t.Error("unexpected dispatch operation")
+				}
+			})
+			key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+			if mode == "404" || mode == "503" {
+				if _, err := issuer.FreezeIssuedDispatch(ctx, f.c, f.c, key, f.l); err != nil {
+					t.Fatal(err)
+				}
+			}
+			admit := func(context.Context, *api.AgentRun) error {
+				n := gates.Add(1)
+				if mode == "gate-first" || mode == "gate-after" && n == 2 {
+					return fmt.Errorf("admission denied")
+				}
+				return nil
+			}
+			if mode == "missing-gate" {
+				admit = nil
+			}
+			record, err := d.ReconcilePending(ctx, key, admit)
+			if mode == "first" || mode == "404" {
+				if err != nil || record == nil || record.Phase != "Running" {
+					t.Fatalf("valid submission failed: %v", err)
+				}
+			} else if err == nil || record != nil {
+				t.Fatal("refused/ambiguous submission returned success")
+			}
+			wantGates, wantWarms, wantPosts := int32(2), int32(1), int32(0)
+			switch mode {
+			case "first", "404", "lost-submit":
+				wantPosts = 1
+			case "503", "missing-gate":
+				wantGates, wantWarms = 0, 0
+			case "gate-first":
+				wantGates, wantWarms = 1, 0
+			}
+			if gates.Load() != wantGates || warms.Load() != wantWarms || posts.Load() != wantPosts {
+				t.Fatalf("wrong transition counts: gates=%d warms=%d posts=%d", gates.Load(), warms.Load(), posts.Load())
+			}
+			if mode == "lost-submit" {
+				if !errors.Is(err, ErrExecutionOutcomeUnknown) {
+					t.Fatal("lost submission not classified as ambiguous")
+				}
+				if record, err := d.ReconcilePending(ctx, key, nil); err != nil || record.Phase != "Running" {
+					t.Fatalf("lost submission failed recovery: %v", err)
+				}
+				if gets.Load() != 1 || posts.Load() != 1 || warms.Load() != 1 {
+					t.Fatal("lost submission was replayed or rewarmed")
+				}
+			}
+		})
+	}
+}

--- a/internal/cellnreview/run_dispatcher_test.go
+++ b/internal/cellnreview/run_dispatcher_test.go
@@ -1,0 +1,113 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestRunDispatcherRecoversAndCancelsWithoutFreshApproval(t *testing.T) {
+	f, m, _ := managedFixture(t)
+	ctx := context.Background()
+	candidate, err := f.l.BuildExecution(ctx, *f.f, *f.a, f.artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var identity struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(candidate.Request, &identity); err != nil {
+		t.Fatal(err)
+	}
+	var gets, cancels, posts atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		phase := "Running"
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v1/executions/"+identity.ID:
+			gets.Add(1)
+		case r.Method == "POST" && r.URL.Path == "/v1/executions/"+identity.ID+"/cancel":
+			cancels.Add(1)
+			phase = "Cancelling"
+		default:
+			posts.Add(1)
+			t.Error("recovery tried to prewarm or submit")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RouterExecution{RequestID: identity.ID, Phase: phase})
+	}))
+	defer server.Close()
+	dir := t.TempDir()
+	ca, routerToken := filepath.Join(dir, "ca.pem"), filepath.Join(dir, "router-token")
+	if err := os.WriteFile(ca, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(routerToken, []byte("public-recovery-router-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	router, err := NewRouterClient(server.URL, routerToken, ca)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer router.CloseIdleConnections()
+	endpoint, _, tokenPath := serveTestIssuer(t, m)
+	issuer, err := NewIssuerClient(IssuerClientOptions{URL: endpoint, TokenFile: tokenPath, CAFile: filepath.Join(filepath.Dir(tokenPath), "cert.pem"), Route: &DispatchRoute{RouterURL: server.URL, Backend: "http://host-a:8787"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer issuer.CloseIdleConnections()
+	key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+	seed := &IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *f.f, Approval: *f.a, Artifacts: f.artifacts}
+	if _, err := issuer.IssueForRun(ctx, f.c, f.c, key, f.l, seed); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := issuer.FreezeIssuedDispatch(ctx, f.c, f.c, key, f.l); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewRunDispatcher(f.c, f.c, map[types.NamespacedName]RunDispatchBinding{{Namespace: f.f.Snapshot.Agent.Namespace, Name: f.f.Snapshot.Agent.Name}: {Issuer: issuer, Router: router, Loader: f.l}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var policy corev1.ConfigMap
+	if err := f.c.Get(ctx, f.l.Source, &policy); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.c.Delete(ctx, &policy); err != nil {
+		t.Fatal(err)
+	}
+	if record, err := d.ReconcilePending(ctx, key, nil); err != nil || record.Phase != "Running" {
+		t.Fatalf("lost acceptance was not recoverable after withdrawal: %v", err)
+	}
+	if record, err := d.Lookup(ctx, key); err != nil || record.Phase != "Running" {
+		t.Fatalf("lookup required fresh approval: %v", err)
+	}
+	if record, err := d.Cancel(ctx, key); err != nil || record.Phase != "Cancelling" {
+		t.Fatalf("cancel required fresh approval: %v", err)
+	}
+	if gets.Load() != 2 || cancels.Load() != 1 || posts.Load() != 0 {
+		t.Fatal("recovery replayed work")
+	}
+	var current api.AgentRun
+	if err := f.c.Get(ctx, key, &current); err != nil {
+		t.Fatal(err)
+	}
+	current.Status.CellnActionID = "substituted"
+	if err := f.c.Status().Update(ctx, &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Lookup(ctx, key); err == nil {
+		t.Fatal("substituted journal accepted")
+	}
+	if gets.Load() != 2 {
+		t.Fatal("invalid journal reached network")
+	}
+}

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -196,7 +196,7 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 	// Catalogue issuance cannot fall through to the legacy task-forge path.
 	// Its separately verified dispatch bridge must consume the saved outcome.
 	if agentRun.Status.CellnIssuance != nil {
-		return ctrl.Result{}, fmt.Errorf("Celln catalogue issuance dispatch is not yet connected")
+		return r.reconcilePendingCatalogue(ctx, log, agentRun)
 	}
 	log.Info("Dispatching AgentRun to Celln backend")
 
@@ -367,6 +367,9 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 		}
 	}
 
+	if agentRun.Status.CellnIssuance != nil {
+		return r.reconcileRunningCatalogue(ctx, log, agentRun)
+	}
 	req, err := cellnRequest(ctx, http.MethodGet, "/v1/executions/"+actionID, nil)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
@@ -407,7 +410,11 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 	if decoder.Decode(new(any)) != io.EOF {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln: trailing execution response data")
 	}
-	if record.RequestID != actionID {
+	return r.applyCellnRecord(ctx, log, agentRun, record)
+}
+
+func (r *AgentRunReconciler) applyCellnRecord(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun, record executionRecord) (ctrl.Result, error) {
+	if record.RequestID != agentRun.Status.CellnActionID {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln: mismatched execution record identity")
 	}
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -149,6 +149,9 @@ const DefaultRunHistoryLimit = 50
 // It watches AgentRun CRDs and reconciles them into Kubernetes Jobs/Pods.
 type AgentRunReconciler struct {
 	client.Client
+	// CatalogueDispatcher is explicit operator wiring; nil refuses catalogue
+	// issuance rather than falling through to legacy forge or OCI execution.
+	CatalogueDispatcher CatalogueDispatcher
 	// APIReader bypasses the controller cache for reads — needed when we
 	// must see status mutations committed by a concurrent reconcile that
 	// the watch-based cache may not yet have observed.
@@ -679,6 +682,9 @@ func (r *AgentRunReconciler) prepareTaskPrerequisites(
 
 // reconcilePending handles an AgentRun that needs a Job created.
 func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (ctrl.Result, error) {
+	if agentRun.Spec.Backend == "celln" && agentRun.Status.CellnIssuance != nil {
+		return r.reconcilePendingCatalogue(ctx, log, agentRun)
+	}
 	ctx, span := controllerTracer.Start(ctx, "agentrun.create_job",
 		trace.WithAttributes(
 			attribute.String("agentrun.name", agentRun.Name),

--- a/internal/controller/celln_cancel.go
+++ b/internal/controller/celln_cancel.go
@@ -20,6 +20,9 @@ func (r *AgentRunReconciler) cancelCelln(ctx context.Context, run *sympoziumv1al
 	if id == "" {
 		return true, nil
 	}
+	if run.Status.CellnIssuance != nil {
+		return r.cancelCatalogue(ctx, run)
+	}
 	if id != cellnActionID(run) {
 		return false, fmt.Errorf("Celln: cancellation identity mismatch")
 	}

--- a/internal/controller/celln_catalogue.go
+++ b/internal/controller/celln_catalogue.go
@@ -1,0 +1,140 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+
+	"github.com/go-logr/logr"
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CatalogueDispatcher interface {
+	ReconcilePending(context.Context, types.NamespacedName, func(context.Context, *api.AgentRun) error) (*cellnreview.RouterExecution, error)
+	Lookup(context.Context, types.NamespacedName) (*cellnreview.RouterExecution, error)
+	Cancel(context.Context, types.NamespacedName) (*cellnreview.RouterExecution, error)
+}
+
+func catalogueRecord(record *cellnreview.RouterExecution) (executionRecord, error) {
+	var out executionRecord
+	if record == nil {
+		return out, fmt.Errorf("missing catalogue execution record")
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return out, err
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.DisallowUnknownFields()
+	if d.Decode(&out) != nil || d.Decode(new(any)) != io.EOF {
+		return out, fmt.Errorf("incompatible catalogue receipt")
+	}
+	return out, nil
+}
+
+func (r *AgentRunReconciler) reconcilePendingCatalogue(ctx context.Context, log logr.Logger, run *api.AgentRun) (ctrl.Result, error) {
+	if r.CatalogueDispatcher == nil || r.APIReader == nil {
+		return ctrl.Result{}, fmt.Errorf("Celln catalogue dispatcher and uncached reader are not configured")
+	}
+	record, err := r.CatalogueDispatcher.ReconcilePending(ctx, client.ObjectKeyFromObject(run), func(ctx context.Context, current *api.AgentRun) error {
+		if os.Getenv("CELLN_HARNESS_ENABLED") != "true" {
+			return fmt.Errorf("Celln Harness is disabled")
+		}
+		if err := r.validatePolicy(ctx, current); err != nil {
+			return err
+		}
+		if err := validateGateHooks(current); err != nil {
+			return err
+		}
+		return r.checkTokenBudget(ctx, log, current)
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	parsed, err := catalogueRecord(record)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// Refresh the durable journal written by the service, never a mutated task
+	// normalized through the OCI Harness path. Do not regress a concurrent terminal.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var current api.AgentRun
+		if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(run), &current); err != nil {
+			return err
+		}
+		if current.UID != run.UID || current.DeletionTimestamp != nil || current.Status.CellnIssuance == nil || current.Status.CellnRequest == "" || current.Status.CellnActionID != parsed.RequestID || (current.Status.Phase != "" && current.Status.Phase != api.AgentRunPhasePending && current.Status.Phase != api.AgentRunPhaseRunning) {
+			return fmt.Errorf("catalogue run changed during dispatch")
+		}
+		current.Status.Phase = api.AgentRunPhaseRunning
+		if current.Status.StartedAt == nil {
+			now := metav1.Now()
+			current.Status.StartedAt = &now
+		}
+		if err := r.Status().Update(ctx, &current); err != nil {
+			return err
+		}
+		*run = current
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return r.applyCellnRecord(ctx, log, run, parsed)
+}
+
+func (r *AgentRunReconciler) reconcileRunningCatalogue(ctx context.Context, log logr.Logger, run *api.AgentRun) (ctrl.Result, error) {
+	if r.CatalogueDispatcher == nil {
+		return ctrl.Result{}, fmt.Errorf("Celln catalogue dispatcher is not configured")
+	}
+	record, err := r.CatalogueDispatcher.Lookup(ctx, client.ObjectKeyFromObject(run))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	parsed, err := catalogueRecord(record)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return r.applyCellnRecord(ctx, log, run, parsed)
+}
+
+func (r *AgentRunReconciler) cancelCatalogue(ctx context.Context, run *api.AgentRun) (bool, error) {
+	if r.CatalogueDispatcher == nil {
+		return false, fmt.Errorf("Celln catalogue dispatcher is not configured")
+	}
+	record, err := r.CatalogueDispatcher.Cancel(ctx, client.ObjectKeyFromObject(run))
+	if err != nil {
+		return false, err
+	}
+	parsed, err := catalogueRecord(record)
+	if err != nil {
+		return false, err
+	}
+	if parsed.RequestID != run.Status.CellnActionID {
+		return false, fmt.Errorf("catalogue cancel identity mismatch")
+	}
+	if !slices.Contains([]string{"Succeeded", "Failed", "Refused", "Cancelled"}, parsed.Phase) {
+		return false, nil
+	}
+	if parsed.Receipt != nil {
+		if err := validateCellnReceipt(run, parsed); err != nil {
+			return false, err
+		}
+		data, _ := json.Marshal(parsed.Receipt)
+		if err := r.updateStatusWithRetry(ctx, run, func(current *api.AgentRun) { current.Status.CellnReceipt = string(data) }); err != nil {
+			return false, err
+		}
+	} else if parsed.Phase == "Succeeded" {
+		return false, fmt.Errorf("catalogue success lacks terminal receipt")
+	}
+	return true, nil
+}

--- a/internal/controller/celln_catalogue_test.go
+++ b/internal/controller/celln_catalogue_test.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type catalogueFixture struct {
+	record                  *cellnreview.RouterExecution
+	pending, lookup, cancel int
+	beforePending           func()
+}
+
+func (f *catalogueFixture) ReconcilePending(context.Context, types.NamespacedName, func(context.Context, *api.AgentRun) error) (*cellnreview.RouterExecution, error) {
+	f.pending++
+	if f.beforePending != nil {
+		f.beforePending()
+	}
+	return f.record, nil
+}
+func (f *catalogueFixture) Lookup(context.Context, types.NamespacedName) (*cellnreview.RouterExecution, error) {
+	f.lookup++
+	return f.record, nil
+}
+func (f *catalogueFixture) Cancel(context.Context, types.NamespacedName) (*cellnreview.RouterExecution, error) {
+	f.cancel++
+	return f.record, nil
+}
+
+func TestCatalogueControllerRecoversWithoutOCIOrLegacyID(t *testing.T) {
+	ctx := context.Background()
+	run := newTestCellnRun(t, "catalogue-recovery", "catalogue-uid")
+	run.Status.CellnIssuance = &api.CellnIssuanceStatus{Phase: "Issued"}
+	run.Status.CellnActionID = "celln-catalogue-derived-id"
+	run.Status.CellnRequest = `{"id":"celln-catalogue-derived-id"}`
+	r := newAgentRunTestReconciler(t, run)
+	r.APIReader = r.Client
+	f := &catalogueFixture{record: &cellnreview.RouterExecution{RequestID: run.Status.CellnActionID, Phase: "Running"}}
+	r.CatalogueDispatcher = f
+	// There is deliberately no Agent/OCI runtime in this fixture. Observing
+	// already-issued work must not require those mutable prerequisites.
+	if _, err := r.reconcilePending(ctx, logr.Discard(), run); err != nil {
+		t.Fatal(err)
+	}
+	var stored api.AgentRun
+	if err := r.Get(ctx, client.ObjectKeyFromObject(run), &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status.Phase != api.AgentRunPhaseRunning || stored.Status.StartedAt == nil || stored.Status.CellnActionID != "celln-catalogue-derived-id" {
+		t.Fatal("catalogue identity or phase was lost")
+	}
+	if _, err := r.reconcileRunningCelln(ctx, logr.Discard(), &stored); err != nil {
+		t.Fatal(err)
+	}
+	f.record.Phase = "Cancelling"
+	if done, err := r.cancelCelln(ctx, &stored); err != nil || done {
+		t.Fatalf("cancellation implied teardown: %v", err)
+	}
+	f.record.Phase = "Cancelled"
+	if done, err := r.cancelCelln(ctx, &stored); err != nil || !done {
+		t.Fatalf("terminal cancellation refused catalogue ID: %v", err)
+	}
+	if f.pending != 1 || f.lookup != 1 || f.cancel != 2 {
+		t.Fatal("wrong catalogue lifecycle calls")
+	}
+}
+
+func TestCatalogueControllerCannotRegressConcurrentTerminalState(t *testing.T) {
+	ctx := context.Background()
+	run := newTestCellnRun(t, "terminal-race", "terminal-uid")
+	run.Status.CellnIssuance = &api.CellnIssuanceStatus{Phase: "Issued"}
+	run.Status.CellnActionID = "catalogue-terminal"
+	run.Status.CellnRequest = `{"id":"catalogue-terminal"}`
+	r := newAgentRunTestReconciler(t, run)
+	r.APIReader = r.Client
+	f := &catalogueFixture{record: &cellnreview.RouterExecution{RequestID: run.Status.CellnActionID, Phase: "Running"}}
+	f.beforePending = func() {
+		var current api.AgentRun
+		if err := r.Get(ctx, client.ObjectKeyFromObject(run), &current); err != nil {
+			t.Fatal(err)
+		}
+		current.Status.Phase = api.AgentRunPhaseSucceeded
+		if err := r.Status().Update(ctx, &current); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r.CatalogueDispatcher = f
+	if _, err := r.reconcilePending(ctx, logr.Discard(), run); err == nil {
+		t.Fatal("concurrent terminal state regressed")
+	}
+	var current api.AgentRun
+	if err := r.Get(ctx, client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Status.Phase != api.AgentRunPhaseSucceeded {
+		t.Fatal("terminal state changed")
+	}
+}

--- a/internal/controller/celln_catalogue_test.go
+++ b/internal/controller/celln_catalogue_test.go
@@ -2,12 +2,16 @@ package controller
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/go-logr/logr"
 	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,7 +49,8 @@ func TestCatalogueControllerRecoversWithoutOCIOrLegacyID(t *testing.T) {
 	r.CatalogueDispatcher = f
 	// There is deliberately no Agent/OCI runtime in this fixture. Observing
 	// already-issued work must not require those mutable prerequisites.
-	if _, err := r.reconcilePending(ctx, logr.Discard(), run); err != nil {
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+	if _, err := r.Reconcile(ctx, request); err != nil {
 		t.Fatal(err)
 	}
 	var stored api.AgentRun
@@ -55,7 +60,14 @@ func TestCatalogueControllerRecoversWithoutOCIOrLegacyID(t *testing.T) {
 	if stored.Status.Phase != api.AgentRunPhaseRunning || stored.Status.StartedAt == nil || stored.Status.CellnActionID != "celln-catalogue-derived-id" {
 		t.Fatal("catalogue identity or phase was lost")
 	}
-	if _, err := r.reconcileRunningCelln(ctx, logr.Discard(), &stored); err != nil {
+	if !slices.Contains(stored.Finalizers, agentRunFinalizer) {
+		t.Fatal("full reconciliation did not retain cleanup finalizer")
+	}
+	var jobs batchv1.JobList
+	if err := r.List(ctx, &jobs); err != nil || len(jobs.Items) != 0 {
+		t.Fatal("catalogue recovery created a Job")
+	}
+	if _, err := r.Reconcile(ctx, request); err != nil {
 		t.Fatal(err)
 	}
 	f.record.Phase = "Cancelling"
@@ -68,6 +80,45 @@ func TestCatalogueControllerRecoversWithoutOCIOrLegacyID(t *testing.T) {
 	}
 	if f.pending != 1 || f.lookup != 1 || f.cancel != 2 {
 		t.Fatal("wrong catalogue lifecycle calls")
+	}
+}
+
+func TestCatalogueFullDeletionWaitsForTerminalCancellation(t *testing.T) {
+	ctx := context.Background()
+	run := newTestCellnRun(t, "catalogue-delete", "delete-uid")
+	run.Finalizers = []string{agentRunFinalizer}
+	run.Status.Phase = api.AgentRunPhaseRunning
+	run.Status.CellnIssuance = &api.CellnIssuanceStatus{Phase: "Issued"}
+	run.Status.CellnActionID = "catalogue-delete-id"
+	run.Status.CellnRequest = `{"id":"catalogue-delete-id"}`
+	r := newAgentRunTestReconciler(t, run)
+	r.APIReader = r.Client
+	f := &catalogueFixture{record: &cellnreview.RouterExecution{RequestID: run.Status.CellnActionID, Phase: "Cancelling"}}
+	r.CatalogueDispatcher = f
+	if err := r.Delete(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+	result, err := r.Reconcile(ctx, request)
+	if err != nil || result.RequeueAfter == 0 {
+		t.Fatalf("deletion did not wait for cleanup: %v", err)
+	}
+	var current api.AgentRun
+	if err := r.Get(ctx, request.NamespacedName, &current); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(current.Finalizers, agentRunFinalizer) {
+		t.Fatal("cleanup finalizer removed before terminal cancellation")
+	}
+	f.record.Phase = "Cancelled"
+	if _, err := r.Reconcile(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Get(ctx, request.NamespacedName, &current); !apierrors.IsNotFound(err) {
+		t.Fatalf("terminal cleanup did not release deletion: %v", err)
+	}
+	if f.cancel != 2 || f.pending != 0 || f.lookup != 0 {
+		t.Fatal("deletion selected wrong operation")
 	}
 }
 


### PR DESCRIPTION
Part of #426. Connects already-issued catalogue runs to verified TLS submission, owner-based lookup/cancellation, controller receipt handling and explicit operator registration. Recovery precedes fresh approval; new submission requires policy/gate/budget checks, exact durable request, pinned prewarm and revalidation. Lost responses do not generate another ID or replay outside router ownership. Cancelling is not teardown. Preserves legacy behavior when unconfigured.

Adds bounded operator JSON configuration, startup refusal for invalid configuration, and opt-in Helm Secret mount/flags. Does not create initial selection/issuance or add user-facing selectors.

Passed full Go race suite with NATS, build/vet, both Helm lints, actual default/legacy/catalogue Helm renders, configuration refusals, positive/404/503 submission paths, admission/approval changes, lost-submit recovery, and controller lifecycle/concurrent-terminal tests. New tests use HTTPS and fake Kubernetes/service fixtures; separate real TLS/router/KVM prewarm evidence is in merged #453. Deployed controller/model acceptance remains next. Scoped documentation/evidence included; keeps epic open.