### PR TITLE
test: prove live catalogue issuance through controller and Celln AI execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ mcp-bridge
 
 # Local machine-specific Claude notes (not shared)
 CLAUDE.local.md
+
+# Local catalogue proof binaries and full execution evidence (publish summaries)
+/target/celln-live-proof/

--- a/docs/evidence/celln-live-catalogue-harness-2026-09-08.json
+++ b/docs/evidence/celln-live-catalogue-harness-2026-09-08.json
@@ -1,0 +1,61 @@
+{
+  "status": "passed",
+  "scope": "actual host Sympozium CLI/controller, isolated Kind API, managed TLS issuer, TLS-fronted pinned Celln router, real KVM dispatcher and real DeepSeek",
+  "sympoziumProductionSource": "2588768271a560dce131bafb332aa5f7cec3bdcd",
+  "testSource": "test/integration/celln-catalogue-setup/live_test.go in the containing commit",
+  "context": "kind-celln-deployed",
+  "namespace": "celln-catalogue-proof-bw6h4",
+  "runUID": "7c9078a6-6ef3-4aee-916b-19d96ef6152f",
+  "action": "celln-475969e6149922559e877b0f559a1e7d1d4d9750bc89758f80a404d88388a9d8",
+  "closure": "blake3:fbb376b56b141a6d2523444e8eb14839de7a2b2297100cc78321bc2570c3e366",
+  "mote": "blake3:fce9708ecfd21fffa09a6d3c838ef2cd45fd6314ebdb26e1396f7b31291fae5e",
+  "modelGrant": "blake3:d59b04acd57a479b7df40c87ef41459b1596ba0a9cafba3cb605d75b700e937d",
+  "receipt": {
+    "phase": "succeeded",
+    "node": "catalogue-live-proof",
+    "cellId": "678f53482166",
+    "startedAt": "2026-09-08T06:21:48Z",
+    "completedAt": "2026-09-08T06:21:51Z",
+    "outputHash": "blake3:12eb830d6f01ef1a6a20af84092a3dd9e8545d103d4ee74956e28d8a4e256024",
+    "outputBytes": 1100
+  },
+  "toolCalls": [
+    {"name":"uppercase", "arguments":{"text":"celln"}, "result":{"text":"CELLN"}},
+    {"name":"length", "arguments":{"text":"CELLN"}, "result":{"length":5}}
+  ],
+  "answer": "CELLN has length 5",
+  "brokerRequests": 3,
+  "brokerDenied": 0,
+  "jobs": 0,
+  "liveCellsAfterTerminal": 0,
+  "checks": [
+    "Catalogue and approval bindings use real API-assigned UIDs and persisted specs",
+    "Actual issue-run CLI committed Issued status before controller startup and dispatch",
+    "Actual controller loaded trusted issuer/router bindings and used the frozen route",
+    "Execution audit correlates grant, three broker requests and the controller receipt",
+    "Execution audit records Dissolved",
+    "Model-policy deletion removed the host admission profile",
+    "Host grant reissuance refused after withdrawal",
+    "Router retained the successful owner receipt after withdrawal"
+  ],
+  "cleanup": {
+    "runFinalizerCompleted": true,
+    "proofNamespacesRemaining": 0,
+    "allOwnedHostProcessesJoined": true,
+    "isolatedControllerRestoredReadyReplicas": 1
+  },
+  "evidenceSHA256": {
+    "agentrun.json": "ccabd9a7ca4eb3099bba1396eae6d444859e1d68dfe0645849026b374a0f565f",
+    "audit.json": "afe706198e7518bd100b763a54b9b9d0d77ead6f5ab18835d2a9d885e617ec02",
+    "summary.json": "44a37b5f06641a0ffd22b2879ebc1f8d2c00566b3e012091d2f4e3e5049b3e4f"
+  },
+  "localEvidence": "target/celln-live-proof/catalogue-live-4099304486",
+  "totalBillableRunsThisChange": 2,
+  "totalBrokerRequestsThisChange": 6,
+  "limits": [
+    "Host processes, not production pod deployment topology",
+    "Public signed fixture and fixture materializer, not production admission/distribution",
+    "One-shot native JSON runtime, not arbitrary OCI Harness or conversations",
+    "No final UI/YAML user-selection, fleet availability or full epic acceptance claim"
+  ]
+}

--- a/docs/evidence/celln-live-catalogue-setup-2026-09-08.json
+++ b/docs/evidence/celln-live-catalogue-setup-2026-09-08.json
@@ -1,0 +1,26 @@
+{
+  "status": "passed",
+  "scope": "fixture setup against the actual isolated Kind Kubernetes API; not execution acceptance",
+  "context": "kind-celln-deployed",
+  "namespace": "celln-catalogue-proof-sw7vb",
+  "runUID": "baa2d3b9-6f5c-4769-b9bc-af84ca199417",
+  "checks": [
+    "Known proof controller UID and absence of nonterminal runs checked before pause",
+    "Runtime, Agent, uppercase and length catalogue objects created with actual API-assigned identities",
+    "Three independent grant documents bind persisted/defaulted Agent, runtime and tool identities",
+    "Independent DeepSeek policy resolved against the frozen run and selected tools",
+    "Zero Jobs in the proof namespace",
+    "Second invocation refused before namespace creation while the restored controller was running",
+    "Portable race test refuses implicit paths and non-proof kubeconfig contexts"
+  ],
+  "cleanup": {
+    "namespaceDeleted": true,
+    "controllerUID": "ca1c69fb-3af7-47f7-ac3f-44e9a26a27cc",
+    "controllerRestoredReplicas": 1,
+    "controllerRolloutPassed": true
+  },
+  "issuanceRequests": 0,
+  "executionSubmissions": 0,
+  "modelCalls": 0,
+  "remaining": "Compose/materialize, run actual issuer and issue-run CLI, execute through configured controller/router, correlate real two-tool AI result and receipt, prove withdrawal and cleanup."
+}

