### PR TITLE
feat: persist catalogue issuance through the operator CLI

### DIFF
--- a/cmd/sympozium/celln_selection_cmd.go
+++ b/cmd/sympozium/celln_selection_cmd.go
@@ -31,8 +31,13 @@ func newCellnSelectionRemoteIssueCmd() *cobra.Command {
 	return newCellnSelectionCmd("issue-remote")
 }
 
+func newCellnSelectionRunIssueCmd() *cobra.Command {
+	return newCellnSelectionCmd("issue-run")
+}
+
 func newCellnSelectionCmd(mode string) *cobra.Command {
-	remote := mode == "issue-remote"
+	durable := mode == "issue-run"
+	remote := mode == "issue-remote" || durable
 	compose, issue := mode == "compose", mode == "issue" || remote
 	var sourceNamespace, operatorSource, runtimeSource, agentSource string
 	var selected []string
@@ -43,10 +48,14 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 	var options cellnreview.ComposeOptions
 	var issueOptions cellnreview.IssueOptions
 	var remoteOptions cellnreview.IssuerClientOptions
+	var route cellnreview.DispatchRoute
 	cmd := &cobra.Command{Use: "plan AGENT", Args: cobra.ExactArgs(1), SilenceUsage: true,
 		Short: "Resolve live grants and emit a Celln composition plan without executing",
 		Long:  "Operator-only planning input. Read three independently configured grant ConfigMaps and live Agent/runtime/tool identities. Prints the resolved authority snapshot and exact compositor input; does not grant authority, certify readiness, write resources, compose images or execute. Tenant-facing callers must not accept these source flags from run requests.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if durable {
+				remoteOptions.Route = &route
+			}
 			if executionMote != "" || executionClosure != "" {
 				if compose || executionMote == "" || executionClosure == "" || modelPolicy == "" || runName == "" {
 					return fmt.Errorf("execution candidate requires plan, --run, --model-policy, --execution-mote and --execution-closure")
@@ -97,12 +106,24 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 								return clientErr
 							}
 							defer issuerClient.CloseIdleConnections()
-							issued, err = issuerClient.Issue(cmd.Context(), modelLoader, *frozen, *modelApproval, artifacts)
+							if durable {
+								seed := &cellnreview.IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *frozen, Approval: *modelApproval, Artifacts: artifacts}
+								// The CLI client is uncached. Preserve the exact seed on retry;
+								// IssueForRun refuses changed history instead of replacing it.
+								issued, err = issuerClient.IssueForRun(cmd.Context(), k8sClient, k8sClient, types.NamespacedName{Namespace: namespace, Name: runName}, modelLoader, seed)
+							} else {
+								issued, err = issuerClient.Issue(cmd.Context(), modelLoader, *frozen, *modelApproval, artifacts)
+							}
 						} else {
 							issued, err = cellnreview.Issue(cmd.Context(), modelLoader, *frozen, *modelApproval, artifacts, issueOptions)
 						}
 						if err != nil {
 							return err
+						}
+						if durable {
+							// Output failure must not withdraw a committed grant: the
+							// controller may already be executing this durable run.
+							return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{"apiVersion": "sympozium.ai/celln-run-issuance-report-v1", "namespace": namespace, "run": runName, "issuancePersisted": true, "controllerMayExecute": true, "artifactReadiness": "not_checked"})
 						}
 						version := "sympozium.ai/celln-issuance-report-v1"
 						if remote {
@@ -198,6 +219,17 @@ func newCellnSelectionCmd(mode string) *cobra.Command {
 		for _, name := range []string{"celln-binary", "policy-root", "composer-publisher"} {
 			_ = cmd.MarkFlagRequired(name)
 		}
+	}
+	if durable {
+		cmd.Use = "issue-run AGENT"
+		cmd.Short = "Persist trusted issuance on an AgentRun for catalogue controller execution"
+		cmd.Long = "Operator-only execution hand-off: persist an immutable Prepared request and serving route before remote issuance, then commit the verified Issued result on the AgentRun. A configured controller may immediately execute it. Retry only with the identical inputs; changed approvals, run identity or route refuse instead of replacing history. Lost CLI output does not undo issuance. Requires AgentRun status write access and controller configuration matching these trusted sources and route. No readiness claim."
+		cmd.Flags().StringVar(&route.RouterURL, "router-url", "", "Exact configured HTTPS router origin frozen before issuance")
+		cmd.Flags().StringVar(&route.Backend, "backend", "", "Exact configured HTTP dispatcher origin behind the router; no fallback")
+		for _, name := range []string{"router-url", "backend"} {
+			_ = cmd.MarkFlagRequired(name)
+		}
+		cmd.Flags().Lookup("run").Usage = "Existing same-namespace AgentRun to durably issue; controller may execute immediately"
 	}
 	return cmd
 }

--- a/cmd/sympozium/celln_selection_cmd_test.go
+++ b/cmd/sympozium/celln_selection_cmd_test.go
@@ -37,6 +37,29 @@ func TestRemoteIssuanceHasNoLocalHostAuthorityFlags(t *testing.T) {
 	}
 }
 
