### PR TITLE
feat(celln): show effective tool permissions without claiming readiness

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -111,6 +111,12 @@ func main() {
 	}
 
 	server := apiserver.NewServer(k8sClient.GetClient(), bus, kubeClient, log.WithName("apiserver"))
+	if path := os.Getenv("CELLN_PERMISSION_PREVIEW_CONFIG"); path != "" {
+		if err := server.LoadCellnPreview(path, k8sClient.GetAPIReader()); err != nil {
+			log.Error(err, "invalid Celln permission preview configuration")
+			os.Exit(1)
+		}
+	}
 
 	// Start llmfit density poller for fitness API endpoints.
 	{

--- a/docs/evidence/celln-permission-preview-2026-09-08.json
+++ b/docs/evidence/celln-permission-preview-2026-09-08.json
@@ -1,0 +1,21 @@
+{
+  "status": "passed",
+  "sourceBase": "356ca5a",
+  "sourceChanges": "permission preview implementation and live browser assertions committed alongside this evidence",
+  "scope": "Actual browser displays trusted grant intersection, then actual automatic controller/KVM/DeepSeek execution returns rendered result",
+  "durationSeconds": 45.27,
+  "namespace": "celln-catalogue-proof-w4gxx",
+  "runUID": "a9394627-6771-46bc-a182-e3a8253205cc",
+  "action": "celln-05f9244eebf2537c5a6bd4baf340085c3042e749d63ab6248571cb006d288581",
+  "closure": "blake3:a8b61214f9ec4bda37fdbce1fcc48d33a444a7e21f2b912ca4c8a199b244fc2b",
+  "modelRequests": 3,
+  "toolCalls": ["uppercase", "length"],
+  "visibleAnswer": "CELLN has length 5",
+  "jobs": 0,
+  "liveCellsAfterCompletion": 0,
+  "modelPolicyWithdrawalAndReissuanceRefusal": true,
+  "ownerReceiptRetained": true,
+  "proofControllerRestored": true,
+  "portableTests": "narrower grant intersection/shared memory cap, immediate withdrawal refusal, empty lending, invalid/duplicate/cross-namespace refs, strict bounded configuration and caller authority injection refusal",
+  "limitations": ["Loopback API without deployed authentication or WebSocket streaming", "No model authority or host readiness claim from preview", "Pre-registered fixture artifacts, not production on-demand admission/distribution", "No conversations/fleet/release qualification claim"]
+}

--- a/docs/guides/celln-permission-preview.md
+++ b/docs/guides/celln-permission-preview.md
@@ -1,0 +1,63 @@
+# Celln tool permission preview
+
+The run dialog displays the current intersection of the tool declaration and
+the operator, runtime and Agent grant layers. It preserves ordered explicit
+lending, supports the one-run runtime override, and shows the shared cell
+memory ceiling after tool limits are applied. No selected tools means none lent.
+
+This is **not readiness or execution authorization**. It does not resolve model
+authority, validate host artifacts, prewarm, reserve capacity, issue a grant or
+submit a run. All execution-time checks still run. The observation refreshes
+every ten seconds while the panel is mounted; errors hide prior permissions.
+The preview is not a Kubernetes transaction or a lease.
+
+## Administrator configuration
+
+Set `CELLN_PERMISSION_PREVIEW_CONFIG` on the API server to an absolute path to
+an operator-owned JSON file with this structure (example names only):
+
+```json
+{
+  "apiVersion": "sympozium.ai/celln-permission-preview-v1",
+  "bindings": [{
+    "agent": {"namespace": "tenant", "name": "agent"},
+    "operatorSource": {"namespace": "authority", "name": "operator-grants"},
+    "runtimeSource": {"namespace": "authority", "name": "runtime-grants"},
+    "agentSource": {"namespace": "authority", "name": "agent-grants"}
+  }]
+}
+```
+
+Use the same trusted grant locations as the catalogue controller. The preview
+configuration intentionally contains no issuer/router credential or host path.
+The API server uses its uncached Kubernetes reader. Grant ConfigMaps must deny
+tenant writes; naming or labelling a ConfigMap cannot establish ownership.
+Provide narrowly scoped read access to these sources using deployment RBAC.
+Do not grant approval writes to enable preview. No new Helm mount is implicit:
+mount this operator-owned file and set the environment variable explicitly.
+Restart the API server to change its source bindings. Grant document changes
+are observed on subsequent requests without restart.
+
+Malformed startup configuration refuses startup. An absent Agent binding gives
+503; unresolved, withdrawn or stale permissions give 422, without exposing
+privileged source names or document contents. The UI still allows requesting a
+run when preview is unavailable: the independent controller/issuer must approve
+it, and preview availability must never become an alternate admission bypass.
+
+## HTTP and YAML
+
+`POST /api/v1/celln-selection/preview?namespace=tenant` accepts only:
+
+```json
+{"agentRef":"agent","cellnSelection":{"toolRefs":[{"name":"uppercase","revision":"v1"}]}}
+```
+
+Optional `cellnSelection.runtimeRef` is a same-namespace override. An explicit
+empty `toolRefs: []` lends nothing. Omitted lists, duplicate names, oversized
+requests and caller-supplied authority locations refuse. Successful responses
+have `Cache-Control: no-store`, effective limits and frozen subject identities,
+`executionAuthorized: false`, and `readiness: "not-established"`.
+
+YAML AgentRuns retain the same `spec.cellnSelection` fields. A YAML author can
+preview those fields with this read-only HTTP operation, but cannot attach a
+preview result as an authority token. The operation creates no Kubernetes object.

--- a/internal/apiserver/celln_preview.go
+++ b/internal/apiserver/celln_preview.go
@@ -1,0 +1,106 @@
+package apiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CellnPreviewBinding struct {
+	Agent          types.NamespacedName `json:"agent"`
+	OperatorSource types.NamespacedName `json:"operatorSource"`
+	RuntimeSource  types.NamespacedName `json:"runtimeSource"`
+	AgentSource    types.NamespacedName `json:"agentSource"`
+}
+
+// ConfigureCellnPreview must run before serving. Configuration is operator-owned
+// and contains only grant locations, never issuer/router credentials. Reader
+// must be uncached. No source locations may be supplied by an HTTP caller.
+func (s *Server) ConfigureCellnPreview(reader client.Reader, bindings []CellnPreviewBinding) error {
+	if reader == nil || len(bindings) == 0 || len(bindings) > 1024 {
+		return fmt.Errorf("reader and bounded preview bindings required")
+	}
+	configured := map[types.NamespacedName]cellnauthority.Loader{}
+	for _, b := range bindings {
+		if b.Agent.Namespace == "" || b.Agent.Name == "" {
+			return fmt.Errorf("namespaced Agent required")
+		}
+		if _, exists := configured[b.Agent]; exists {
+			return fmt.Errorf("duplicate Agent binding")
+		}
+		seen := map[types.NamespacedName]bool{}
+		for _, ref := range []types.NamespacedName{b.OperatorSource, b.RuntimeSource, b.AgentSource} {
+			if ref.Namespace == "" || ref.Name == "" || seen[ref] {
+				return fmt.Errorf("three distinct configured sources required")
+			}
+			seen[ref] = true
+		}
+		configured[b.Agent] = cellnauthority.Loader{Reader: reader, OperatorSource: b.OperatorSource, RuntimeSource: b.RuntimeSource, AgentSource: b.AgentSource}
+	}
+	s.cellnPreview = configured
+	return nil
+}
+
+func (s *Server) LoadCellnPreview(path string, reader client.Reader) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("absolute preview configuration path required")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	raw, err := io.ReadAll(io.LimitReader(f, (1<<20)+1))
+	if err != nil || len(raw) > 1<<20 {
+		return fmt.Errorf("preview configuration unreadable or oversized")
+	}
+	var config struct {
+		APIVersion string                `json:"apiVersion"`
+		Bindings   []CellnPreviewBinding `json:"bindings"`
+	}
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if d.Decode(&config) != nil || d.Decode(new(any)) != io.EOF || config.APIVersion != "sympozium.ai/celln-permission-preview-v1" {
+		return fmt.Errorf("invalid preview configuration")
+	}
+	return s.ConfigureCellnPreview(reader, config.Bindings)
+}
+
+func (s *Server) previewCellnSelection(w http.ResponseWriter, r *http.Request) {
+	ns := r.URL.Query().Get("namespace")
+	if ns == "" {
+		ns = "default"
+	}
+	var req struct {
+		AgentRef  string                      `json:"agentRef"`
+		Selection api.CellnCatalogueSelection `json:"cellnSelection"`
+	}
+	d := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8192))
+	d.DisallowUnknownFields()
+	if d.Decode(&req) != nil || d.Decode(new(any)) != io.EOF || req.AgentRef == "" {
+		http.Error(w, "bounded explicit catalogue selection required", http.StatusBadRequest)
+		return
+	}
+	l, ok := s.cellnPreview[types.NamespacedName{Namespace: ns, Name: req.AgentRef}]
+	if !ok {
+		http.Error(w, "Permission preview is not configured for this Agent; readiness is not established", http.StatusServiceUnavailable)
+		return
+	}
+	preview, err := l.Preview(r.Context(), types.NamespacedName{Namespace: ns, Name: req.AgentRef}, req.Selection)
+	if err != nil {
+		// Do not expose privileged ConfigMap names/contents or other bindings.
+		http.Error(w, "Selection permissions could not be resolved from current approvals; no execution authorized", http.StatusUnprocessableEntity)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, preview)
+}