--- a/docs/guides/celln-live-catalogue-proof.md
+++ b/docs/guides/celln-live-catalogue-proof.md
@@ -1,0 +1,74 @@
+# Live catalogue-backed Harness proof
+
+`test/integration/test-celln-catalogue-harness.sh` exercises the actual Sympozium
+CLI and controller binaries against an isolated Kind API, a TLS-authenticated
+managed issuer, a TLS-fronted actual Celln router, a host KVM dispatcher and
+DeepSeek. The model calls `uppercase` and then `length`, returning
+`CELLN has length 5`.
+
+This differs from the earlier explicit-artifact controller proof: runtime/tool
+catalogue objects and independent grant documents use Kubernetes-assigned UIDs
+and persisted specs. Composition is derived from those approved objects. The
+actual `celln-tool issue-run` command freezes issuance and serving route in
+AgentRun status before the actual controller is started.
+
+## Explicit prerequisites
+
+- Existing `kind-celln-deployed` kubeconfig; no default or Framework context.
+- The isolated `harness-proof-controller` deployment at one replica with its
+  local proof image, and no unfinished AgentRuns. The script temporarily pauses
+  that deployment and restores its original UID at one replica on exit.
+- The current AgentRun, AgentRuntime and CellnTool CRDs installed in that cluster.
+- Go, kubectl, jq, real `/dev/kvm`, the Celln artifact toolchain and readable kernel.
+- The public signed catalogue fixture, native JSON Harness package and explicit
+  public-fixture materializer used by `TestComposeRealCellnArtifacts`.
+- Permission for a billable DeepSeek test, limited to three requests and 1,536
+  total output tokens per run. A failure must be investigated before rerunning.
+
+```sh
+export CELLN_PAUSE_TEST_CONTROLLER=1
+export CELLN_CONTROLLER_KUBECONFIG=/absolute/isolated-kubeconfig
+export CELLN_COMPOSITION_FIXTURE=/absolute/public-catalogue-fixture
+export CELLN_COMPOSITION_BINARY=/absolute/celln
+export CELLN_ISSUANCE_MATERIALIZER=/absolute/prepare_issuance_fixture
+export CELLN_HARNESS_PACKAGE=/absolute/native-json-harness-package
+export CELLN_LIVE_CREDENTIAL_FILE=/absolute/host-only-deepseek-key
+export CELLN_LIVE_EVIDENCE_PARENT=/absolute/existing-evidence-directory
+test/integration/test-celln-catalogue-harness.sh
+```
+
+Alternatively, explicitly set `CELLN_LIVE_DEEPSEEK_ZSHRC` instead of
+`CELLN_LIVE_CREDENTIAL_FILE` to a shell configuration containing exactly one
+literal `DEEPSEEK_API_KEY=sk-...` assignment. The test parses only that literal;
+it never sources the shell configuration or evaluates expansions. The extracted
+key is written to a private temporary host file and removed with test cleanup.
+No key contents enter Kubernetes, command-line arguments, the guest, or evidence.
+
+## Assertions and cleanup
+
+The test verifies durable `Issued` status before dispatch, three model events,
+the two ordered tool results, the final answer, terminal status/receipt, zero
+Jobs, the matching grant and receipt in the execution audit, `Dissolved`, and
+zero live cells. It deletes the independent model policy, waits for managed
+host-profile withdrawal, requires host grant reissuance to refuse, and retrieves
+the same successful owner receipt after withdrawal.
+
+The test owns and joins all host processes and TLS listeners. Run deletion is
+attempted while the controller can still reconcile cancellation/finalizers;
+namespace deletion is UID-scoped. The outer script then restores the isolated
+deployment. Cleanup failures fail the test; they do not authorize stripping
+finalizers or deleting unrelated resources. The newly generated evidence
+directory retains AgentRun status, audit, node state, Job list and summary.
+
+Portable `go test` skips this billable test unless `CELLN_LIVE_CATALOGUE=1` is
+explicitly supplied. The setup helper also has non-network tests rejecting
+implicit paths and non-proof contexts.
+
+## What this does not prove
+
+The controller, issuer and router run as real host processes, not deployed
+production pods. Both tools come from an operator-selected public signed fixture;
+the materializer is not a production admission/distribution service. TLS uses
+public test certificates restricted to loopback. This is one bounded one-shot
+run, not UI/YAML selection, arbitrary OCI Harness support, conversations,
+multi-host availability, fleet revocation, or full epic/release acceptance.