+func TestDurableIssuanceRequiresRouteAndWarnsAboutExecution(t *testing.T) {
+	cmd := newCellnSelectionRunIssueCmd()
+	for _, name := range []string{"issuer-url", "issuer-token-file", "run", "model-policy", "execution-mote", "execution-closure", "router-url", "backend", "grant-namespace", "operator-grants", "runtime-grants", "agent-grants"} {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil || len(flag.Annotations["cobra_annotation_bash_completion_one_required_flag"]) == 0 {
+			t.Fatalf("missing required durable issuance input %s", name)
+		}
+	}
+	for _, name := range []string{"policy-root", "celln-binary", "composer-publisher", "profile-lifetime", "key-file", "router-token-file"} {
+		if cmd.Flags().Lookup(name) != nil {
+			t.Fatalf("issuance command accepts unnecessary authority flag %s", name)
+		}
+	}
+	if !strings.Contains(cmd.Long, "may immediately execute") || !strings.Contains(cmd.Flags().Lookup("run").Usage, "may execute immediately") {
+		t.Fatal("durable hand-off fails to disclose controller execution")
+	}
+	// Preserve the existing provisioning-only command's contract.
+	remote := newCellnSelectionRemoteIssueCmd()
+	if remote.Flags().Lookup("router-url") != nil || !strings.Contains(remote.Long, "No dispatch") {
+		t.Fatal("provisioning-only command changed")
+	}
+}
+
 func TestSelectionPlanRequiresExplicitSourcesAndWellFormedSelections(t *testing.T) {
 	for _, args := range [][]string{
 		{"agent"},

--- a/cmd/sympozium/celln_tool_cmd.go
+++ b/cmd/sympozium/celln_tool_cmd.go
@@ -51,6 +51,7 @@ func newCellnToolCmd() *cobra.Command {
 	cmd.AddCommand(newCellnSelectionComposeCmd())
 	cmd.AddCommand(newCellnSelectionIssueCmd())
 	cmd.AddCommand(newCellnSelectionRemoteIssueCmd())
+	cmd.AddCommand(newCellnSelectionRunIssueCmd())
 	cmd.AddCommand(newCellnWithdrawGrantCmd())
 	cmd.AddCommand(newCellnRecoverGrantsCmd())
 	cmd.AddCommand(newCellnIssuerServiceCmd())

--- a/docs/guides/celln-durable-issuance-cli.md
+++ b/docs/guides/celln-durable-issuance-cli.md
@@ -1,0 +1,50 @@
+# Durable catalogue issuance from the operator CLI
+
+`sympozium celln-tool issue-run AGENT` persists the verified issuer result on
+an existing AgentRun. Unlike `issue-remote`, this is an **execution hand-off**:
+the catalogue controller can submit the run as soon as issuance is committed.
+The command itself does not call the router or assert readiness.
+
+Use an explicit kubeconfig and namespace. Only operators with trusted grant
+source configuration and AgentRun status write permission should use this
+command; source and route flags are not tenant-controlled inputs.
+
+```sh
+sympozium --kubeconfig /absolute/isolated-kubeconfig --namespace tenant \
+  celln-tool issue-run assistant --run task-1 \
+  --grant-namespace operator \
+  --operator-grants operator-grants --runtime-grants runtime-grants \
+  --agent-grants assistant-grants --model-policy model-policy \
+  --tool uppercase@v1 --tool length@v1 \
+  --execution-mote blake3:REPLACE_WITH_ADMITTED_MOTE_HASH \
+  --execution-closure blake3:REPLACE_WITH_COMPOSED_CLOSURE_HASH \
+  --issuer-url https://issuer.example \
+  --issuer-token-file /absolute/issuer-token \
+  --issuer-ca-file /absolute/issuer-ca.pem \
+  --router-url https://router.example --backend http://dispatcher.internal:9400
+```
+
+The names, revisions and hashes above are placeholders, not runnable admitted
+artifacts. Composition and host admission must already be complete. The
+controller's catalogue binding must match the Agent, authority sources, issuer
+and frozen serving route. Its router credential stays in controller configuration;
+the issuance command does not need it.
+
+Until high-level catalogue run creation exists, isolate or pause the intended
+controller **before creating the pending run**, create the run and its independent
+approvals, issue it, then resume the configured controller. An unissued pending
+run is not a holding queue: an active legacy controller can process it through
+the ordinary Celln path before this command records issuance. Do not pause a
+shared production controller to run a demonstration.
+
+The CLI saves `Prepared` before contacting the issuer and `Issued` only after
+independent result validation. A lost response, status acknowledgement or output
+does not authorize changing identity, deleting the journal or switching hosts.
+Retry with the identical command inputs while the run is still pending; changed
+approvals, identity or route refuse. Once dispatch starts, inspect AgentRun status
+and let the controller recover the saved router owner rather than reissuing.
+Output failure does not revoke a committed grant that may already be in use.
+
+This is an operator bridge to the real catalogue-backed proof, not the final
+UI/YAML selection workflow, automatic admission, conversation support or a
+production-readiness claim.


### PR DESCRIPTION
## Purpose
Advances #426 by exposing the existing durable IssueForRun path as celln-tool issue-run. It freezes the configured router/backend before remote provisioning and persists Prepared/Issued state for the merged catalogue controller bridge (#454).

The existing issue-remote command remains provisioning-only. The new command explicitly warns that committing issuance enables controller execution. Output errors do not withdraw potentially active grants. No local host authority or router credential flags are accepted.

## Validation
- go test -race ./cmd/sympozium ./internal/cellnreview -count=1 passed.
- go build ./cmd/sympozium passed.
- go vet ./cmd/sympozium ./internal/cellnreview passed.
- git diff --check passed.
- CLI tests cover required route/authority inputs, absent unnecessary authority flags, execution warning and unchanged provisioning command. Existing library tests cover durable issuance and recovery; this PR does not yet prove a live CLI-to-controller model task.

## Operational limits
Guide documents the initial pending-run race with an active legacy controller and requires isolated setup. High-level run creation/selection, automatic admission and the deployed catalogue-backed AI proof remain open. No cluster mutations or model calls were made for this PR.