### PR TITLE
feat: offer Harness in Celln catalogue selection in the run UI

### DIFF
--- a/charts/celln_tool_ui_test.go
+++ b/charts/celln_tool_ui_test.go
@@ -1,0 +1,42 @@
+package charts
+
+import (
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestAPIServerCataloguePermissionIsReadOnly(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm required for chart rendering")
+	}
+	raw, err := exec.Command("helm", "template", "test", "sympozium", "--show-only", "templates/rbac.yaml").CombinedOutput()
+	if err != nil {
+		t.Fatalf("render: %v: %s", err, raw)
+	}
+	found := false
+	for _, document := range strings.Split(string(raw), "---") {
+		var role rbacv1.ClusterRole
+		if yaml.Unmarshal([]byte(document), &role) != nil || role.Kind != "ClusterRole" || !strings.HasSuffix(role.Name, "-apiserver") {
+			continue
+		}
+		for _, rule := range role.Rules {
+			if !slices.Contains(rule.Resources, "cellntools") {
+				continue
+			}
+			found = true
+			for _, verb := range rule.Verbs {
+				if !slices.Contains([]string{"get", "list", "watch"}, verb) {
+					t.Fatalf("catalogue write authority: %s", verb)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("catalogue read permission absent")
+	}
+}

--- a/charts/sympozium/templates/rbac.yaml
+++ b/charts/sympozium/templates/rbac.yaml
@@ -208,6 +208,10 @@ metadata:
   labels:
     {{- include "sympozium.labels" . | nindent 4 }}
 rules:
+  # Catalogue selection UI can inspect reviewed metadata, never approve tools.
+  - apiGroups: ["sympozium.ai"]
+    resources: ["cellntools"]
+    verbs: ["get", "list", "watch"]
   # Sympozium CRDs — CRUD for REST API / web UI operations
   - apiGroups: ["sympozium.ai"]
     resources:

--- a/docs/evidence/celln-selection-ui-2026-09-08.json
+++ b/docs/evidence/celln-selection-ui-2026-09-08.json
@@ -1,0 +1,31 @@
+{
+  "status": "passed",
+  "scope": "initial run-selection UI contract, read-only catalogue endpoint and RBAC; not live UI-to-model acceptance",
+  "browser": {
+    "runner": "Cypress 15.13.0, Electron 138, local Vite",
+    "testsPassed": 5,
+    "tests": [
+      "Ordered uppercase/length lending sends explicit provider/model and no OCI runtime override",
+      "Empty selection sends an explicit empty list",
+      "OCI-only runtime cannot be requested as native Celln Harness",
+      "Catalogue retrieval failure blocks submission",
+      "One-run runtime override is nested inside cellnSelection"
+    ],
+    "apiResponses": "intercepted fixtures",
+    "clusterTokenDiscovery": false,
+    "modelCalls": 0
+  },
+  "checks": [
+    "Full go test -race ./... -count=1 with real NATS fixture available",
+    "go build ./... and go vet ./...",
+    "npm run build (TypeScript and production Vite build)",
+    "Namespace-scoped sorted catalogue endpoint, empty array and unsupported mutation tests",
+    "Rendered Helm apiserver catalogue rule permits only get/list/watch"
+  ],
+  "limits": [
+    "Request waits for operator issuance; no automatic packaging/distribution",
+    "Displayed catalogue limits are declared metadata, not the final grant intersection",
+    "Conversations and full borrowed-tool submission/review UI remain open",
+    "Existing dependency audit reported 17 vulnerabilities (2 low, 3 moderate, 12 high); lockfile unchanged and dependency remediation not performed here"
+  ]
+}

--- a/docs/guides/celln-harness-selection-ux.md
+++ b/docs/guides/celln-harness-selection-ux.md
@@ -1,11 +1,33 @@
-# Harness + Celln selection UX: API foundation, UI still pending
+# Harness + Celln selection UX: initial UI/API selection, provisioning pending
 
 Recorded for [epic #426](https://github.com/sympozium-ai/sympozium/issues/426)
 after the user's UI/YAML question. The approved experience has three distinct
 choices: Harness identity, execution placement, and explicitly borrowed tools.
 The [advanced JSON API](celln-json-harness.md) and the high-level AgentRun
-`cellnSelection` schema are implemented. The UI selector and automatic
-provisioning remain pending: a catalogue request waits for trusted issuance.
+`cellnSelection` schema are implemented. Runs → New Run now supports initial
+catalogue selection. Automatic provisioning remains pending: a catalogue
+request waits for trusted issuance.
+
+## Current run form
+
+Select an Agent, inherit its Harness or choose a one-run override, then select
+Celln. A compatible native JSON profile opens **Harness in Celln**, with an
+explicit DeepSeek model and ordered tool checkboxes. Empty selection lends no
+tools. The form shows catalogue descriptions, support owners, publisher keys
+and declared limits; these are not the final effective grant intersection.
+Incompatible runtimes and unavailable catalogues block the request. A native
+runtime without an OCI image cannot be submitted to the Job backend.
+
+The button says **Request catalogue run** because readiness is not established.
+The operator must still provision the selected artifacts and commit issuance.
+Run details show the selected tools and the controller's issuance observation.
+Without a selected Harness, the existing Celln host-forge path retains its
+separate ambient-host-model warning. No Celln chat/session button is exposed.
+
+Catalogue listing uses a namespace-scoped read-only endpoint and read-only
+apiserver RBAC. It does not expose tool approval or grant mutation. Browser
+contract tests use intercepted responses; they do not establish live deployment
+or full UI → model → tool acceptance.
 
 ## UI requirements
 

--- a/internal/apiserver/celln_tools_test.go
+++ b/internal/apiserver/celln_tools_test.go
@@ -1,0 +1,53 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCellnCatalogueListIsNamespaceScopedSortedAndReadOnly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := api.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	object := func(ns, name string) *api.CellnTool {
+		return &api.CellnTool{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}, Spec: api.CellnToolSpec{Revision: "v1"}}
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(object("default", "z"), object("default", "a"), object("other", "private")).Build()
+	s := NewServer(c, nil, nil, logr.Discard())
+	for _, tc := range []struct {
+		query string
+		want  []string
+	}{{"", []string{"a", "z"}}, {"?namespace=other", []string{"private"}}, {"?namespace=empty", []string{}}} {
+		res := httptest.NewRecorder()
+		s.Handler(nil).ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/api/v1/celln-tools"+tc.query, nil))
+		if res.Code != 200 {
+			t.Fatalf("list: %d", res.Code)
+		}
+		var tools []api.CellnTool
+		if err := json.Unmarshal(res.Body.Bytes(), &tools); err != nil {
+			t.Fatal(err)
+		}
+		if tools == nil || len(tools) != len(tc.want) {
+			t.Fatal("wrong namespace or null empty list")
+		}
+		for i, name := range tc.want {
+			if tools[i].Name != name {
+				t.Fatal("unstable order or namespace leak")
+			}
+		}
+	}
+	res := httptest.NewRecorder()
+	s.Handler(nil).ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/api/v1/celln-tools", nil))
+	if res.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("catalogue mutation exposed: %d", res.Code)
+	}
+}

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -145,6 +145,7 @@ func (s *Server) buildMux(frontendFS fs.FS, expected *tokenReader) http.Handler 
 
 	// Administrator-approved harness runtimes
 	mux.HandleFunc("GET /api/v1/runtimes", s.listRuntimes)
+	mux.HandleFunc("GET /api/v1/celln-tools", s.listCellnTools)
 	mux.HandleFunc("POST /api/v1/runtimes/install-defaults", s.installDefaultRuntimes)
 	// Persistent harness sessions. The API server owns the only browser-facing
 	// route to a session's private in-cluster Service.
@@ -421,6 +422,25 @@ func (s *Server) listRuntimes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sort.Slice(list.Items, func(i, j int) bool { return list.Items[i].Name < list.Items[j].Name })
+	writeJSON(w, list.Items)
+}
+
+// Catalogue metadata is review input, not per-Agent authority or readiness.
+// This endpoint intentionally provides no create/approve/status mutation.
+func (s *Server) listCellnTools(w http.ResponseWriter, r *http.Request) {
+	ns := r.URL.Query().Get("namespace")
+	if ns == "" {
+		ns = "default"
+	}
+	var list sympoziumv1alpha1.CellnToolList
+	if err := s.client.List(r.Context(), &list, client.InNamespace(ns)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	sort.Slice(list.Items, func(i, j int) bool { return list.Items[i].Name < list.Items[j].Name })
+	if list.Items == nil {
+		list.Items = []sympoziumv1alpha1.CellnTool{}
+	}
 	writeJSON(w, list.Items)
 }
 

--- a/web/cypress.selection.config.ts
+++ b/web/cypress.selection.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "cypress";
+
+// UI contract fixtures only. No kubeconfig, cluster-token discovery, or model.
+export default defineConfig({
+  e2e: {
+    baseUrl: "http://127.0.0.1:5178",
+    env: { API_TOKEN: "public-selection-ui-fixture" },
+    supportFile: "cypress/support/e2e.ts",
+    specPattern: "cypress/e2e/celln-selection.cy.ts",
+    viewportWidth: 1280,
+    viewportHeight: 1000,
+    video: false,
+  },
+});

--- a/web/cypress/e2e/celln-selection.cy.ts
+++ b/web/cypress/e2e/celln-selection.cy.ts
@@ -1,0 +1,74 @@
+// Browser UI contract tests with intercepted APIs, not model/cluster E2E.
+const native = { metadata: { name: "native", namespace: "default" }, spec: { celln: { contractVersion: "celln.json-tools/v1", revision: "v1", lifecycle: "disposable-one-shot", publisherKey: "public" } } };
+const oci = { metadata: { name: "oci", namespace: "default" }, spec: { image: "example/oci:v1" } };
+const tools = ["uppercase", "length"].map((name) => ({ metadata: { name, namespace: "default" }, spec: { revision: "v1", description: `${name} fixture`, publisherKey: "public-publisher", invocationABI: "celln.json-stdio/v1", lane: "tool", limits: { timeoutMillis: 1000, memoryBytes: 1024, argumentBytes: 128, outputBytes: 128, workspace: "none", effects: "none" } } }));
+
+function openForm(runtime = "native", unavailable = false) {
+  cy.intercept("GET", "/api/v1/**", { body: [] });
+  cy.intercept("GET", "/api/v1/runs*", { body: [] });
+  cy.intercept("GET", "/api/v1/agents*", { body: [{ metadata: { name: "agent" }, spec: { runtimeRef: runtime, agents: { default: { model: "deepseek-chat" } } } }] });
+  cy.intercept("GET", "/api/v1/runtimes*", { body: [native, oci] });
+  cy.intercept("GET", "/api/v1/celln-tools*", unavailable ? { statusCode: 503, body: "unavailable" } : { body: tools });
+  cy.intercept("GET", "/api/v1/capabilities*", { body: { celln: { available: true, reason: "Node preflight only" } } });
+  cy.visit("/runs?create=1");
+  cy.get('[role="dialog"]').find('[role="combobox"]').eq(0).click();
+  cy.get('[role="option"]').contains("agent").click();
+  cy.get('textarea').type("Uppercase celln, then measure its length");
+  cy.get('[role="dialog"]').find('[role="combobox"]').eq(2).click();
+  cy.get('[role="option"]').contains("Celln —").click();
+}
+
+describe("Harness in Celln run selection", () => {
+  it("sends explicit ordered lending without an OCI runtime task override", () => {
+    openForm();
+    cy.contains("Selection readiness is not established").scrollIntoView().should("be.visible");
+    cy.contains("Uses whatever AI provider").should("not.exist");
+    cy.get('[data-testid="celln-harness-selection"]').contains("label", "uppercase@v1").find("input").check();
+    cy.get('[data-testid="celln-harness-selection"]').contains("label", "length@v1").find("input").check();
+    cy.intercept("POST", "/api/v1/runs*", (request) => {
+      expect(request.body.backend).to.eq("celln");
+      expect(request.body.provider).to.eq("deepseek");
+      expect(request.body.model).to.eq("deepseek-chat");
+      expect(request.body).not.to.have.property("runtimeRef");
+      expect(request.body.cellnSelection).to.deep.eq({ toolRefs: [{ name: "uppercase", revision: "v1" }, { name: "length", revision: "v1" }] });
+      request.reply({ statusCode: 201, body: { metadata: { name: "pending" } } });
+    }).as("create");
+    cy.contains("button", "Request catalogue run").click();
+    cy.wait("@create");
+  });
+
+  it("keeps an empty list explicit and does not lend the whole catalogue", () => {
+    openForm();
+    cy.intercept("POST", "/api/v1/runs*", (request) => {
+      expect(request.body.cellnSelection.toolRefs).to.deep.eq([]);
+      request.reply({ statusCode: 201, body: { metadata: { name: "empty" } } });
+    }).as("empty");
+    cy.contains("button", "Request catalogue run").click();
+    cy.wait("@empty");
+  });
+
+  it("blocks an OCI-only runtime instead of silently changing execution", () => {
+    openForm("oci");
+    cy.contains("does not declare the supported native JSON Celln contract").should("be.visible");
+    cy.contains("button", "Request catalogue run").should("be.disabled");
+  });
+
+  it("blocks when catalogue loading fails", () => {
+    openForm("native", true);
+    cy.contains("Cannot load the catalogue", { timeout: 15000 }).scrollIntoView().should("be.visible");
+    cy.contains("button", "Request catalogue run").should("be.disabled");
+  });
+
+  it("sends a one-run override inside catalogue selection, never as an OCI task", () => {
+    openForm("oci");
+    cy.get('[role="dialog"]').find('[role="combobox"]').eq(1).click();
+    cy.get('[role="option"]').contains("native").click();
+    cy.intercept("POST", "/api/v1/runs*", (request) => {
+      expect(request.body).not.to.have.property("runtimeRef");
+      expect(request.body.cellnSelection).to.deep.eq({ runtimeRef: "native", toolRefs: [] });
+      request.reply({ statusCode: 201, body: { metadata: { name: "override" } } });
+    }).as("override");
+    cy.contains("button", "Request catalogue run").click();
+    cy.wait("@override");
+  });
+});

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -69,6 +69,10 @@ export function useRuntimes() {
   return useQuery({ queryKey: ["runtimes"], queryFn: api.runtimes.list });
 }
 
+export function useCellnTools() {
+  return useQuery({ queryKey: ["celln-tools"], queryFn: api.cellnTools.list });
+}
+
 export function useInstallDefaultRuntimes() {
   const qc = useQueryClient();
   return useMutation({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,7 @@
 // ── Common K8s types ─────────────────────────────────────────────────────────
 
 export interface ObjectMeta {
+  uid?: string;
   name: string;
   namespace?: string;
   creationTimestamp?: string;
@@ -135,7 +136,8 @@ export interface Agent {
 export interface AgentRuntime {
   metadata: ObjectMeta;
   spec: {
-    image: string;
+    image?: string;
+    celln?: { contractVersion: string; revision: string; lifecycle: string; publisherKey: string };
     contractVersion?: string;
     capabilities?: string[];
     session?: {
@@ -153,6 +155,25 @@ export interface AgentRuntime {
     resolvedImageDigest?: string;
     conditions?: Condition[];
   };
+}
+
+export interface CellnSelection {
+  runtimeRef?: string;
+  toolRefs: { name: string; revision: string }[];
+}
+
+export interface CellnTool {
+  metadata: ObjectMeta;
+  spec: {
+    revision: string;
+    description: string;
+    supportOwner: string;
+    publisherKey: string;
+    invocationABI: string;
+    lane: string;
+    limits: { timeoutMillis: number; memoryBytes: number; argumentBytes: number; outputBytes: number; workspace: string; effects: string };
+  };
+  status?: { conditions?: Condition[] };
 }
 
 export interface HarnessSession {
@@ -232,6 +253,7 @@ export interface TaskModeSpec {
 export type AgentRunTask = string | TaskModeSpec;
 
 export interface AgentRunSpec {
+  cellnSelection?: CellnSelection;
   agentRef: string;
   agentId: string;
   sessionKey: string;
@@ -1310,6 +1332,8 @@ export const api = {
       timeout?: string;
       backend?: string;
       runtimeRef?: string;
+      provider?: string;
+      cellnSelection?: CellnSelection;
     }) =>
       apiFetch<AgentRun>("/api/v1/runs", {
         method: "POST",
@@ -1330,6 +1354,10 @@ export const api = {
       apiFetch<InstallDefaultRuntimesResponse>("/api/v1/runtimes/install-defaults", {
         method: "POST",
       }),
+  },
+
+  cellnTools: {
+    list: () => apiFetch<CellnTool[]>("/api/v1/celln-tools"),
   },
 
   harnessSessions: {

--- a/web/src/pages/harness-detail.tsx
+++ b/web/src/pages/harness-detail.tsx
@@ -35,7 +35,7 @@ export function HarnessDetailPage() {
         <Card>
           <CardHeader><CardTitle className="text-base">Artifact and contract</CardTitle></CardHeader>
           <CardContent className="space-y-4 text-sm">
-            <Field label="Approved image" value={runtime.spec.image} mono />
+            <Field label="Approved OCI image" value={runtime.spec.image || "No OCI image — native Celln profile"} mono />
             <Field label="Resolved immutable digest" value={runtime.status?.resolvedImageDigest || "Pending resolution"} mono />
             <Field label="Adapter contract" value={runtime.spec.contractVersion || "Not declared"} />
             <Field label="Support owner" value={runtime.spec.supportOwner || "Not declared"} />

--- a/web/src/pages/harnesses.tsx
+++ b/web/src/pages/harnesses.tsx
@@ -91,7 +91,7 @@ export function HarnessesPage() {
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-3 text-sm">
-                  <Field label="Executed image" value={runtime.status?.resolvedImageDigest || runtime.spec.image} mono />
+                  <Field label="OCI image" value={runtime.status?.resolvedImageDigest || runtime.spec.image || "No OCI image — native Celln profile"} mono />
                   <div className="grid grid-cols-2 gap-3">
                     <Field label="Contract" value={runtime.spec.contractVersion || "not declared"} />
                     <Field label="Support owner" value={runtime.spec.supportOwner || "not declared"} />

--- a/web/src/pages/run-detail.tsx
+++ b/web/src/pages/run-detail.tsx
@@ -234,6 +234,13 @@ export function RunDetailPage() {
         </div>
       )}
 
+      {run.spec.cellnSelection && <div className="space-y-2 rounded-lg border border-amber-500/30 p-3 text-sm" data-testid="catalogue-run-summary">
+        <p className="font-medium">Harness in Celln — catalogue request</p>
+        <p className="text-muted-foreground">Runtime: {run.spec.cellnSelection.runtimeRef || "Agent default (resolved by trusted issuance)"}</p>
+        <p className="text-muted-foreground">Borrowed tools: {run.spec.cellnSelection.toolRefs.map((ref) => `${ref.name}@${ref.revision}`).join(" → ") || "none"}</p>
+        <p>{run.status?.conditions?.find((condition) => condition.type === "CellnIssuanceCommitted")?.message || "Waiting for a catalogue issuance observation. A submitted request does not establish readiness."}</p>
+      </div>}
+
       {/* PostRunFailed condition */}
       {run.status?.conditions?.some(
         (c) => c.type === "PostRunFailed" && c.status === "True",

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -9,6 +9,7 @@ import {
   useGateVerdict,
   useCapabilities,
   useRuntimes,
+  useCellnTools,
 } from "@/hooks/use-api";
 import { StatusBadge } from "@/components/status-badge";
 import {
@@ -74,6 +75,8 @@ export function RunsPage() {
   const observability = useObservabilityMetrics();
   const capabilities = useCapabilities();
   const runtimes = useRuntimes();
+  const catalogue = useCellnTools();
+  const [lentTools, setLentTools] = useState<{ name: string; revision: string }[]>([]);
   const deleteRun = useDeleteRun();
   const createRun = useCreateRun();
   const gateVerdict = useGateVerdict();
@@ -91,6 +94,13 @@ export function RunsPage() {
     runtimeRef: "",
   });
   const selectedAgent = (instances.data || []).find((agent) => agent.metadata.name === form.agentRef);
+  const runtimeName = form.runtimeRef || selectedAgent?.spec.runtimeRef || "";
+  const selectedRuntime = (runtimes.data || []).find((runtime) => runtime.metadata.name === runtimeName);
+  const cellnHarness = form.backend === "celln" && !!runtimeName;
+  const compatibleHarness = selectedRuntime?.spec.celln?.contractVersion === "celln.json-tools/v1";
+  const staleTools = lentTools.some((ref) => !(catalogue.data || []).some((tool) => tool.metadata.name === ref.name && tool.spec.revision === ref.revision));
+  const blockedSelection = cellnHarness && (!compatibleHarness || !form.model.trim() || catalogue.isLoading || catalogue.isError || staleTools);
+  const jobIncompatible = form.backend === "job" && !!selectedRuntime?.spec.celln && !selectedRuntime.spec.image;
 
   useEffect(() => {
     if (searchParams.get("create") === "1") {
@@ -127,10 +137,15 @@ export function RunsPage() {
   const hasCellnRuns = sorted.some((r) => r.spec.backend === "celln");
 
   const handleCreate = () => {
-    createRun.mutate(form, {
+    if (blockedSelection || jobIncompatible) return;
+    const request = cellnHarness
+      ? { ...form, runtimeRef: undefined, provider: "deepseek", cellnSelection: { runtimeRef: form.runtimeRef || undefined, toolRefs: lentTools } }
+      : form;
+    createRun.mutate(request, {
       onSuccess: () => {
         setOpen(false);
         setForm({ agentRef: "", task: "", model: "", timeout: "5m", backend: "job", runtimeRef: "" });
+        setLentTools([]);
       },
     });
   };
@@ -153,7 +168,7 @@ export function RunsPage() {
               <Plus className="mr-2 h-4 w-4" /> New Run
             </Button>
           </DialogTrigger>
-          <DialogContent>
+          <DialogContent className="max-h-[90vh] overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Create Run</DialogTitle>
               <DialogDescription>
@@ -165,7 +180,7 @@ export function RunsPage() {
                 <Label>Instance</Label>
                 <Select
                   value={form.agentRef}
-                  onValueChange={(v) => setForm({ ...form, agentRef: v })}
+                  onValueChange={(v) => { setForm({ ...form, agentRef: v, runtimeRef: "" }); setLentTools([]); }}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select agent" />
@@ -195,7 +210,7 @@ export function RunsPage() {
                 <Label>One-run harness override (advanced)</Label>
                 <Select
                   value={form.runtimeRef || "inherit"}
-                  onValueChange={(v) => setForm({ ...form, runtimeRef: v === "inherit" ? "" : v })}
+                  onValueChange={(v) => { setForm({ ...form, runtimeRef: v === "inherit" ? "" : v }); setLentTools([]); }}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Use Agent default" />
@@ -215,13 +230,13 @@ export function RunsPage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Model (optional)</Label>
+                  <Label>{cellnHarness ? "Model (required — DeepSeek)" : "Model (optional)"}</Label>
                   <Input
                     value={form.model}
                     onChange={(e) =>
                       setForm({ ...form, model: e.target.value })
                     }
-                    placeholder="gpt-4o"
+                    placeholder={cellnHarness ? "deepseek-chat" : "gpt-4o"}
                   />
                 </div>
                 <div className="space-y-2">
@@ -239,7 +254,7 @@ export function RunsPage() {
                 <Label>Backend</Label>
                 <Select
                   value={form.backend}
-                  onValueChange={(v) => setForm({ ...form, backend: v })}
+                  onValueChange={(v) => { setForm({ ...form, backend: v, model: v === "celln" && !form.model ? "deepseek-chat" : form.model }); setLentTools([]); }}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Standard (Kubernetes Job)" />
@@ -249,6 +264,7 @@ export function RunsPage() {
                     <SelectItem value="celln">Celln — hermetic, hardware-isolated</SelectItem>
                   </SelectContent>
                 </Select>
+                {jobIncompatible && <p role="alert" className="text-xs text-red-400">This Harness has no OCI image for the Job backend. Select Celln or choose an OCI-compatible Harness.</p>}
                 {form.backend === "celln" && (
                   <>
                     <p className="text-xs text-muted-foreground mt-1">
@@ -256,10 +272,35 @@ export function RunsPage() {
                       No ensembles, delegation, shared memory, or streaming.
                       Best for single-shot high-risk or sensitive tasks.
                     </p>
-                    <p className="text-xs text-amber-500/80 mt-1">
+                    {!cellnHarness && <p className="text-xs text-amber-500/80 mt-1">
                       Uses whatever AI provider is configured on the KVM
                       host, not this run's Model field.
-                    </p>
+                    </p>}
+                    {cellnHarness && <div className="space-y-3 rounded-md border p-3" data-testid="celln-harness-selection">
+                      <p className="text-sm font-medium">Harness in Celln — {runtimeName}</p>
+                      {!compatibleHarness && <p role="alert" className="text-xs text-red-400">This Harness does not declare the supported native JSON Celln contract. No backend fallback will be used.</p>}
+                      <p className="text-xs text-muted-foreground">The model loop runs inside the cell. DeepSeek model access is independently approved by the host; Kubernetes model credentials are not used. One-shot tasks only; conversations are not supported yet.</p>
+                      <Label>Borrowed catalogue tools (optional, maximum 16)</Label>
+                      {catalogue.isLoading && <p className="text-xs">Loading catalogue…</p>}
+                      {catalogue.isError && <p role="alert" className="text-xs text-red-400">Cannot load the catalogue. Submission is disabled.</p>}
+                      {!catalogue.isLoading && !catalogue.isError && !(catalogue.data || []).length && <p className="text-xs">No reviewed tools in this namespace. An empty selection lends no tools.</p>}
+                      {(catalogue.data || []).map((tool) => {
+                        const checked = lentTools.some((ref) => ref.name === tool.metadata.name && ref.revision === tool.spec.revision);
+                        const supported = tool.spec.invocationABI === "celln.json-stdio/v1" && tool.spec.lane === "tool";
+                        return <label key={tool.metadata.uid || tool.metadata.name} className="block space-y-1 rounded border p-2 text-xs">
+                          <span className="flex items-center gap-2"><input type="checkbox" checked={checked} disabled={!compatibleHarness || !supported || (!checked && lentTools.length >= 16)} onChange={() => setLentTools(checked ? lentTools.filter((ref) => ref.name !== tool.metadata.name) : [...lentTools, { name: tool.metadata.name, revision: tool.spec.revision }])} />
+                            <span>{tool.metadata.name}@{tool.spec.revision}{!supported ? " — unsupported ABI/lane" : ""}</span></span>
+                          <span className="block text-muted-foreground">{tool.spec.description}</span>
+                          <span className="block text-muted-foreground">Support owner: {tool.spec.supportOwner}</span>
+                          <span className="block break-all text-muted-foreground">Publisher: {tool.spec.publisherKey}</span>
+                          <span className="block text-muted-foreground">Declared limits: {tool.spec.limits.timeoutMillis} ms · {tool.spec.limits.memoryBytes} bytes memory · workspace {tool.spec.limits.workspace} · effects {tool.spec.limits.effects}</span>
+                        </label>;
+                      })}
+                      <p className="text-xs">Lending order: {lentTools.map((ref) => `${ref.name}@${ref.revision}`).join(" → ") || "none"}</p>
+                      {staleTools && <p role="alert" className="text-xs text-red-400">The catalogue changed. Clear and reselect the borrowed tools before submitting.</p>}
+                      {!!lentTools.length && <Button type="button" variant="outline" size="sm" onClick={() => setLentTools([])}>Clear borrowed tools</Button>}
+                      <p className="text-xs text-amber-500">Selection readiness is not established. Catalogue metadata is not permission to run. This request waits for operator issuance, which checks the effective permissions and prepares the approved artifacts. No automatic provisioning yet.</p>
+                    </div>}
                     {capabilities.data && !capabilities.data.celln.available ? (
                       <p className="flex items-start gap-1 text-xs text-red-400 mt-1">
                         <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
@@ -284,10 +325,10 @@ export function RunsPage() {
                 className="w-full bg-primary hover:bg-primary/90 text-primary-foreground border-0"
                 onClick={handleCreate}
                 disabled={
-                  !form.agentRef || !form.task || createRun.isPending
+                  !form.agentRef || !form.task || createRun.isPending || blockedSelection || jobIncompatible
                 }
               >
-                {createRun.isPending ? "Creating…" : "Create Run"}
+                {createRun.isPending ? "Creating…" : cellnHarness ? "Request catalogue run" : "Create Run"}
               </Button>
             </div>
           </DialogContent>


### PR DESCRIPTION
## Outcome
Advances #426 using merged #457. New Run keeps Harness identity, backend placement and explicitly lent catalogue tools separate. Native Celln selections send an explicit DeepSeek model/provider and ordered cellnSelection, never a top-level OCI runtime override. Empty means no tools. Unsupported runtime/backend combinations and catalogue load failure block the request.

The form says Request catalogue run and explains that selection readiness is not established: automatic provisioning is still pending. Publisher/support-owner and declared limits are shown without claiming they are the effective grant intersection. Run details display the issuance observation. The legacy no-Harness host-forge path retains its separate model warning.

A namespace-scoped GET celln-tools endpoint and read-only apiserver RBAC support metadata listing; no tool approval or grant mutation is exposed.

## Validation
- Five Cypress/Electron UI contract tests passed using intercepted APIs and a public fixture token, with no cluster discovery or model calls.
- TypeScript and production Vite build passed.
- Full Go race suite with real NATS fixture, build and vet passed.
- Namespace/sort/empty-list/method tests and actual Helm read-only catalogue permission test passed.
- Evidence and updated UX guide included.

## Limits
Not live UI-to-model acceptance, automatic admission/distribution, effective-permission preflight, BYO submission/review UI or conversations. Existing lockfile audit reports 17 vulnerabilities; dependencies were not changed in this PR.