### PR TITLE
feat: automatically issue registered catalogue compositions

### DIFF
--- a/docs/evidence/celln-registered-auto-issuance-2026-09-08.json
+++ b/docs/evidence/celln-registered-auto-issuance-2026-09-08.json
@@ -1,0 +1,41 @@
+{
+  "status": "passed",
+  "scope": "automatic trusted issuance/execution of an operator-registered composition; not on-demand admission/distribution",
+  "liveProof": {
+    "context": "kind-celln-deployed",
+    "namespace": "celln-catalogue-proof-mwmr8",
+    "runUID": "4ab50ed7-933c-4600-9158-0766ee117ba4",
+    "action": "celln-0aa520b0b9068bee77bd686d933b57060674e46658b2ac3b2e1c7b7c036cd68e",
+    "closure": "blake3:2d297fff9688d2c3f95bc1801ffc41d52bf4c7a934dc51bee06fe708b2864aee",
+    "automaticRegisteredIssuance": true,
+    "issuanceCLIUsed": false,
+    "answer": "CELLN has length 5",
+    "tools": ["uppercase", "length"],
+    "brokerRequests": 3,
+    "jobs": 0,
+    "liveCells": 0,
+    "auditAndReceiptCorrelated": true,
+    "modelPolicyWithdrawn": true,
+    "hostReissuanceRefused": true,
+    "ownerReceiptRetained": true,
+    "proofNamespacesRemaining": 0,
+    "isolatedControllerRestoredReadyReplicas": 1,
+    "localEvidence": "target/celln-live-proof/catalogue-live-1459789282",
+    "agentrunSHA256": "1ddd04101bf07479b9de76ac5f3e557b009bb2250bdd4bb9dfc172eec1767bc4",
+    "auditSHA256": "d0c231057aa9b85f8b98471ac87feab880113c702744a6e0c309b41efa865896"
+  },
+  "portableChecks": [
+    "Full Go race suite with real NATS fixture available",
+    "Build and vet",
+    "Registered composition bounds, malformed hashes, ambiguity and configuration-copy validation",
+    "Missing/unmatched registration and admission refusal create no issuance",
+    "Lost Prepared acknowledgement, lost Issued acknowledgement and failed result commit recover using saved identity after registration removal",
+    "Controller config accepts explicit registrations and rejects invalid registration bounds"
+  ],
+  "limits": [
+    "Actual host processes and Kind API, not production pod deployment topology",
+    "Public fixture artifacts were composed/materialized before registration",
+    "No full browser-to-model acceptance or conversational lifecycle",
+    "Registration removal is not approval or fleet revocation"
+  ]
+}

--- a/docs/guides/celln-harness-selection-ux.md
+++ b/docs/guides/celln-harness-selection-ux.md
@@ -5,8 +5,9 @@ after the user's UI/YAML question. The approved experience has three distinct
 choices: Harness identity, execution placement, and explicitly borrowed tools.
 The [advanced JSON API](celln-json-harness.md) and the high-level AgentRun
 `cellnSelection` schema are implemented. Runs → New Run now supports initial
-catalogue selection. Automatic provisioning remains pending: a catalogue
-request waits for trusted issuance.
+catalogue selection. [Registered compositions](celln-registered-issuance.md) can
+receive automatic trusted issuance; unmatched selections wait for operator
+preparation. On-demand admission/distribution remains pending.
 
 ## Current run form
 
@@ -19,7 +20,8 @@ Incompatible runtimes and unavailable catalogues block the request. A native
 runtime without an OCI image cannot be submitted to the Job backend.
 
 The button says **Request catalogue run** because readiness is not established.
-The operator must still provision the selected artifacts and commit issuance.
+The operator must still prepare/register new compositions. For an exact
+registered composition, the controller can commit issuance automatically.
 Run details show the selected tools and the controller's issuance observation.
 Without a selected Harness, the existing Celln host-forge path retains its
 separate ambient-host-model warning. No Celln chat/session button is exposed.