--- a/internal/apiserver/celln_preview_test.go
+++ b/internal/apiserver/celln_preview_test.go
@@ -1,0 +1,62 @@
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPreviewEndpointRefusesUnconfiguredOrCallerAuthority(t *testing.T) {
+	s := NewServer(nil, nil, nil, logr.Discard())
+	for _, tc := range []struct {
+		body string
+		code int
+	}{
+		{`{"agentRef":"agent","cellnSelection":{"toolRefs":[]}}`, 503},
+		{`{"agentRef":"agent","operatorSource":{"name":"mine"},"cellnSelection":{"toolRefs":[]}}`, 400},
+		{`{"agentRef":"agent","cellnSelection":{"toolRefs":[]}} {}`, 400},
+		{strings.Repeat("x", 8193), 400},
+	} {
+		r := httptest.NewRecorder()
+		s.Handler(nil).ServeHTTP(r, httptest.NewRequest(http.MethodPost, "/api/v1/celln-selection/preview", strings.NewReader(tc.body)))
+		if r.Code != tc.code {
+			t.Fatalf("status %d want %d", r.Code, tc.code)
+		}
+	}
+}
+
+func TestPreviewConfigurationStrictAndBounded(t *testing.T) {
+	s := NewServer(nil, nil, nil, logr.Discard())
+	c := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	valid := `{"apiVersion":"sympozium.ai/celln-permission-preview-v1","bindings":[{"agent":{"namespace":"tenant","name":"agent"},"operatorSource":{"namespace":"authority","name":"operator"},"runtimeSource":{"namespace":"authority","name":"runtime"},"agentSource":{"namespace":"authority","name":"agent"}}]}`
+	for _, tc := range []struct {
+		raw  string
+		good bool
+	}{
+		{valid, true}, {valid + ` {}`, false}, {strings.Replace(valid, `"bindings"`, `"unknown"`, 1), false},
+		{strings.Replace(valid, `"name":"runtime"`, `"name":"operator"`, 1), false},
+		{`{"apiVersion":"sympozium.ai/celln-permission-preview-v1","bindings":[]}`, false},
+		{strings.Repeat("x", (1<<20)+1), false},
+	} {
+		path := filepath.Join(t.TempDir(), "preview.json")
+		if err := os.WriteFile(path, []byte(tc.raw), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.LoadCellnPreview(path, c); (err == nil) != tc.good {
+			t.Fatalf("configuration accepted=%t want %t: %v", err == nil, tc.good, err)
+		}
+	}
+	if err := s.LoadCellnPreview("relative.json", c); err == nil {
+		t.Fatal("relative path accepted")
+	}
+	if err := s.ConfigureCellnPreview(nil, nil); err == nil {
+		t.Fatal("missing reader accepted")
+	}
+}

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -7,6 +7,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"github.com/sympozium-ai/sympozium/internal/cellnauthority"
 	"io"
 	"io/fs"
 	"net"
@@ -59,6 +60,7 @@ var memoryProxyClient = &http.Client{
 
 // Server is the Sympozium API server.
 type Server struct {
+	cellnPreview map[types.NamespacedName]cellnauthority.Loader
 	client       client.Client
 	eventBus     eventbus.EventBus
 	kube         kubernetes.Interface
@@ -146,6 +148,7 @@ func (s *Server) buildMux(frontendFS fs.FS, expected *tokenReader) http.Handler 
 	// Administrator-approved harness runtimes
 	mux.HandleFunc("GET /api/v1/runtimes", s.listRuntimes)
 	mux.HandleFunc("GET /api/v1/celln-tools", s.listCellnTools)
+	mux.HandleFunc("POST /api/v1/celln-selection/preview", s.previewCellnSelection)
 	mux.HandleFunc("POST /api/v1/runtimes/install-defaults", s.installDefaultRuntimes)
 	// Persistent harness sessions. The API server owns the only browser-facing
 	// route to a session's private in-cluster Service.

--- a/internal/cellnauthority/preview.go
+++ b/internal/cellnauthority/preview.go
@@ -1,0 +1,52 @@
+package cellnauthority
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// PermissionPreview is an observation of the current tool grant intersection,
+// not model authorization, admission, readiness, a lease or a dispatch ticket.
+type PermissionPreview struct {
+	Agent               Subject                     `json:"agent"`
+	Runtime             Subject                     `json:"runtime"`
+	Tools               []Grant                     `json:"tools"`
+	RuntimeLimits       api.AgentRuntimeCellnLimits `json:"runtimeLimits"`
+	ExecutionAuthorized bool                        `json:"executionAuthorized"`
+	Readiness           string                      `json:"readiness"`
+}
+
+func (l Loader) Preview(ctx context.Context, agent types.NamespacedName, intent api.CellnCatalogueSelection) (*PermissionPreview, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if intent.ToolRefs == nil || len(intent.ToolRefs) > 16 || (intent.RuntimeRef != "" && len(validation.IsDNS1123Subdomain(intent.RuntimeRef)) != 0) {
+		return nil, fmt.Errorf("explicit bounded toolRefs and same-namespace runtime name required")
+	}
+	selected := make([]Selection, 0, len(intent.ToolRefs))
+	seen := map[string]bool{}
+	for _, ref := range intent.ToolRefs {
+		if len(validation.IsDNS1123Subdomain(ref.Name)) != 0 || ref.Revision == "" || len(ref.Revision) > 64 || seen[ref.Name] {
+			return nil, fmt.Errorf("unique names and exact bounded revisions required")
+		}
+		seen[ref.Name] = true
+		selected = append(selected, Selection{Name: ref.Name, Revision: ref.Revision})
+	}
+	snapshot, err := l.resolveRuntime(ctx, agent, selected, intent.RuntimeRef)
+	if err != nil {
+		return nil, err
+	}
+	prepared, err := Prepare(*snapshot, 33554432)
+	if err != nil {
+		return nil, err
+	}
+	result := &PermissionPreview{Agent: snapshot.Agent, Runtime: snapshot.Runtime, Tools: []Grant{}, RuntimeLimits: prepared.Limits, Readiness: "not-established"}
+	for _, tool := range snapshot.Tools {
+		result.Tools = append(result.Tools, Grant{Tool: tool.Identity, Limits: *tool.Limits.DeepCopy()})
+	}
+	return result, nil
+}

--- a/internal/cellnauthority/preview_test.go
+++ b/internal/cellnauthority/preview_test.go
@@ -1,0 +1,63 @@
+package cellnauthority
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPermissionPreviewUsesCurrentIntersection(t *testing.T) {
+	l, c, agent, selected := loaderFixture(t)
+	ctx := context.Background()
+	var cm corev1.ConfigMap
+	if err := c.Get(ctx, l.AgentSource, &cm); err != nil {
+		t.Fatal(err)
+	}
+	var doc GrantDocument
+	if err := json.Unmarshal([]byte(cm.Data["grants.json"]), &doc); err != nil {
+		t.Fatal(err)
+	}
+	doc.Grants[0].Limits.TimeoutMillis = 7
+	doc.Grants[0].Limits.MemoryBytes = 1024
+	raw, _ := json.Marshal(doc)
+	cm.Data["grants.json"] = string(raw)
+	if err := c.Update(ctx, &cm); err != nil {
+		t.Fatal(err)
+	}
+	intent := api.CellnCatalogueSelection{ToolRefs: []api.CellnCatalogueToolRef{{Name: selected[0].Name, Revision: selected[0].Revision}}}
+	got, err := l.Preview(ctx, agent, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ExecutionAuthorized || got.Readiness != "not-established" || len(got.Tools) != 1 || got.Tools[0].Limits.TimeoutMillis != 7 || got.RuntimeLimits.MemoryBytes != 1024 {
+		t.Fatalf("wrong effective preview: %+v", got)
+	}
+	if err := c.Delete(ctx, &cm); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Preview(ctx, agent, intent); err == nil {
+		t.Fatal("withdrawn grants previewed")
+	}
+}
+
+func TestPermissionPreviewRefusesAmbiguity(t *testing.T) {
+	l, _, agent, selected := loaderFixture(t)
+	ref := api.CellnCatalogueToolRef{Name: selected[0].Name, Revision: selected[0].Revision}
+	for _, intent := range []api.CellnCatalogueSelection{
+		{}, {ToolRefs: []api.CellnCatalogueToolRef{ref, ref}},
+		{RuntimeRef: "other/runtime", ToolRefs: []api.CellnCatalogueToolRef{}},
+		{ToolRefs: []api.CellnCatalogueToolRef{{Name: "other/tool", Revision: "v1"}}},
+		{RuntimeRef: "unapproved", ToolRefs: []api.CellnCatalogueToolRef{}},
+	} {
+		if _, err := l.Preview(context.Background(), agent, intent); err == nil {
+			t.Fatalf("accepted %+v", intent)
+		}
+	}
+	got, err := l.Preview(context.Background(), agent, api.CellnCatalogueSelection{ToolRefs: []api.CellnCatalogueToolRef{}})
+	if err != nil || got.Tools == nil || len(got.Tools) != 0 {
+		t.Fatalf("explicit empty preview: %+v %v", got, err)
+	}
+}

--- a/test/integration/celln-catalogue-setup/browser_test.go
+++ b/test/integration/celln-catalogue-setup/browser_test.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/sympozium-ai/sympozium/internal/apiserver"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Serve the built application with real API handlers, on loopback only. No
 // intercepted responses, default kubeconfig discovery or external dev server.
-func browserServer(t *testing.T, c client.Client) string {
+func browserServer(t *testing.T, c client.Client, namespace string) string {
 	t.Helper()
 	web := os.Getenv("CELLN_LIVE_WEB_ROOT")
 	if !filepath.IsAbs(web) {
@@ -24,7 +25,10 @@ func browserServer(t *testing.T, c client.Client) string {
 	}
 	index, err := os.ReadFile(filepath.Join(web, "dist", "index.html"))
 	must(t, err)
-	api := apiserver.NewServer(c, nil, nil, logr.Discard()).Handler(nil)
+	server := apiserver.NewServer(c, nil, nil, logr.Discard())
+	ref := func(name string) types.NamespacedName { return types.NamespacedName{Namespace: namespace, Name: name} }
+	must(t, server.ConfigureCellnPreview(c, []apiserver.CellnPreviewBinding{{Agent: ref("agent"), OperatorSource: ref("operator"), RuntimeSource: ref("runtime"), AgentSource: ref("agent")}}))
+	api := server.Handler(nil)
 	assets := http.FileServer(http.Dir(filepath.Join(web, "dist")))
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/test/integration/celln-catalogue-setup/live_test.go
+++ b/test/integration/celln-catalogue-setup/live_test.go
@@ -154,7 +154,7 @@ func TestLiveCatalogueHarness(t *testing.T) {
 		t.Cleanup(server.Close)
 		var created api.AgentRun
 		if browserSubmission {
-			browserURL = browserServer(t, c)
+			browserURL = browserServer(t, c, ns.Name)
 			runBrowser(t, ctx, browserURL, ns.Name, "", setup.Spec.Task.GetPrompt())
 			var runs api.AgentRunList
 			must(t, c.List(ctx, &runs, client.InNamespace(ns.Name)))

--- a/web/cypress/e2e/celln-live.cy.ts
+++ b/web/cypress/e2e/celln-live.cy.ts
@@ -25,6 +25,9 @@ describe("live Harness-in-Celln", () => {
       cy.get('[data-testid="celln-harness-selection"]').contains("label", `${name}@`).find("input").check();
     }
     // Observe the real request/response; never reply with fixture data.
+    cy.get('[data-testid="celln-permission-preview"]').contains("Shared cell memory ceiling:").scrollIntoView().should("be.visible");
+    cy.get('[data-testid="celln-permission-preview"]').contains("uppercase@").should("be.visible");
+    cy.get('[data-testid="celln-permission-preview"]').contains("length@").should("be.visible");
     cy.intercept("POST", "/api/v1/runs*").as("created");
     cy.contains("button", "Request catalogue run").click();
     cy.wait("@created").then(({ request, response }) => {

--- a/web/src/components/celln-permission-preview.tsx
+++ b/web/src/components/celln-permission-preview.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { api, getNamespace, type CellnSelection } from "@/lib/api";
+
+export function CellnPermissionPreview({ agentRef, selection }: { agentRef: string; selection: CellnSelection }) {
+  const preview = useQuery({
+    queryKey: ["celln-permission-preview", getNamespace(), agentRef, selection],
+    queryFn: () => api.cellnTools.preview(agentRef, selection),
+    retry: false,
+    staleTime: 0,
+    gcTime: 0,
+    refetchInterval: 10000,
+  });
+  return <div className="space-y-1 rounded border p-2 text-xs" data-testid="celln-permission-preview">
+    <p>Effective tool permissions — current approval intersection</p>
+    {preview.isPending || preview.isFetching ? <p>Checking current approvals…</p> : preview.isError ? <p role="status">Permissions unavailable: {preview.error.message}</p> : preview.data ? <>
+      {preview.data.tools.length === 0 && <p>No tools lent.</p>}
+      {preview.data.tools.map(({ tool, limits }) => <p key={tool.name}>{tool.name}@{tool.revision}: {limits.timeoutMillis} ms · {limits.memoryBytes} bytes memory · input {limits.argumentBytes} bytes · output {limits.outputBytes} bytes · workspace {limits.workspace} · effects {limits.effects}</p>)}
+      <p>Shared cell memory ceiling: {preview.data.runtimeLimits.memoryBytes} bytes</p>
+    </> : null}
+    <p className="text-muted-foreground">Observation only, refreshed every 10 seconds. Does not check model authority, host readiness or capacity and does not authorize execution. Approvals are checked again before execution.</p>
+  </div>;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -162,6 +162,15 @@ export interface CellnSelection {
   toolRefs: { name: string; revision: string }[];
 }
 
+export interface CellnPermissionPreview {
+  agent: { name: string; uid: string };
+  runtime: { name: string; uid: string };
+  tools: { tool: { name: string; revision: string }; limits: CellnTool["spec"]["limits"] }[];
+  runtimeLimits: { memoryBytes: number; timeoutMillis: number; workspace: string };
+  executionAuthorized: false;
+  readiness: "not-established";
+}
+
 export interface CellnTool {
   metadata: ObjectMeta;
   spec: {
@@ -1358,6 +1367,7 @@ export const api = {
 
   cellnTools: {
     list: () => apiFetch<CellnTool[]>("/api/v1/celln-tools"),
+    preview: (agentRef: string, cellnSelection: CellnSelection) => apiFetch<CellnPermissionPreview>("/api/v1/celln-selection/preview", { method: "POST", body: JSON.stringify({ agentRef, cellnSelection }) }),
   },
 
   harnessSessions: {

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -61,6 +61,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useRunsSeen } from "@/hooks/use-runs-seen";
 import type { AgentRun } from "@/lib/api";
+import { CellnPermissionPreview } from "@/components/celln-permission-preview";
 
 /** Returns true when a run is in PostRunning with a gate hook awaiting a verdict. */
 function isAwaitingGate(run: AgentRun): boolean {
@@ -297,6 +298,7 @@ export function RunsPage() {
                         </label>;
                       })}
                       <p className="text-xs">Lending order: {lentTools.map((ref) => `${ref.name}@${ref.revision}`).join(" → ") || "none"}</p>
+                      {compatibleHarness && !staleTools && <CellnPermissionPreview agentRef={form.agentRef} selection={{ runtimeRef: form.runtimeRef || undefined, toolRefs: lentTools }} />}
                       {staleTools && <p role="alert" className="text-xs text-red-400">The catalogue changed. Clear and reselect the borrowed tools before submitting.</p>}
                       {!!lentTools.length && <Button type="button" variant="outline" size="sm" onClick={() => setLentTools([])}>Clear borrowed tools</Button>}
                       <p className="text-xs text-amber-500">Selection readiness is not established. Catalogue metadata is not permission to run. Registered compositions can receive trusted issuance automatically; new combinations require operator preparation. Current approvals and effective permissions are checked before execution.</p>


### PR DESCRIPTION
Advances #426, stacked on #461. Adds a bounded read-only permission preview using uncached live Agent/runtime/tool identities and the existing three-layer trusted grant resolver. Separate strict operator source configuration contains no issuer/router credentials; caller-supplied source locations refuse. UI shows current effective tool ceilings and shared cell memory cap, hides stale data on errors, and explicitly excludes model authority/readiness/capacity/execution authorization. Includes operator/HTTP/YAML documentation. Tests cover narrower intersections, withdrawal, empty lending, ambiguous refs and strict bounded config. Actual built-browser → live preview → automatic issuance → real KVM/DeepSeek two tools → rendered result passed in 45.27s; cleanup/withdrawal/refusal/retained receipt passed and isolated controller restored. Full Go race/build/vet and web build passed. No production admission/distribution, conversation or fleet qualification claim; no implicit Helm mount/RBAC broadening.