--- a/test/integration/celln-catalogue-setup/live_test.go
+++ b/test/integration/celln-catalogue-setup/live_test.go
@@ -1,0 +1,501 @@
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"github.com/sympozium-ai/sympozium/internal/cellnreview"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Explicitly billable, host-KVM test. The caller pauses/restores only the known
+// isolated proof controller. No environment-default cluster is ever selected.
+func TestLiveCatalogueHarness(t *testing.T) {
+	if os.Getenv("CELLN_LIVE_CATALOGUE") != "1" {
+		t.Skip("explicit isolated live catalogue/model proof required")
+	}
+	path := func(name string) string {
+		p := os.Getenv(name)
+		if !filepath.IsAbs(p) {
+			t.Fatalf("absolute %s required", name)
+		}
+		return p
+	}
+	kube := path("CELLN_CONTROLLER_KUBECONFIG")
+	fixture := path("CELLN_COMPOSITION_FIXTURE")
+	binary := path("CELLN_COMPOSITION_BINARY")
+	materializer := path("CELLN_ISSUANCE_MATERIALIZER")
+	packagePath := path("CELLN_HARNESS_PACKAGE")
+	cli := path("CELLN_LIVE_SYMPOZIUM_BINARY")
+	controller := path("CELLN_LIVE_CONTROLLER_BINARY")
+	config, err := clientcmd.LoadFromFile(kube)
+	must(t, err)
+	if config.CurrentContext != "kind-celln-deployed" {
+		t.Fatal("only isolated kind-celln-deployed permitted")
+	}
+	rest, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
+	must(t, err)
+	scheme := runtime.NewScheme()
+	must(t, api.AddToScheme(scheme))
+	must(t, corev1.AddToScheme(scheme))
+	must(t, appsv1.AddToScheme(scheme))
+	must(t, batchv1.AddToScheme(scheme))
+	c, err := client.New(rest, client.Options{Scheme: scheme})
+	must(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+	var deployment appsv1.Deployment
+	must(t, c.Get(ctx, types.NamespacedName{Namespace: "sympozium-system", Name: "harness-proof-controller"}, &deployment))
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 || deployment.Status.Replicas != 0 || deployment.Status.ObservedGeneration < deployment.Generation {
+		t.Fatal("proof controller must be stopped")
+	}
+	dir := t.TempDir()
+	evidence := filepath.Join(dir, "evidence")
+	if parent := os.Getenv("CELLN_LIVE_EVIDENCE_PARENT"); parent != "" {
+		if !filepath.IsAbs(parent) {
+			t.Fatal("absolute evidence parent required")
+		}
+		evidence, err = os.MkdirTemp(parent, "catalogue-live-")
+		must(t, err)
+	} else {
+		must(t, os.Mkdir(evidence, 0700))
+	}
+	t.Logf("evidence directory: %s", evidence)
+	credential := os.Getenv("CELLN_LIVE_CREDENTIAL_FILE")
+	if source := os.Getenv("CELLN_LIVE_DEEPSEEK_ZSHRC"); source != "" {
+		if credential != "" || !filepath.IsAbs(source) {
+			t.Fatal("choose one explicit host credential source")
+		}
+		raw, err := os.ReadFile(source)
+		must(t, err)
+		if len(raw) > 1<<20 {
+			t.Fatal("shell configuration exceeds bound")
+		}
+		matches := regexp.MustCompile(`(?m)^\s*(?:export\s+)?DEEPSEEK_API_KEY\s*=\s*(['"]?)(sk-[A-Za-z0-9_-]+)(['"]?)\s*(?:#.*)?$`).FindAllSubmatch(raw, -1)
+		if len(matches) != 1 || string(matches[0][1]) != string(matches[0][3]) {
+			t.Fatal("exactly one literal DeepSeek assignment required; shell configuration is never sourced")
+		}
+		credential = filepath.Join(dir, "deepseek-key")
+		must(t, os.WriteFile(credential, matches[0][2], 0600))
+	}
+	if !filepath.IsAbs(credential) {
+		t.Fatal("absolute host credential file or explicit literal shell configuration required")
+	}
+	root := filepath.Join(dir, "store")
+	must(t, os.CopyFS(root, os.DirFS(fixture)))
+	var source catalogue
+	readJSON(t, filepath.Join(root, "catalogue.json"), &source)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "celln-catalogue-proof-", Labels: map[string]string{"sympozium.ai/celln-catalogue-proof": "true"}}}
+	must(t, c.Create(ctx, ns))
+	t.Cleanup(func() {
+		cleanup, stop := context.WithTimeout(context.Background(), 15*time.Second)
+		defer stop()
+		uid := ns.UID
+		if err := c.Delete(cleanup, ns, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); err != nil {
+			t.Errorf("namespace cleanup %s: %v", ns.Name, err)
+		}
+	})
+	report, err := populate(ctx, c, ns.Name, source)
+	must(t, err)
+	frozen := report["frozen"].(*cellnauthority.FrozenSelection)
+	l := cellnauthority.Loader{Reader: c, OperatorSource: types.NamespacedName{Namespace: ns.Name, Name: "operator"}, RuntimeSource: types.NamespacedName{Namespace: ns.Name, Name: "runtime"}, AgentSource: types.NamespacedName{Namespace: ns.Name, Name: "agent"}}
+	ml := cellnauthority.ModelLoader{Selection: l, Source: types.NamespacedName{Namespace: ns.Name, Name: "model"}}
+	o := cellnreview.ComposeOptions{Binary: binary, PolicyRoot: root, KeyFile: filepath.Join(root, "public-fixture-seed"), OutputDir: filepath.Join(dir, "composed")}
+	composition, err := cellnreview.Compose(ctx, l, *frozen, o)
+	must(t, err)
+	var artifacts cellnauthority.ExecutionArtifacts
+	must(t, json.Unmarshal(command(t, ctx, nil, materializer, root, o.OutputDir, packagePath), &artifacts))
+	var signed struct {
+		Publisher string `json:"publisher"`
+	}
+	readJSON(t, filepath.Join(o.OutputDir, "signed-closure.json"), &signed)
+	// Only a host mapping references the credential; no Kubernetes Secret, CLI
+	// argument containing the key, environment injection or guest copy is used.
+	writeJSON(t, filepath.Join(root, "model-credentials.json"), map[string]any{"apiVersion": "sympozium.ai/celln-host-credentials-v1", "profiles": map[string]string{"catalogue-proof": credential}})
+	managed, err := cellnreview.NewManagedIssuer(cellnreview.IssueOptions{Binary: binary, PolicyRoot: root, ComposerPublisher: signed.Publisher, ProfileLifetime: 5 * time.Minute}, map[types.NamespacedName]cellnauthority.ModelLoader{{Namespace: ns.Name, Name: "agent"}: ml}, time.Second)
+	must(t, err)
+	issuerURL, issuerToken, issuerCA := liveIssuer(t, ctx, dir, managed)
+	backendToken, routerToken := filepath.Join(dir, "backend-token"), filepath.Join(dir, "router-token")
+	must(t, os.WriteFile(backendToken, []byte("public-live-catalogue-backend-token"), 0600))
+	must(t, os.WriteFile(routerToken, []byte("public-live-catalogue-router-token"), 0600))
+	backendAddr, routerAddr := freeAddress(t), freeAddress(t)
+	backend := "http://" + backendAddr
+	startProcess(t, ctx, nil, binary, "--root", root, "dispatcher", "--listen", backendAddr, "--token-file", backendToken, "--node-name", "catalogue-live-proof", "--mote-store", filepath.Join(root, "motes"), "--tool-store", filepath.Join(root, "tools"), "--allow-egress-host", "api.deepseek.com", "--egress-slots", "1")
+	waitTCP(t, backendAddr)
+	startProcess(t, ctx, nil, binary, "route", "--listen", routerAddr, "--backends", backend, "--token-file", backendToken, "--client-token-file", routerToken, "--ownership-dir", filepath.Join(dir, "ownership"))
+	waitTCP(t, routerAddr)
+	target, err := url.Parse("http://" + routerAddr)
+	must(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	transport := &http.Transport{Proxy: nil}
+	proxy.Transport = transport
+	t.Cleanup(transport.CloseIdleConnections)
+	router := httptest.NewTLSServer(proxy)
+	t.Cleanup(router.Close)
+	routerCA := filepath.Join(dir, "router-ca.pem")
+	must(t, os.WriteFile(routerCA, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: router.Certificate().Raw}), 0600))
+	args := []string{"--kubeconfig", kube, "--namespace", ns.Name, "celln-tool", "issue-run", "agent", "--run", "run", "--grant-namespace", ns.Name, "--operator-grants", "operator", "--runtime-grants", "runtime", "--agent-grants", "agent", "--model-policy", "model", "--execution-mote", artifacts.Mote.Hash, "--execution-closure", artifacts.Closure.Hash, "--issuer-url", issuerURL, "--issuer-token-file", issuerToken, "--issuer-ca-file", issuerCA, "--router-url", router.URL, "--backend", backend}
+	for _, tool := range source.Tools {
+		args = append(args, "--tool", tool.Name+"@"+tool.Spec.Revision)
+	}
+	var issuedReport struct {
+		IssuancePersisted    bool `json:"issuancePersisted"`
+		ControllerMayExecute bool `json:"controllerMayExecute"`
+	}
+	must(t, json.Unmarshal(command(t, ctx, nil, cli, args...), &issuedReport))
+	if !issuedReport.IssuancePersisted || !issuedReport.ControllerMayExecute {
+		t.Fatal("CLI did not acknowledge durable execution hand-off")
+	}
+	var run api.AgentRun
+	key := types.NamespacedName{Namespace: ns.Name, Name: "run"}
+	must(t, c.Get(ctx, key, &run))
+	if run.Status.CellnIssuance == nil || run.Status.CellnIssuance.Phase != "Issued" || run.Status.CellnActionID != "" {
+		t.Fatal("issuance did not precede dispatch")
+	}
+	configPath := filepath.Join(dir, "controller.json")
+	writeJSON(t, configPath, cellnreview.ControllerDispatchConfig{APIVersion: "sympozium.ai/celln-catalogue-controller-v1", Bindings: []cellnreview.ControllerDispatchBinding{{Agent: types.NamespacedName{Namespace: ns.Name, Name: "agent"}, Issuer: cellnreview.ControllerEndpoint{URL: issuerURL, TokenFile: issuerToken, CAFile: issuerCA}, Router: cellnreview.ControllerEndpoint{URL: router.URL, TokenFile: routerToken, CAFile: routerCA}, Backend: backend, OperatorSource: l.OperatorSource, RuntimeSource: l.RuntimeSource, AgentSource: l.AgentSource, ModelSource: ml.Source}}})
+	env := cleanControllerEnv(kube, configPath)
+	startProcess(t, ctx, env, controller, "--metrics-bind-address=0", "--health-probe-bind-address=0", "--max-run-history=100")
+	// Registered after the controller process cleanup: remove the run while
+	// cancellation/finalizer reconciliation is still available, even on failure.
+	t.Cleanup(func() {
+		cleanup, stop := context.WithTimeout(context.Background(), 50*time.Second)
+		defer stop()
+		if err := c.Delete(cleanup, &api.AgentRun{ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: "run"}}); client.IgnoreNotFound(err) != nil {
+			t.Errorf("run cleanup: %v", err)
+			return
+		}
+		for cleanup.Err() == nil {
+			var current api.AgentRun
+			if err := c.Get(cleanup, key, &current); err != nil {
+				if client.IgnoreNotFound(err) == nil {
+					return
+				}
+				t.Errorf("cleanup lookup: %v", err)
+				return
+			}
+			time.Sleep(time.Second)
+		}
+		t.Error("run finalizer did not complete before controller shutdown")
+	})
+	deadline := time.Now().Add(200 * time.Second)
+	for time.Now().Before(deadline) {
+		must(t, c.Get(ctx, key, &run))
+		if run.Status.Phase == api.AgentRunPhaseSucceeded || run.Status.Phase == api.AgentRunPhaseFailed {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if run.Status.Phase != api.AgentRunPhaseSucceeded {
+		writeJSON(t, filepath.Join(evidence, "agentrun.json"), run)
+		t.Fatalf("catalogue run did not succeed: phase=%s error=%s", run.Status.Phase, run.Status.Error)
+	}
+	validateLiveResult(t, run)
+	var jobs batchv1.JobList
+	must(t, c.List(ctx, &jobs, client.InNamespace(ns.Name)))
+	if len(jobs.Items) != 0 {
+		t.Fatal("unexpected workload Jobs")
+	}
+	var audit struct {
+		Receipt   json.RawMessage `json:"receipt"`
+		Execution struct {
+			ModelGrant string `json:"modelGrant"`
+			Broker     struct {
+				Requests int `json:"requests"`
+			} `json:"broker"`
+		} `json:"execution"`
+		Events []struct {
+			Phase string `json:"phase"`
+		} `json:"events"`
+	}
+	auditBytes := authenticatedGet(t, ctx, router.Client(), router.URL+"/v1/executions/"+run.Status.CellnActionID+"/audit", routerToken)
+	must(t, json.Unmarshal(auditBytes, &audit))
+	dissolved := false
+	for _, event := range audit.Events {
+		if event.Phase == "Dissolved" {
+			dissolved = true
+		}
+	}
+	var request struct {
+		Harness struct {
+			ModelGrant api.CellnImmutableRef `json:"modelGrant"`
+		} `json:"harness"`
+	}
+	must(t, json.Unmarshal([]byte(run.Status.CellnRequest), &request))
+	if audit.Execution.Broker.Requests != 3 || audit.Execution.ModelGrant != request.Harness.ModelGrant.Hash || !dissolved || !sameJSON(audit.Receipt, []byte(run.Status.CellnReceipt)) {
+		t.Fatal("audit does not correlate model budget, grant, receipt and dissolution")
+	}
+	var node struct {
+		Node struct {
+			LiveCells int `json:"live_cells"`
+		} `json:"node"`
+	}
+	must(t, json.Unmarshal(authenticatedGet(t, ctx, &http.Client{Timeout: 10 * time.Second}, backend+"/v1/node", backendToken), &node))
+	if node.Node.LiveCells != 0 {
+		t.Fatal("live cells remain after terminal result")
+	}
+	writeJSON(t, filepath.Join(evidence, "agentrun.json"), run)
+	must(t, os.WriteFile(filepath.Join(evidence, "audit.json"), auditBytes, 0600))
+	writeJSON(t, filepath.Join(evidence, "node.json"), node)
+	writeJSON(t, filepath.Join(evidence, "jobs.json"), jobs)
+	// Current approval withdrawal must not prevent retrieving the existing
+	// owner, but must remove host admission before any new use.
+	must(t, c.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: "model"}}))
+	var issued cellnreview.IssuedSelection
+	must(t, json.Unmarshal([]byte(run.Status.CellnIssuance.Result), &issued))
+	profilePath := filepath.Join(root, "trusted-model-profiles", issued.Profile+".json")
+	for end := time.Now().Add(10 * time.Second); time.Now().Before(end); {
+		if _, err := os.Stat(profilePath); os.IsNotExist(err) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if _, err := os.Stat(profilePath); !os.IsNotExist(err) {
+		t.Fatal("model approval withdrawal did not remove profile")
+	}
+	withdrawnRequest := filepath.Join(dir, "withdrawn-request.json")
+	must(t, os.WriteFile(withdrawnRequest, issued.Request, 0600))
+	refusal := exec.CommandContext(ctx, binary, "--root", root, "harness-grant", withdrawnRequest, "--profile", issued.Profile)
+	if out, err := refusal.CombinedOutput(); err == nil {
+		t.Fatalf("withdrawn host profile still issued a grant: %s", out)
+	}
+	routerClient, err := cellnreview.NewRouterClient(router.URL, routerToken, routerCA)
+	must(t, err)
+	defer routerClient.CloseIdleConnections()
+	record, err := routerClient.Lookup(ctx, cellnreview.DispatchRoute{RouterURL: router.URL, Backend: backend}, run.Status.CellnActionID)
+	must(t, err)
+	if record.Phase != "Succeeded" || string(record.Receipt) != run.Status.CellnReceipt { // Compare JSON semantics, not serialization order.
+		var a, b any
+		must(t, json.Unmarshal(record.Receipt, &a))
+		must(t, json.Unmarshal([]byte(run.Status.CellnReceipt), &b))
+		x, _ := json.Marshal(a)
+		y, _ := json.Marshal(b)
+		if record.Phase != "Succeeded" || string(x) != string(y) {
+			t.Fatal("owner receipt changed after withdrawal")
+		}
+	}
+	writeJSON(t, filepath.Join(evidence, "summary.json"), map[string]any{"status": "passed", "scope": "actual host CLI/controller/issuer/router/KVM with isolated Kind API and real DeepSeek; not deployed pod topology or production admission", "namespace": ns.Name, "runUID": run.UID, "action": run.Status.CellnActionID, "closure": composition.Closure, "brokerRequests": 3, "toolCalls": 2, "jobs": 0, "liveCells": 0, "modelPolicyWithdrawn": true, "hostReissuanceRefused": true, "ownerReceiptRetained": true})
+	t.Logf("PASS actual Kind catalogue -> signed composition -> TLS issuer -> issue-run CLI durable status -> configured controller -> TLS pinned router -> KVM -> DeepSeek uppercase and length -> terminal receipt -> model-policy withdrawal -> retained owner receipt; namespace=%s runUID=%s action=%s closure=%s", ns.Name, run.UID, run.Status.CellnActionID, composition.Closure)
+}
+
+func sameJSON(a, b []byte) bool {
+	var x, y any
+	if json.Unmarshal(a, &x) != nil || json.Unmarshal(b, &y) != nil {
+		return false
+	}
+	p, _ := json.Marshal(x)
+	q, _ := json.Marshal(y)
+	return string(p) == string(q)
+}
+func authenticatedGet(t *testing.T, ctx context.Context, c *http.Client, url, tokenPath string) []byte {
+	t.Helper()
+	token, err := os.ReadFile(tokenPath)
+	must(t, err)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	must(t, err)
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+	res, err := c.Do(req)
+	must(t, err)
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("proof observation HTTP %d", res.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(res.Body, 1048577))
+	must(t, err)
+	if len(raw) > 1048576 {
+		t.Fatal("observation exceeds bound")
+	}
+	return raw
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func readJSON(t *testing.T, path string, out any) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	must(t, err)
+	must(t, json.Unmarshal(raw, out))
+}
+func writeJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	must(t, err)
+	must(t, os.WriteFile(path, raw, 0600))
+}
+func command(t *testing.T, ctx context.Context, env []string, binary string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v: %s", filepath.Base(binary), err, out)
+	}
+	return out
+}
+func freeAddress(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	must(t, err)
+	addr := l.Addr().String()
+	must(t, l.Close())
+	return addr
+}
+func waitTCP(t *testing.T, addr string) {
+	t.Helper()
+	for end := time.Now().Add(10 * time.Second); time.Now().Before(end); {
+		c, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			_ = c.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("listener did not start: " + addr)
+}
+func startProcess(t *testing.T, ctx context.Context, env []string, binary string, args ...string) {
+	t.Helper()
+	child, cancel := context.WithCancel(ctx)
+	log, err := os.CreateTemp(t.TempDir(), "process.log")
+	must(t, err)
+	cmd := exec.CommandContext(child, binary, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	cmd.Stdout, cmd.Stderr = log, log
+	must(t, cmd.Start())
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("owned process did not stop")
+		}
+		_ = log.Close()
+		if t.Failed() {
+			raw, _ := os.ReadFile(log.Name())
+			if len(raw) > 12000 {
+				raw = raw[len(raw)-12000:]
+			}
+			t.Logf("%s log: %s", filepath.Base(binary), raw)
+		}
+	})
+}
+func cleanControllerEnv(kube, config string) []string {
+	var env []string
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "CELLN_") || key == "KUBECONFIG" || key == "NATS_URL" || key == "AGENT_SANDBOX_ENABLED" || key == "OTEL_EXPORTER_OTLP_ENDPOINT" || key == "SYMPOZIUM_PRICING_CONFIGMAP" {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env, "KUBECONFIG="+kube, "NATS_URL=", "AGENT_SANDBOX_ENABLED=false", "CELLN_HARNESS_ENABLED=true", "CELLN_CATALOGUE_CONFIG="+config)
+}
+func liveIssuer(t *testing.T, ctx context.Context, dir string, m *cellnreview.ManagedIssuer) (string, string, string) {
+	t.Helper()
+	sample := httptest.NewTLSServer(http.NotFoundHandler())
+	cert := sample.TLS.Certificates[0]
+	sample.Close()
+	key, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	must(t, err)
+	token, ca, private := filepath.Join(dir, "issuer-token"), filepath.Join(dir, "issuer-ca.pem"), filepath.Join(dir, "issuer-key.pem")
+	must(t, os.WriteFile(token, []byte("public-live-catalogue-issuer-token"), 0600))
+	must(t, os.WriteFile(ca, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}), 0600))
+	must(t, os.WriteFile(private, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}), 0600))
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	must(t, err)
+	child, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- cellnreview.ServeIssuer(child, l, m, token, ca, private) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("issuer shutdown: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("issuer did not stop")
+		}
+	})
+	for end := time.Now().Add(10 * time.Second); time.Now().Before(end); {
+		ready, _ := m.Status()
+		if ready {
+			return "https://" + l.Addr().String(), token, ca
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("issuer provisioning gate did not open")
+	return "", "", ""
+}
+func validateLiveResult(t *testing.T, run api.AgentRun) {
+	t.Helper()
+	var calls []map[string]any
+	models := 0
+	completed := false
+	for _, line := range strings.Split(run.Status.Result, "\n") {
+		if !strings.HasPrefix(line, "CELLN_HARNESS_EVENT ") {
+			continue
+		}
+		var event map[string]any
+		must(t, json.Unmarshal([]byte(strings.TrimPrefix(line, "CELLN_HARNESS_EVENT ")), &event))
+		switch event["type"] {
+		case "model":
+			models++
+		case "tool":
+			calls = append(calls, event)
+		case "completed":
+			completed = event["answer"] == "CELLN has length 5"
+		}
+	}
+	if models != 3 || len(calls) != 2 || !completed {
+		t.Fatalf("unexpected model/tool event counts or answer: models=%d tools=%d completed=%t", models, len(calls), completed)
+	}
+	want := []struct {
+		name   string
+		result string
+	}{{"uppercase", `{"text":"CELLN"}`}, {"length", `{"length":5}`}}
+	for i, w := range want {
+		raw, err := json.Marshal(calls[i]["result"])
+		must(t, err)
+		if calls[i]["name"] != w.name || string(raw) != w.result {
+			t.Fatal(fmt.Sprintf("tool %d did not return expected output", i))
+		}
+	}
+	if run.Status.CellnReceipt == "" || run.Status.CellnActionID == "" {
+		t.Fatal("missing correlated receipt/identity")
+	}
+}

--- a/test/integration/celln-catalogue-setup/main.go
+++ b/test/integration/celln-catalogue-setup/main.go
@@ -1,0 +1,189 @@
+// Fixture setup for the isolated catalogue execution proof. This is not an
+// admission service: it installs operator-selected public fixture metadata only.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type catalogue struct {
+	RuntimeSpec api.AgentRuntimeSpec `json:"runtimeSpec"`
+	Tools       []struct {
+		Name string            `json:"name"`
+		Spec api.CellnToolSpec `json:"spec"`
+	} `json:"tools"`
+}
+
+func main() {
+	var kubeconfig, cataloguePath string
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "Absolute isolated Kind kubeconfig")
+	flag.StringVar(&cataloguePath, "catalogue", "", "Absolute operator-selected public catalogue fixture")
+	flag.Parse()
+	if err := setup(kubeconfig, cataloguePath); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func setup(kubeconfig, cataloguePath string) error {
+	if !filepath.IsAbs(kubeconfig) || !filepath.IsAbs(cataloguePath) {
+		return fmt.Errorf("explicit absolute kubeconfig and catalogue paths required")
+	}
+	config, err := clientcmd.LoadFromFile(kubeconfig)
+	if err != nil {
+		return err
+	}
+	if config.CurrentContext != "kind-celln-deployed" {
+		return fmt.Errorf("only kind-celln-deployed is permitted")
+	}
+	rest, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return err
+	}
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{api.AddToScheme, corev1.AddToScheme, appsv1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			return err
+		}
+	}
+	c, err := client.New(rest, client.Options{Scheme: scheme})
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	var deployment appsv1.Deployment
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "sympozium-system", Name: "harness-proof-controller"}, &deployment); err != nil {
+		return err
+	}
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 || deployment.Status.Replicas != 0 || deployment.Status.ObservedGeneration < deployment.Generation {
+		return fmt.Errorf("isolated proof controller must be stopped before pending run creation")
+	}
+	raw, err := os.ReadFile(cataloguePath)
+	if err != nil {
+		return err
+	}
+	var source catalogue
+	if err := json.Unmarshal(raw, &source); err != nil {
+		return err
+	}
+	if source.RuntimeSpec.Celln == nil || len(source.Tools) != 2 {
+		return fmt.Errorf("native runtime and exactly two fixture tools required")
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "celln-catalogue-proof-", Labels: map[string]string{"sympozium.ai/celln-catalogue-proof": "true"}}}
+	if err := c.Create(ctx, ns); err != nil {
+		return err
+	}
+	success := false
+	defer func() {
+		if !success {
+			cleanup, stop := context.WithTimeout(context.Background(), 15*time.Second)
+			defer stop()
+			// A failed setup never hands the namespace to the controller. Delete
+			// only the namespace whose API-assigned UID this process created.
+			uid := ns.UID
+			if err := c.Delete(cleanup, ns, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); err != nil {
+				fmt.Fprintf(os.Stderr, "fixture namespace cleanup failed for %s: %v\n", ns.Name, err)
+			}
+		}
+	}()
+	report, err := populate(ctx, c, ns.Name, source)
+	if err != nil {
+		return err
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+		return err
+	}
+	success = true // caller owns cleanup after receiving the complete report
+	return nil
+}
+
+func populate(ctx context.Context, c client.Client, namespace string, source catalogue) (map[string]any, error) {
+	rt := &api.AgentRuntime{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "runtime"}, Spec: source.RuntimeSpec}
+	agent := &api.Agent{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "agent"}, Spec: api.AgentSpec{RuntimeRef: "runtime"}}
+	for _, obj := range []client.Object{rt, agent} {
+		if err := c.Create(ctx, obj); err != nil {
+			return nil, err
+		}
+		// Read persisted/defaulted specs, never assume fixture UIDs or defaults.
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return nil, err
+		}
+	}
+	aid, err := cellnauthority.IdentifySubject("Agent", agent.ObjectMeta, agent.Spec)
+	if err != nil {
+		return nil, err
+	}
+	rid, err := cellnauthority.IdentifySubject("AgentRuntime", rt.ObjectMeta, rt.Spec)
+	if err != nil {
+		return nil, err
+	}
+	var grants []cellnauthority.Grant
+	var selected []cellnauthority.Selection
+	for _, tool := range source.Tools {
+		obj := &api.CellnTool{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: tool.Name}, Spec: tool.Spec}
+		if err := c.Create(ctx, obj); err != nil {
+			return nil, err
+		}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return nil, err
+		}
+		id, err := cellnauthority.Identify(*obj)
+		if err != nil {
+			return nil, err
+		}
+		grants = append(grants, cellnauthority.Grant{Tool: id, Limits: obj.Spec.Limits})
+		selected = append(selected, cellnauthority.Selection{Name: obj.Name, Revision: obj.Spec.Revision})
+	}
+	createDocument := func(name, key string, value any) error {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		return c.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}, Data: map[string]string{key: string(raw)}})
+	}
+	for _, layer := range []string{"operator", "runtime", "agent"} {
+		if err := createDocument(layer, "grants.json", cellnauthority.GrantDocument{APIVersion: "sympozium.ai/celln-grants-v1", Layer: layer, Agent: aid, Runtime: rid, Grants: grants}); err != nil {
+			return nil, err
+		}
+	}
+	model := cellnauthority.ModelPolicyDocument{APIVersion: "sympozium.ai/celln-model-policy-v1", Agent: aid, Runtime: rid, Provider: "deepseek", Model: "deepseek-chat", URL: "https://api.deepseek.com/chat/completions", CredentialProfile: "catalogue-proof", MaxRequests: 3, MaxOutputTokens: 512, MaxTotalOutputTokens: 1536}
+	if err := createDocument("model", "model-policy.json", model); err != nil {
+		return nil, err
+	}
+	var run api.AgentRun
+	if err := json.Unmarshal([]byte(`{"spec":{"agentRef":"agent","agentId":"default","sessionKey":"catalogue-proof","backend":"celln","task":"Call uppercase with text celln, then call length with the returned text. Use both tools exactly once in that order. Finally answer exactly: CELLN has length 5","systemPrompt":"Use the explicitly lent tools. Do not calculate tool results yourself.","model":{"provider":"deepseek","model":"deepseek-chat"},"timeout":"180s"}}`), &run); err != nil {
+		return nil, err
+	}
+	run.Namespace, run.Name = namespace, "run"
+	if err := c.Create(ctx, &run); err != nil {
+		return nil, err
+	}
+	l := cellnauthority.Loader{Reader: c, OperatorSource: types.NamespacedName{Namespace: namespace, Name: "operator"}, RuntimeSource: types.NamespacedName{Namespace: namespace, Name: "runtime"}, AgentSource: types.NamespacedName{Namespace: namespace, Name: "agent"}}
+	frozen, err := l.FreezeRun(ctx, client.ObjectKeyFromObject(&run), selected, 33554432)
+	if err != nil {
+		return nil, err
+	}
+	ml := cellnauthority.ModelLoader{Selection: l, Source: types.NamespacedName{Namespace: namespace, Name: "model"}}
+	approval, err := ml.Resolve(ctx, *frozen)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"namespace": namespace, "run": run.Name, "frozen": frozen, "modelApproval": approval, "executionAuthorized": false}, nil
+}