--- a/docs/guides/celln-registered-issuance.md
+++ b/docs/guides/celln-registered-issuance.md
@@ -1,0 +1,65 @@
+# Automatic issuance for registered catalogue compositions
+
+The catalogue controller can issue a named `cellnSelection` without an operator
+invoking `issue-run` for every AgentRun. This works only for exact compositions
+already materialized and admitted on the configured host. It is not an automatic
+compositor, admission service or distribution system.
+
+Add `compositions` to the relevant Agent binding in `CELLN_CATALOGUE_CONFIG`:
+
+```json
+{
+  "compositions": [{
+    "sources": ["blake3:RUNTIME_SOURCE", "blake3:FIRST_TOOL_SOURCE", "blake3:SECOND_TOOL_SOURCE"],
+    "imageBytes": 33554432,
+    "artifacts": {
+      "mote": {"hash": "blake3:ADMITTED_MOTE"},
+      "closure": {"hash": "blake3:COMPOSED_CLOSURE"}
+    }
+  }]
+}
+```
+
+This is a binding fragment, not a complete config. Replace every placeholder
+with a full BLAKE3 identity. Source order must exactly match the composition
+plan, including the runtime source. The constructor rejects ambiguous duplicate
+sequences, malformed hashes, more than 128 entries per Agent, and image sizes
+outside 32–512 MiB or not 2 MiB aligned. Configuration is copied at startup;
+restart the controller after changes.
+
+## Authority and recovery
+
+The controller resolves the run's ordered same-namespace intent, checks current
+independent approvals and admission gates, and matches the registered source
+sequence. Registration supplies artifact locations, not authority: the issuer
+still verifies the signed composition, admitted mote, model policy and host
+credential mapping. No signing keys, host paths, grant-source configuration or
+router credentials come from the user's run.
+
+`Prepared` is saved before contacting the issuer. The verified result becomes
+`Issued`, then the existing pinned prewarm/submission lifecycle continues.
+Interrupted preparation resumes the saved request and route, without choosing
+another registration or regenerating identity. Current approval/admission
+checks still apply. Removing a registration prevents new preparation through
+that entry; it does not revoke a saved request or grant. Use independent policy
+and host withdrawal mechanisms for revocation, not registry edits. Saved
+Prepared requests remain recoverable after registration removal.
+
+An unmatched run remains unsubmitted with `CellnIssuanceCommitted=False`, reason
+`AwaitingRegisteredComposition`. Omitting registrations disables automatic
+initial issuance; the operator CLI remains available. Harness enablement and
+controller admission gates are required before issuance and submission.
+
+## Proof and limits
+
+Set `CELLN_LIVE_AUTOMATIC_ISSUANCE=1` when running the opt-in
+`test/integration/test-celln-catalogue-harness.sh`. The test creates a named
+selection and registers public fixture artifacts, skips the issuance CLI, and
+requires the actual controller to issue and execute through TLS issuer/router
+and KVM. It checks the real DeepSeek two-tool answer, audit/receipt correlation,
+cleanup and withdrawal refusal.
+
+This proves registered automatic issuance/execution. The fixture materializer
+is not production admission. On-demand packaging/distribution, selection-specific
+readiness, live browser-to-model, conversations and fleet qualification remain
+separate release gates.

--- a/internal/cellnreview/controller_config.go
+++ b/internal/cellnreview/controller_config.go
@@ -18,14 +18,15 @@ type ControllerEndpoint struct {
 	CAFile    string `json:"caFile,omitempty"`
 }
 type ControllerDispatchBinding struct {
-	Agent          types.NamespacedName `json:"agent"`
-	Issuer         ControllerEndpoint   `json:"issuer"`
-	Router         ControllerEndpoint   `json:"router"`
-	Backend        string               `json:"backend"`
-	OperatorSource types.NamespacedName `json:"operatorSource"`
-	RuntimeSource  types.NamespacedName `json:"runtimeSource"`
-	AgentSource    types.NamespacedName `json:"agentSource"`
-	ModelSource    types.NamespacedName `json:"modelSource"`
+	Compositions   []RegisteredComposition `json:"compositions,omitempty"`
+	Agent          types.NamespacedName    `json:"agent"`
+	Issuer         ControllerEndpoint      `json:"issuer"`
+	Router         ControllerEndpoint      `json:"router"`
+	Backend        string                  `json:"backend"`
+	OperatorSource types.NamespacedName    `json:"operatorSource"`
+	RuntimeSource  types.NamespacedName    `json:"runtimeSource"`
+	AgentSource    types.NamespacedName    `json:"agentSource"`
+	ModelSource    types.NamespacedName    `json:"modelSource"`
 }
 type ControllerDispatchConfig struct {
 	APIVersion string                      `json:"apiVersion"`
@@ -86,7 +87,7 @@ func LoadRunDispatcher(path string, writer client.Client, reader client.Reader) 
 			return nil, nil, err
 		}
 		closers = append(closers, router.CloseIdleConnections)
