### PR TITLE
test(celln): prove HTTP-created automatic catalogue execution

### DIFF
--- a/docs/evidence/celln-http-auto-issuance-2026-09-08.json
+++ b/docs/evidence/celln-http-auto-issuance-2026-09-08.json
@@ -1,0 +1,32 @@
+{
+  "status": "passed",
+  "date": "2026-09-08",
+  "scope": "Actual HTTP handler with real isolated Kind API, automatic registered issuance, actual host controller/issuer/router and KVM, real DeepSeek",
+  "sourceBase": "6ebfde6c622bc08cc040d7377e65a072c4501466",
+  "sourceChanges": "HTTP submission variant committed alongside this evidence; subsequent extra logging does not change execution",
+  "command": "test/integration/test-celln-catalogue-harness.sh with CELLN_LIVE_AUTOMATIC_ISSUANCE=1 and CELLN_LIVE_HTTP_SUBMISSION=1 plus explicit isolated fixture and credential paths",
+  "durationSeconds": 38.43,
+  "namespace": "celln-catalogue-proof-gtc6h",
+  "runUID": "45fab0cb-5116-4b68-9699-a78cc456664a",
+  "action": "celln-339046c21ea831787e07da95f3bc982f9d64f8d5f8e30fc11e9823968db74abd",
+  "closure": "blake3:4253cf9a68aab5b0ade27a7444a4b294f489ebd07696e7bb5ce2817876ea5fa6",
+  "httpCreatedRunSHA256": "6c0e907afb6725e28d844548023992161a0370d51095e23ba39fec30c695e926",
+  "terminalRunSHA256": "3560f2cf3aa62b87346f5a193f4ad3440df7d5741582d29e252ee3151861ac0c",
+  "auditSHA256": "f0aa2e9294fb25b300714cfa9899b025f050ad617d2be2c4550a14e8af4f6696",
+  "manualIssuance": false,
+  "httpRunPatched": false,
+  "modelRequests": 3,
+  "toolCalls": ["uppercase", "length"],
+  "answer": "CELLN has length 5",
+  "jobs": 0,
+  "liveCellsAfterCompletion": 0,
+  "modelPolicyWithdrawalAndHostReissuanceRefusal": true,
+  "ownerReceiptRetained": true,
+  "proofControllerRestored": true,
+  "limitations": [
+    "Loopback test HTTP server without API authentication; not deployed auth or browser proof",
+    "Public fixture materializer and registered artifacts, not production on-demand admission/distribution",
+    "One-shot native JSON Harness, not conversations or arbitrary OCI Harness compatibility",
+    "No fleet/release qualification claim"
+  ]
+}

--- a/docs/guides/celln-registered-issuance.md
+++ b/docs/guides/celln-registered-issuance.md
@@ -52,6 +52,14 @@ controller admission gates are required before issuance and submission.
 
 ## Proof and limits
 
+Set `CELLN_LIVE_HTTP_SUBMISSION=1` as well to create the execution run through
+the actual HTTP API handler backed by the isolated Kubernetes API. This variant
+replaces the unissued setup run before starting the controller and freezes the
+new persisted identity/spec without patching the API output. It records
+`http-created-run.json`. The loopback test server deliberately has no API auth;
+this proves HTTP request translation and automatic execution, not browser,
+deployed authentication, or production topology acceptance.
+
 Set `CELLN_LIVE_AUTOMATIC_ISSUANCE=1` when running the opt-in
 `test/integration/test-celln-catalogue-harness.sh`. The test creates a named
 selection and registers public fixture artifacts, skips the issuance CLI, and

--- a/test/integration/celln-catalogue-setup/live_test.go
+++ b/test/integration/celln-catalogue-setup/live_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/json"
@@ -20,7 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/apiserver"
 	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
 	"github.com/sympozium-ai/sympozium/internal/cellnreview"
 	appsv1 "k8s.io/api/apps/v1"