--- a/test/integration/celln-catalogue-setup/main_test.go
+++ b/test/integration/celln-catalogue-setup/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetupRejectsImplicitPathsAndOtherContexts(t *testing.T) {
+	if err := setup("", "catalogue.json"); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("implicit environment accepted: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\ncurrent-context: kubernetes-admin@kubernetes\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := setup(path, "/not-read-catalogue.json"); err == nil || !strings.Contains(err.Error(), "only kind-celln-deployed") {
+		t.Fatalf("non-proof cluster accepted: %v", err)
+	}
+}

--- a/test/integration/test-celln-catalogue-harness.sh
+++ b/test/integration/test-celln-catalogue-harness.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Explicit, billable catalogue proof against the existing isolated Kind cluster.
+set -euo pipefail
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+: "${CELLN_CONTROLLER_KUBECONFIG:?explicit isolated kubeconfig required}"
+: "${CELLN_COMPOSITION_FIXTURE:?public signed catalogue fixture required}"
+: "${CELLN_COMPOSITION_BINARY:?actual Celln binary required}"
+: "${CELLN_ISSUANCE_MATERIALIZER:?explicit public-fixture materializer required}"
+: "${CELLN_HARNESS_PACKAGE:?native JSON Harness package required}"
+: "${CELLN_LIVE_EVIDENCE_PARENT:?existing absolute evidence parent required}"
+[[ ${CELLN_PAUSE_TEST_CONTROLLER:-} == 1 ]] || { echo 'Explicit isolated test-controller pause required' >&2; exit 1; }
+[[ -n ${CELLN_LIVE_CREDENTIAL_FILE:-} || -n ${CELLN_LIVE_DEEPSEEK_ZSHRC:-} ]] || { echo 'Explicit host DeepSeek credential source required' >&2; exit 1; }
+kc() { kubectl --kubeconfig "$CELLN_CONTROLLER_KUBECONFIG" --context kind-celln-deployed "$@"; }
+[[ $(kubectl --kubeconfig "$CELLN_CONTROLLER_KUBECONFIG" config current-context) == kind-celln-deployed ]]
+work=$(mktemp -d /tmp/sympozium-catalogue-proof.XXXXXX)
+paused=false
+paused_uid=''
+cleanup() {
+  if [[ "$paused" == true ]]; then
+    [[ $(kc get deployment harness-proof-controller -n sympozium-system -o jsonpath='{.metadata.uid}') == "$paused_uid" ]] || { echo 'Controller identity changed; refusing restoration' >&2; return 1; }
+    kc scale deployment harness-proof-controller -n sympozium-system --current-replicas=0 --replicas=1
+    kc rollout status deployment harness-proof-controller -n sympozium-system --timeout=60s
+  fi
+  case "$work" in /tmp/sympozium-catalogue-proof.*) rm -r -- "$work" ;; esac
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+# Build before pausing the existing controller. No ambient cluster deployment.
+(cd "$repo" && go build -o "$work/sympozium" ./cmd/sympozium && go build -o "$work/controller" ./cmd/controller)
+kc get agentruns -A -o json | jq -e 'all(.items[]; .status.phase=="Succeeded" or .status.phase=="Failed" or .status.phase=="Cancelled")' >/dev/null
+state=$(kc get deployment harness-proof-controller -n sympozium-system -o json)
+jq -e '.spec.replicas==1 and (.spec.template.spec.containers[0].image|startswith("localhost/sympozium-celln-controller:"))' <<<"$state" >/dev/null
+paused_uid=$(jq -r '.metadata.uid' <<<"$state")
+paused=true
+kc scale deployment harness-proof-controller -n sympozium-system --current-replicas=1 --replicas=0
+deadline=$((SECONDS+60))
+until kc get deployment harness-proof-controller -n sympozium-system -o json | jq -e '(.status.replicas // 0)==0 and .status.observedGeneration>=.metadata.generation' >/dev/null; do
+  (( SECONDS < deadline )) || { echo 'Proof controller did not stop' >&2; exit 1; }
+  sleep 1
+done
+export CELLN_LIVE_CATALOGUE=1
+export CELLN_LIVE_SYMPOZIUM_BINARY="$work/sympozium"
+export CELLN_LIVE_CONTROLLER_BINARY="$work/controller"
+cd "$repo"
+go test -race ./test/integration/celln-catalogue-setup -run '^TestLiveCatalogueHarness$' -count=1 -v