-		bindings[b.Agent] = RunDispatchBinding{Issuer: issuer, Router: router, Loader: cellnauthority.ModelLoader{Selection: cellnauthority.Loader{Reader: reader, OperatorSource: b.OperatorSource, RuntimeSource: b.RuntimeSource, AgentSource: b.AgentSource}, Source: b.ModelSource}}
+		bindings[b.Agent] = RunDispatchBinding{Issuer: issuer, Router: router, Compositions: b.Compositions, Loader: cellnauthority.ModelLoader{Selection: cellnauthority.Loader{Reader: reader, OperatorSource: b.OperatorSource, RuntimeSource: b.RuntimeSource, AgentSource: b.AgentSource}, Source: b.ModelSource}}
 	}
 	result, err := NewRunDispatcher(writer, reader, bindings)
 	if err != nil {

--- a/internal/cellnreview/controller_config_test.go
+++ b/internal/cellnreview/controller_config_test.go
@@ -10,11 +10,16 @@ import (
 )
 
 func TestLoadRunDispatcherConfig(t *testing.T) {
-	for _, mode := range []string{"valid", "version", "empty", "duplicate", "sources", "shared-token", "plaintext", "unknown", "trailing"} {
+	for _, mode := range []string{"valid", "registered", "invalid-registration", "version", "empty", "duplicate", "sources", "shared-token", "plaintext", "unknown", "trailing"} {
 		t.Run(mode, func(t *testing.T) {
 			f := provisionFixture(t)
 			config := ControllerDispatchConfig{APIVersion: "sympozium.ai/celln-catalogue-controller-v1", Bindings: []ControllerDispatchBinding{{Agent: types.NamespacedName{Namespace: "tenant", Name: "agent"}, Issuer: ControllerEndpoint{URL: "https://issuer.example", TokenFile: "/operator/issuer-token"}, Router: ControllerEndpoint{URL: "https://router.example", TokenFile: "/operator/router-token"}, Backend: "http://host-a:8787", OperatorSource: f.l.Selection.OperatorSource, RuntimeSource: f.l.Selection.RuntimeSource, AgentSource: f.l.Selection.AgentSource, ModelSource: f.l.Source}}}
 			switch mode {
+			case "registered", "invalid-registration":
+				config.Bindings[0].Compositions = []RegisteredComposition{{Sources: f.f.Prepared.Composition.Sources, ImageBytes: 33554432, Artifacts: f.artifacts}}
+				if mode == "invalid-registration" {
+					config.Bindings[0].Compositions[0].ImageBytes = 0
+				}
 			case "version":
 				config.APIVersion = "bad"
 			case "empty":
@@ -43,7 +48,7 @@ func TestLoadRunDispatcherConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 			d, close, err := LoadRunDispatcher(path, f.c, f.c)
-			if mode == "valid" {
+			if mode == "valid" || mode == "registered" {
 				if err != nil || d == nil || close == nil {
 					t.Fatalf("valid config refused: %v", err)
 				}

--- a/internal/cellnreview/registered_issuance.go
+++ b/internal/cellnreview/registered_issuance.go
@@ -1,0 +1,120 @@
+package cellnreview
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var ErrNoRegisteredComposition = errors.New("no operator-registered composition matches this selection")
+
+// RegisteredComposition locates already-materialized artifacts. Registration
+// neither admits them nor grants execution: the host issuer independently
+// verifies the exact signed composition, mote and current authority.
+type RegisteredComposition struct {
+	Sources    []string                          `json:"sources"`
+	ImageBytes int64                             `json:"imageBytes"`
+	Artifacts  cellnauthority.ExecutionArtifacts `json:"artifacts"`
+}
+
+func copyRegisteredCompositions(in []RegisteredComposition) ([]RegisteredComposition, error) {
+	if len(in) > 128 {
+		return nil, fmt.Errorf("at most 128 registered compositions per Agent")
+	}
+	out := make([]RegisteredComposition, len(in))
+	seen := map[string]bool{}
+	for i, r := range in {
+		if len(r.Sources) < 1 || len(r.Sources) > 17 || r.ImageBytes < 33554432 || r.ImageBytes > 536870912 || r.ImageBytes%2097152 != 0 || !artifactHash(r.Artifacts.Mote.Hash) || !artifactHash(r.Artifacts.Closure.Hash) {
+			return nil, fmt.Errorf("bounded exact registered artifacts and image size required")
+		}
+		for _, hash := range r.Sources {
+			if !artifactHash(hash) {
+				return nil, fmt.Errorf("registered source must be an exact closure hash")
+			}
+		}
+		key, _ := json.Marshal(r.Sources)
+		if seen[string(key)] {
+			return nil, fmt.Errorf("ambiguous registered source sequence")
+		}
+		seen[string(key)] = true
+		out[i] = r
+		out[i].Sources = append([]string(nil), r.Sources...)
+	}
+	return out, nil
+}
+
+// EnsureIssued automates only the existing durable issuance path for named
+// catalogue intent. It never composes, admits, distributes, prewarms or submits.
+// Once Prepared exists, retries use that exact saved seed/route, not a newly
+// selected registration. Removing a registration is not approval revocation.
+func (d *RunDispatcher) EnsureIssued(ctx context.Context, key types.NamespacedName, admit func(context.Context, *api.AgentRun) error) error {
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	var run api.AgentRun
+	if err := d.reader.Get(ctx, key, &run); err != nil {
+		return err
+	}
+	if run.Spec.CellnSelection == nil || run.Spec.Backend != "celln" || run.Spec.Celln != nil {
+		return fmt.Errorf("named catalogue intent required")
+	}
+	if err := provisionableRun(&run); err != nil {
+		return err
+	}
+	b, ok := d.bindings[types.NamespacedName{Namespace: key.Namespace, Name: run.Spec.AgentRef}]
+	if !ok {
+		return ErrNoRegisteredComposition
+	}
+	if run.Status.CellnIssuance == nil && len(b.Compositions) == 0 {
+		return ErrNoRegisteredComposition
+	}
+	if admit == nil {
+		return fmt.Errorf("controller admission checks required before issuance")
+	}
+	if err := admit(ctx, &run); err != nil {
+		return err
+	}
+	var seed *IssuerRequest
+	if run.Status.CellnIssuance == nil {
+		selected := make([]cellnauthority.Selection, 0, len(run.Spec.CellnSelection.ToolRefs))
+		for _, ref := range run.Spec.CellnSelection.ToolRefs {
+			selected = append(selected, cellnauthority.Selection{Name: ref.Name, Revision: ref.Revision})
+		}
+		frozen, err := b.Loader.Selection.FreezeRun(ctx, key, selected, 33554432)
+		if err != nil {
+			return err
+		}
+		var registration *RegisteredComposition
+		for i := range b.Compositions {
+			if slices.Equal(b.Compositions[i].Sources, frozen.Prepared.Composition.Sources) {
+				registration = &b.Compositions[i]
+				break
+			}
+		}
+		if registration == nil {
+			return ErrNoRegisteredComposition
+		}
+		if registration.ImageBytes != 33554432 {
+			frozen, err = b.Loader.Selection.FreezeRun(ctx, key, selected, registration.ImageBytes)
+			if err != nil {
+				return err
+			}
+			if !slices.Equal(registration.Sources, frozen.Prepared.Composition.Sources) {
+				return fmt.Errorf("selection changed during artifact resolution")
+			}
+		}
+		approval, err := b.Loader.Resolve(ctx, *frozen)
+		if err != nil {
+			return err
+		}
+		seed = &IssuerRequest{APIVersion: "sympozium.ai/celln-issuer-request-v1", Frozen: *frozen, Approval: *approval, Artifacts: registration.Artifacts}
+	}
+	_, err := b.Issuer.IssueForRun(ctx, d.writer, d.reader, key, b.Loader, seed)
+	return err
+}

--- a/internal/cellnreview/registered_issuance_test.go
+++ b/internal/cellnreview/registered_issuance_test.go
@@ -1,0 +1,144 @@
+package cellnreview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestRegisteredCompositionValidationAndCopy(t *testing.T) {
+	f := provisionFixture(t)
+	base := RegisteredComposition{Sources: f.f.Prepared.Composition.Sources, ImageBytes: 33554432, Artifacts: f.artifacts}
+	for _, mode := range []string{"valid", "empty-sources", "bad-source", "bad-mote", "small", "unaligned", "ambiguous"} {
+		r := base
+		r.Sources = append([]string(nil), base.Sources...)
+		switch mode {
+		case "empty-sources":
+			r.Sources = nil
+		case "bad-source":
+			r.Sources[0] = "bad"
+		case "bad-mote":
+			r.Artifacts.Mote.Hash = "bad"
+		case "small":
+			r.ImageBytes = 1
+		case "unaligned":
+			r.ImageBytes++
+		}
+		input := []RegisteredComposition{r}
+		if mode == "ambiguous" {
+			input = append(input, r)
+		}
+		out, err := copyRegisteredCompositions(input)
+		if mode != "valid" {
+			if err == nil {
+				t.Fatalf("accepted %s", mode)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		input[0].Sources[0] = "mutated"
+		if out[0].Sources[0] == "mutated" {
+			t.Fatal("configuration alias retained")
+		}
+	}
+}
+
+func TestRegisteredAutomaticIssuanceAndPreparedRecovery(t *testing.T) {
+	for _, mode := range []string{"issued", "missing", "unmatched", "gate", "prepared-ack", "result-ack", "result-before"} {
+		t.Run(mode, func(t *testing.T) {
+			f, m, _ := managedFixture(t)
+			ctx := context.Background()
+			key := types.NamespacedName{Namespace: f.f.Run.Namespace, Name: f.f.Run.Name}
+			var run api.AgentRun
+			if err := f.c.Get(ctx, key, &run); err != nil {
+				t.Fatal(err)
+			}
+			run.Spec.CellnSelection = &api.CellnCatalogueSelection{ToolRefs: []api.CellnCatalogueToolRef{}}
+			if err := f.c.Update(ctx, &run); err != nil {
+				t.Fatal(err)
+			}
+			endpoint, _, token := serveTestIssuer(t, m)
+			issuer, err := NewIssuerClient(IssuerClientOptions{URL: endpoint, TokenFile: token, CAFile: filepath.Join(filepath.Dir(token), "cert.pem"), Route: &DispatchRoute{RouterURL: "https://router.example", Backend: "http://host-a:8787"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer issuer.CloseIdleConnections()
+			router, err := NewRouterClient("https://router.example", "/never-read-auto-issuance-router-token", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer router.CloseIdleConnections()
+			registrations := []RegisteredComposition{{Sources: append([]string(nil), f.f.Prepared.Composition.Sources...), ImageBytes: 33554432, Artifacts: f.artifacts}}
+			if mode == "missing" {
+				registrations = nil
+			}
+			if mode == "unmatched" {
+				registrations[0].Sources[0] = "blake3:" + strings.Repeat("e", 64)
+			}
+			binding := RunDispatchBinding{Issuer: issuer, Router: router, Loader: f.l, Compositions: registrations}
+			bindings := map[types.NamespacedName]RunDispatchBinding{{Namespace: f.f.Snapshot.Agent.Namespace, Name: f.f.Snapshot.Agent.Name}: binding}
+			d, err := NewRunDispatcher(f.c, f.c, bindings)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "prepared-ack" {
+				d.writer = issuanceStatusFault{Client: f.c, phase: "Prepared", afterCommit: true}
+			}
+			if mode == "result-ack" || mode == "result-before" {
+				d.writer = issuanceStatusFault{Client: f.c, phase: "Issued", afterCommit: mode == "result-ack"}
+			}
+			admit := func(context.Context, *api.AgentRun) error {
+				if mode == "gate" {
+					return fmt.Errorf("gate refused")
+				}
+				return nil
+			}
+			err = d.EnsureIssued(ctx, key, admit)
+			if mode == "missing" || mode == "unmatched" || mode == "gate" {
+				if err == nil {
+					t.Fatal("unregistered/denied selection issued")
+				}
+				if mode != "gate" && !errors.Is(err, ErrNoRegisteredComposition) {
+					t.Fatal(err)
+				}
+				if err := f.c.Get(ctx, key, &run); err != nil {
+					t.Fatal(err)
+				}
+				if run.Status.CellnIssuance != nil {
+					t.Fatal("refusal prepared host work")
+				}
+				return
+			}
+			if mode != "issued" && err == nil {
+				t.Fatal("lost status acknowledgement was ignored")
+			}
+			if mode == "issued" && err != nil {
+				t.Fatal(err)
+			}
+			// Recreate the controller service with no registrations. Recovery
+			// must use durable history, never require a new artifact choice.
+			binding.Compositions = nil
+			d, err = NewRunDispatcher(f.c, f.c, map[types.NamespacedName]RunDispatchBinding{{Namespace: f.f.Snapshot.Agent.Namespace, Name: f.f.Snapshot.Agent.Name}: binding})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := d.EnsureIssued(ctx, key, admit); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.c.Get(ctx, key, &run); err != nil {
+				t.Fatal(err)
+			}
+			if run.Status.CellnIssuance == nil || run.Status.CellnIssuance.Phase != "Issued" || run.Status.CellnActionID != "" || run.Status.CellnRequest != "" || run.Status.StartedAt != nil {
+				t.Fatal("issuance was not durable or crossed into dispatch")
+			}
+		})
+	}
+}

--- a/internal/cellnreview/run_dispatcher.go
+++ b/internal/cellnreview/run_dispatcher.go
@@ -14,9 +14,10 @@ import (
 )
 
 type RunDispatchBinding struct {
-	Issuer *IssuerClient
-	Router *RouterClient
-	Loader cellnauthority.ModelLoader
+	Issuer       *IssuerClient
+	Router       *RouterClient
+	Loader       cellnauthority.ModelLoader
+	Compositions []RegisteredComposition
 }
 
 // RunDispatcher consumes durable catalogue issuance. Bindings are trusted
@@ -37,6 +38,11 @@ func NewRunDispatcher(writer client.Client, reader client.Reader, bindings map[t
 			return nil, fmt.Errorf("binding requires matching frozen route and separate issuer/router credentials")
 		}
 		b.Loader.Selection.Reader = reader
+		var err error
+		b.Compositions, err = copyRegisteredCompositions(b.Compositions)
+		if err != nil {
+			return nil, err
+		}
 		copy[key] = b
 	}
 	return &RunDispatcher{writer, reader, copy}, nil

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -686,8 +686,8 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		if agentRun.Spec.Backend != "celln" || agentRun.Spec.Celln != nil || !agentRun.Spec.Task.IsString() {
 			return ctrl.Result{}, r.failRun(ctx, agentRun, "Catalogue selection requires backend celln, a string task and no explicit artifacts")
 		}
-		if agentRun.Status.CellnIssuance == nil {
-			return r.awaitCatalogueIssuance(ctx, agentRun)
+		if agentRun.Status.CellnIssuance == nil || agentRun.Status.CellnIssuance.Phase == "Prepared" {
+			return r.awaitCatalogueIssuance(ctx, log, agentRun)
 		}
 	}
 	if agentRun.Spec.Backend == "celln" && agentRun.Status.CellnIssuance != nil {

--- a/internal/controller/celln_catalogue.go
+++ b/internal/controller/celln_catalogue.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,13 +28,35 @@ type CatalogueDispatcher interface {
 	Cancel(context.Context, types.NamespacedName) (*cellnreview.RouterExecution, error)
 }
 
+type catalogueProvisioner interface {
+	EnsureIssued(context.Context, types.NamespacedName, func(context.Context, *api.AgentRun) error) error
+}
+
 // A named catalogue request must never fall through to forge/explicit artifact
 // execution while an operator or provisioning controller prepares issuance.
-func (r *AgentRunReconciler) awaitCatalogueIssuance(ctx context.Context, run *api.AgentRun) (ctrl.Result, error) {
+func (r *AgentRunReconciler) awaitCatalogueIssuance(ctx context.Context, log logr.Logger, run *api.AgentRun) (ctrl.Result, error) {
 	condition := metav1.Condition{Type: "CellnIssuanceCommitted", Status: metav1.ConditionFalse, Reason: "AwaitingIssuance", Message: "Waiting for trusted catalogue issuance; no execution has been submitted", ObservedGeneration: run.Generation}
 	if r.CatalogueDispatcher == nil {
 		condition.Reason = "DispatcherNotConfigured"
 		condition.Message = "Catalogue controller binding is not configured; no execution has been submitted"
+	}
+	if provisioner, ok := r.CatalogueDispatcher.(catalogueProvisioner); ok {
+		if r.APIReader == nil {
+			return ctrl.Result{}, fmt.Errorf("uncached reader required for automatic catalogue issuance")
+		}
+		err := provisioner.EnsureIssued(ctx, client.ObjectKeyFromObject(run), func(ctx context.Context, current *api.AgentRun) error { return r.catalogueAdmission(ctx, log, current) })
+		if err == nil {
+			var current api.AgentRun
+			if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(run), &current); err != nil {
+				return ctrl.Result{}, err
+			}
+			return r.reconcilePendingCatalogue(ctx, log, &current)
+		}
+		if !errors.Is(err, cellnreview.ErrNoRegisteredComposition) {
+			return ctrl.Result{}, err
+		}
+		condition.Reason = "AwaitingRegisteredComposition"
+		condition.Message = "No operator-registered admitted composition matches these source closures; no execution has been submitted"
 	}
 	result := ctrl.Result{RequeueAfter: 5 * time.Second}
 	if existing := meta.FindStatusCondition(run.Status.Conditions, condition.Type); existing != nil && existing.Status == condition.Status && existing.Reason == condition.Reason && existing.Message == condition.Message && existing.ObservedGeneration == condition.ObservedGeneration {
@@ -46,6 +69,19 @@ func (r *AgentRunReconciler) awaitCatalogueIssuance(ctx context.Context, run *ap
 		meta.SetStatusCondition(&current.Status.Conditions, condition)
 	})
 	return result, err
+}
+
+func (r *AgentRunReconciler) catalogueAdmission(ctx context.Context, log logr.Logger, current *api.AgentRun) error {
+	if os.Getenv("CELLN_HARNESS_ENABLED") != "true" {
+		return fmt.Errorf("Celln Harness is disabled")
+	}
+	if err := r.validatePolicy(ctx, current); err != nil {
+		return err
+	}
+	if err := validateGateHooks(current); err != nil {
+		return err
+	}
+	return r.checkTokenBudget(ctx, log, current)
 }
 
 func catalogueRecord(record *cellnreview.RouterExecution) (executionRecord, error) {
@@ -70,16 +106,7 @@ func (r *AgentRunReconciler) reconcilePendingCatalogue(ctx context.Context, log 
 		return ctrl.Result{}, fmt.Errorf("Celln catalogue dispatcher and uncached reader are not configured")
 	}
 	record, err := r.CatalogueDispatcher.ReconcilePending(ctx, client.ObjectKeyFromObject(run), func(ctx context.Context, current *api.AgentRun) error {
-		if os.Getenv("CELLN_HARNESS_ENABLED") != "true" {
-			return fmt.Errorf("Celln Harness is disabled")
-		}
-		if err := r.validatePolicy(ctx, current); err != nil {
-			return err
-		}
-		if err := validateGateHooks(current); err != nil {
-			return err
-		}
-		return r.checkTokenBudget(ctx, log, current)
+		return r.catalogueAdmission(ctx, log, current)
 	})
 	if err != nil {
 		return ctrl.Result{}, err

--- a/test/integration/celln-catalogue-setup/live_test.go
+++ b/test/integration/celln-catalogue-setup/live_test.go
@@ -52,6 +52,7 @@ func TestLiveCatalogueHarness(t *testing.T) {
 	materializer := path("CELLN_ISSUANCE_MATERIALIZER")
 	packagePath := path("CELLN_HARNESS_PACKAGE")
 	cli := path("CELLN_LIVE_SYMPOZIUM_BINARY")
+	automatic := os.Getenv("CELLN_LIVE_AUTOMATIC_ISSUANCE") == "1"
 	controller := path("CELLN_LIVE_CONTROLLER_BINARY")
 	config, err := clientcmd.LoadFromFile(kube)
 	must(t, err)
@@ -167,18 +168,27 @@ func TestLiveCatalogueHarness(t *testing.T) {
 		IssuancePersisted    bool `json:"issuancePersisted"`
 		ControllerMayExecute bool `json:"controllerMayExecute"`
 	}
-	must(t, json.Unmarshal(command(t, ctx, nil, cli, args...), &issuedReport))
-	if !issuedReport.IssuancePersisted || !issuedReport.ControllerMayExecute {
-		t.Fatal("CLI did not acknowledge durable execution hand-off")
+	if !automatic {
+		must(t, json.Unmarshal(command(t, ctx, nil, cli, args...), &issuedReport))
+		if !issuedReport.IssuancePersisted || !issuedReport.ControllerMayExecute {
+			t.Fatal("CLI did not acknowledge durable execution hand-off")
+		}
 	}
 	var run api.AgentRun
 	key := types.NamespacedName{Namespace: ns.Name, Name: "run"}
 	must(t, c.Get(ctx, key, &run))
-	if run.Status.CellnIssuance == nil || run.Status.CellnIssuance.Phase != "Issued" || run.Status.CellnActionID != "" {
+	if !automatic && (run.Status.CellnIssuance == nil || run.Status.CellnIssuance.Phase != "Issued" || run.Status.CellnActionID != "") {
 		t.Fatal("issuance did not precede dispatch")
 	}
+	if automatic && run.Status.CellnIssuance != nil {
+		t.Fatal("automatic proof was manually issued")
+	}
 	configPath := filepath.Join(dir, "controller.json")
-	writeJSON(t, configPath, cellnreview.ControllerDispatchConfig{APIVersion: "sympozium.ai/celln-catalogue-controller-v1", Bindings: []cellnreview.ControllerDispatchBinding{{Agent: types.NamespacedName{Namespace: ns.Name, Name: "agent"}, Issuer: cellnreview.ControllerEndpoint{URL: issuerURL, TokenFile: issuerToken, CAFile: issuerCA}, Router: cellnreview.ControllerEndpoint{URL: router.URL, TokenFile: routerToken, CAFile: routerCA}, Backend: backend, OperatorSource: l.OperatorSource, RuntimeSource: l.RuntimeSource, AgentSource: l.AgentSource, ModelSource: ml.Source}}})
+	var registrations []cellnreview.RegisteredComposition
+	if automatic {
+		registrations = []cellnreview.RegisteredComposition{{Sources: frozen.Prepared.Composition.Sources, ImageBytes: frozen.Prepared.Composition.ImageBytes, Artifacts: artifacts}}
+	}
+	writeJSON(t, configPath, cellnreview.ControllerDispatchConfig{APIVersion: "sympozium.ai/celln-catalogue-controller-v1", Bindings: []cellnreview.ControllerDispatchBinding{{Compositions: registrations, Agent: types.NamespacedName{Namespace: ns.Name, Name: "agent"}, Issuer: cellnreview.ControllerEndpoint{URL: issuerURL, TokenFile: issuerToken, CAFile: issuerCA}, Router: cellnreview.ControllerEndpoint{URL: router.URL, TokenFile: routerToken, CAFile: routerCA}, Backend: backend, OperatorSource: l.OperatorSource, RuntimeSource: l.RuntimeSource, AgentSource: l.AgentSource, ModelSource: ml.Source}}})
 	env := cleanControllerEnv(kube, configPath)
 	startProcess(t, ctx, env, controller, "--metrics-bind-address=0", "--health-probe-bind-address=0", "--max-run-history=100")
 	// Registered after the controller process cleanup: remove the run while
@@ -216,6 +226,9 @@ func TestLiveCatalogueHarness(t *testing.T) {
 		t.Fatalf("catalogue run did not succeed: phase=%s error=%s", run.Status.Phase, run.Status.Error)
 	}
 	validateLiveResult(t, run)
+	if run.Status.CellnIssuance == nil || run.Status.CellnIssuance.Phase != "Issued" {
+		t.Fatal("terminal run lacks committed issuance")
+	}
 	var jobs batchv1.JobList
 	must(t, c.List(ctx, &jobs, client.InNamespace(ns.Name)))
 	if len(jobs.Items) != 0 {
@@ -299,8 +312,8 @@ func TestLiveCatalogueHarness(t *testing.T) {
 			t.Fatal("owner receipt changed after withdrawal")
 		}
 	}
-	writeJSON(t, filepath.Join(evidence, "summary.json"), map[string]any{"status": "passed", "scope": "actual host CLI/controller/issuer/router/KVM with isolated Kind API and real DeepSeek; not deployed pod topology or production admission", "namespace": ns.Name, "runUID": run.UID, "action": run.Status.CellnActionID, "closure": composition.Closure, "brokerRequests": 3, "toolCalls": 2, "jobs": 0, "liveCells": 0, "modelPolicyWithdrawn": true, "hostReissuanceRefused": true, "ownerReceiptRetained": true})
-	t.Logf("PASS actual Kind catalogue -> signed composition -> TLS issuer -> issue-run CLI durable status -> configured controller -> TLS pinned router -> KVM -> DeepSeek uppercase and length -> terminal receipt -> model-policy withdrawal -> retained owner receipt; namespace=%s runUID=%s action=%s closure=%s", ns.Name, run.UID, run.Status.CellnActionID, composition.Closure)
+	writeJSON(t, filepath.Join(evidence, "summary.json"), map[string]any{"status": "passed", "scope": "actual host controller/issuer/router/KVM with isolated Kind API and real DeepSeek; not deployed pod topology or production admission", "automaticRegisteredIssuance": automatic, "issuanceCLIUsed": !automatic, "namespace": ns.Name, "runUID": run.UID, "action": run.Status.CellnActionID, "closure": composition.Closure, "brokerRequests": 3, "toolCalls": 2, "jobs": 0, "liveCells": 0, "modelPolicyWithdrawn": true, "hostReissuanceRefused": true, "ownerReceiptRetained": true})
+	t.Logf("PASS actual Kind named catalogue -> signed composition -> TLS issuer -> durable status -> configured controller -> TLS pinned router -> KVM -> DeepSeek uppercase and length -> terminal receipt -> model-policy withdrawal -> retained owner receipt; automaticRegisteredIssuance=%t namespace=%s runUID=%s action=%s closure=%s", automatic, ns.Name, run.UID, run.Status.CellnActionID, composition.Closure)
 }
 
 func sameJSON(a, b []byte) bool {

--- a/test/integration/celln-catalogue-setup/main.go
+++ b/test/integration/celln-catalogue-setup/main.go
@@ -172,6 +172,10 @@ func populate(ctx context.Context, c client.Client, namespace string, source cat
 		return nil, err
 	}
 	run.Namespace, run.Name = namespace, "run"
+	run.Spec.CellnSelection = &api.CellnCatalogueSelection{ToolRefs: []api.CellnCatalogueToolRef{}}
+	for _, ref := range selected {
+		run.Spec.CellnSelection.ToolRefs = append(run.Spec.CellnSelection.ToolRefs, api.CellnCatalogueToolRef{Name: ref.Name, Revision: ref.Revision})
+	}
 	if err := c.Create(ctx, &run); err != nil {
 		return nil, err
 	}

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -299,7 +299,7 @@ export function RunsPage() {
                       <p className="text-xs">Lending order: {lentTools.map((ref) => `${ref.name}@${ref.revision}`).join(" → ") || "none"}</p>
                       {staleTools && <p role="alert" className="text-xs text-red-400">The catalogue changed. Clear and reselect the borrowed tools before submitting.</p>}
                       {!!lentTools.length && <Button type="button" variant="outline" size="sm" onClick={() => setLentTools([])}>Clear borrowed tools</Button>}
-                      <p className="text-xs text-amber-500">Selection readiness is not established. Catalogue metadata is not permission to run. This request waits for operator issuance, which checks the effective permissions and prepares the approved artifacts. No automatic provisioning yet.</p>
+                      <p className="text-xs text-amber-500">Selection readiness is not established. Catalogue metadata is not permission to run. Registered compositions can receive trusted issuance automatically; new combinations require operator preparation. Current approvals and effective permissions are checked before execution.</p>
                     </div>}
                     {capabilities.data && !capabilities.data.celln.available ? (
                       <p className="flex items-start gap-1 text-xs text-red-400 mt-1">


### PR DESCRIPTION
## Outcome
Advances #426: a named cellnSelection can now be issued and executed by the controller without a per-run operator issuance command, provided its exact ordered source closures match an operator-registered, already-materialized composition.

Registration is artifact lookup, not authority or readiness. The host issuer independently checks signed sources, admitted mote and current model authority. Prepared is persisted before the host call; interrupted issuance resumes its saved seed/route rather than choosing a new registration. Missing registrations remain waiting. Removing a registration is not revocation of saved work.

## Evidence
Actual isolated Kind named selection → controller automatic durable issuance → TLS issuer/router → real KVM → DeepSeek uppercase and length → CELLN has length 5. The issuance CLI was deliberately not invoked. Three model requests, correlated audit/receipt, zero Jobs/live cells, model-policy withdrawal, refused host reissuance and retained owner receipt all passed. Temporary namespace removed and isolated controller restored to 1/1; Framework untouched.

## Checks
Full Go race suite with real NATS fixture, build/vet and web build passed. Unit tests cover registration bounds/copy/ambiguity, missing/unmatched registrations, admission refusal and lost Prepared/Issued acknowledgements including recovery after registration removal. Evidence and operator guide included.

## Remaining scope
This is automatic issuance for registered artifacts, not on-demand composition/admission/distribution. The live proof uses real host processes and a public fixture materializer, not production pod topology or live browser submission. Full readiness, conversations, fleet and release gates remain open.