@@ -53,6 +56,10 @@ func TestLiveCatalogueHarness(t *testing.T) {
 	packagePath := path("CELLN_HARNESS_PACKAGE")
 	cli := path("CELLN_LIVE_SYMPOZIUM_BINARY")
 	automatic := os.Getenv("CELLN_LIVE_AUTOMATIC_ISSUANCE") == "1"
+	httpSubmission := os.Getenv("CELLN_LIVE_HTTP_SUBMISSION") == "1"
+	if httpSubmission && !automatic {
+		t.Fatal("HTTP submission requires automatic issuance")
+	}
 	controller := path("CELLN_LIVE_CONTROLLER_BINARY")
 	config, err := clientcmd.LoadFromFile(kube)
 	must(t, err)
@@ -125,6 +132,49 @@ func TestLiveCatalogueHarness(t *testing.T) {
 	must(t, err)
 	frozen := report["frozen"].(*cellnauthority.FrozenSelection)
 	l := cellnauthority.Loader{Reader: c, OperatorSource: types.NamespacedName{Namespace: ns.Name, Name: "operator"}, RuntimeSource: types.NamespacedName{Namespace: ns.Name, Name: "runtime"}, AgentSource: types.NamespacedName{Namespace: ns.Name, Name: "agent"}}
+	runName := "run"
+	if httpSubmission {
+		// The setup run has never been issued and the controller is stopped.
+		// Replace it with a run created by the actual HTTP handler, then freeze
+		// that persisted UID/spec. Do not patch HTTP output to fit the fixture.
+		var setup api.AgentRun
+		must(t, c.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: runName}, &setup))
+		if setup.Status.CellnIssuance != nil || setup.Status.CellnActionID != "" || len(setup.Finalizers) != 0 {
+			t.Fatal("setup run unexpectedly active")
+		}
+		uid := setup.UID
+		must(t, c.Delete(ctx, &setup, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}))
+		// Loopback-only test HTTP server; this is not a deployment/auth proof.
+		server := httptest.NewServer(apiserver.NewServer(c, nil, nil, logr.Discard()).Handler(nil))
+		t.Cleanup(server.Close)
+		body, err := json.Marshal(apiserver.CreateRunRequest{AgentRef: setup.Spec.AgentRef, Task: setup.Spec.Task.GetPrompt(), Model: "deepseek-chat", Provider: "deepseek", Backend: "celln", Timeout: "180s", CellnSelection: setup.Spec.CellnSelection})
+		must(t, err)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/api/v1/runs?namespace="+url.QueryEscape(ns.Name), bytes.NewReader(body))
+		must(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		response, err := server.Client().Do(req)
+		must(t, err)
+		raw, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+		response.Body.Close()
+		must(t, err)
+		if response.StatusCode != http.StatusCreated {
+			t.Fatalf("HTTP create failed: %d %s", response.StatusCode, raw)
+		}
+		var created api.AgentRun
+		must(t, json.Unmarshal(raw, &created))
+		if created.Namespace != ns.Name || created.UID == "" || created.UID == uid || created.Name == "" {
+			t.Fatal("HTTP did not return a new persisted run")
+		}
+		runName = created.Name
+		selected := make([]cellnauthority.Selection, 0, len(setup.Spec.CellnSelection.ToolRefs))
+		for _, ref := range setup.Spec.CellnSelection.ToolRefs {
+			selected = append(selected, cellnauthority.Selection{Name: ref.Name, Revision: ref.Revision})
+		}
+		frozen, err = l.FreezeRun(ctx, client.ObjectKeyFromObject(&created), selected, 33554432)
+		must(t, err)
+		writeJSON(t, filepath.Join(evidence, "http-created-run.json"), created)
+		t.Logf("actual HTTP submission persisted run %s/%s UID=%s; no Kubernetes patch applied", created.Namespace, created.Name, created.UID)
+	}
 	ml := cellnauthority.ModelLoader{Selection: l, Source: types.NamespacedName{Namespace: ns.Name, Name: "model"}}
 	o := cellnreview.ComposeOptions{Binary: binary, PolicyRoot: root, KeyFile: filepath.Join(root, "public-fixture-seed"), OutputDir: filepath.Join(dir, "composed")}
 	composition, err := cellnreview.Compose(ctx, l, *frozen, o)
@@ -175,7 +225,7 @@ func TestLiveCatalogueHarness(t *testing.T) {
 		}
 	}
 	var run api.AgentRun
-	key := types.NamespacedName{Namespace: ns.Name, Name: "run"}
+	key := types.NamespacedName{Namespace: ns.Name, Name: runName}
 	must(t, c.Get(ctx, key, &run))
 	if !automatic && (run.Status.CellnIssuance == nil || run.Status.CellnIssuance.Phase != "Issued" || run.Status.CellnActionID != "") {
 		t.Fatal("issuance did not precede dispatch")
@@ -196,7 +246,7 @@ func TestLiveCatalogueHarness(t *testing.T) {
 	t.Cleanup(func() {
 		cleanup, stop := context.WithTimeout(context.Background(), 50*time.Second)
 		defer stop()
-		if err := c.Delete(cleanup, &api.AgentRun{ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: "run"}}); client.IgnoreNotFound(err) != nil {
+		if err := c.Delete(cleanup, &api.AgentRun{ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: runName}}); client.IgnoreNotFound(err) != nil {
 			t.Errorf("run cleanup: %v", err)
 			return
 		}


### PR DESCRIPTION
Advances #426. Adds an opt-in live HTTP submission variant to the isolated catalogue proof: actual API handler with real Kind client, persisted generated run identity, automatic registered issuance, actual controller/TLS issuer/pinned router/KVM and real DeepSeek two-tool execution. No patching the HTTP-created run or manual issuance. Committed evidence records successful execution, cleanup, policy withdrawal/refusal, retained receipt and controller restoration. Portable package tests and focused cellnreview/controller/apiserver race suites passed. Live proof passed in 38.43s (three model requests). Explicit limits: unauthenticated loopback test HTTP server, not browser/deployed topology, production admission/distribution or conversations.