### PR DESCRIPTION
## Outcome
Advances #426 with a real catalogue-backed one-shot proof, beyond the previous explicit-artifact execution path.

Actual isolated Kind API identities and persisted/defaulted specs → independent tool/model approval documents → signed runtime/two-tool composition → real managed TLS issuer → actual issue-run CLI durable AgentRun issuance → configured actual controller → TLS-fronted pinned actual Celln router → real KVM → DeepSeek uppercase and length → CELLN has length 5.

## Evidence
- Two successful billable runs, three broker requests each. The strengthened second run verifies zero Jobs/live cells, correlated audit/grant/receipt and Dissolved, host-profile withdrawal and refused host reissuance, plus retained owner receipt.
- Temporary namespaces deleted, owned host processes joined, isolated proof controller restored to 1/1. Framework untouched.
- Public evidence record: docs/evidence/celln-live-catalogue-harness-2026-09-08.json.
- Reproducible opt-in script and guide included. Credentials remain host-side and are not printed or stored in Kubernetes.

## Regression checks
Full go test -race ./... -count=1 passed with the real NATS fixture available. go build ./..., go vet ./..., bash syntax and git diff --check passed. Ordinary portable tests skip the billable test unless explicitly enabled.

## Scope limits
Host CLI/controller/issuer/router processes against the isolated Kind API, not production pod deployment topology. Public signed catalogue fixture and explicit fixture materializer, not production admission/distribution. One bounded native JSON run, not UI/YAML lending selection, arbitrary OCI harness support, conversations, fleet revocation or full epic acceptance.