### PR TITLE
Fix #415: Gate sequential edges for subagent batch children

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1377,6 +1377,12 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 	if agentRun.Spec.AgentRef == "" {
 		return nil
 	}
+	// Child runs spawned by spawn_subagents batches must not independently
+	// execute sequential edges. The parent run collates batch results first,
+	// then it is the only run that should trigger downstream sequential stages.
+	if agentRun.Labels["sympozium.ai/subagent-batch-id"] != "" {
+		return nil
+	}
 	var sourceInst sympoziumv1alpha1.Agent
 	if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &sourceInst); err != nil {
 		return nil // Instance gone — skip.

--- a/internal/controller/agentrun_delegation_executor_test.go
+++ b/internal/controller/agentrun_delegation_executor_test.go
@@ -247,7 +247,7 @@ func TestTriggerSequentialSuccessors_SubagentChildrenDoNotTrigger(t *testing.T) 
 	ensemble := &sympoziumv1alpha1.Ensemble{
 		ObjectMeta: metav1.ObjectMeta{Name: "team", Namespace: "default"},
 		Spec: sympoziumv1alpha1.EnsembleSpec{
-			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{{Name: "reviewer", Schedule: &sympoziumv1alpha1.ScheduleSpec{Task: "review"}}},
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{{Name: "reviewer", Schedule: &sympoziumv1alpha1.AgentConfigSchedule{Task: "review"}}},
 			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
 				{Source: "architect", Target: "reviewer", Type: "sequential"},
 			},

--- a/internal/controller/agentrun_delegation_executor_test.go
+++ b/internal/controller/agentrun_delegation_executor_test.go
@@ -207,3 +207,113 @@ func TestDelegationEdgeActive(t *testing.T) {
 		}
 	}
 }
+
+func listSequentialRuns(t *testing.T, r *AgentRunReconciler) []sympoziumv1alpha1.AgentRun {
+	t.Helper()
+	var runs sympoziumv1alpha1.AgentRunList
+	if err := r.List(context.Background(), &runs, client.InNamespace("default")); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	var out []sympoziumv1alpha1.AgentRun
+	for _, ar := range runs.Items {
+		if ar.Labels["sympozium.ai/sequential-from"] != "" {
+			out = append(out, ar)
+		}
+	}
+	return out
+}
+
+func TestTriggerSequentialSuccessors_SubagentChildrenDoNotTrigger(t *testing.T) {
+	sourceInst := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-architect",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/agent-config": "architect",
+				"sympozium.ai/ensemble":     "team",
+			},
+		},
+	}
+	targetInst := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-reviewer",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/agent-config": "reviewer",
+				"sympozium.ai/ensemble":     "team",
+			},
+		},
+	}
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "team", Namespace: "default"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{{Name: "reviewer", Schedule: &sympoziumv1alpha1.ScheduleSpec{Task: "review"}}},
+			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+				{Source: "architect", Target: "reviewer", Type: "sequential"},
+			},
+		},
+	}
+	parentRun := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent-run", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentRunSpec{AgentRef: "team-architect", Task: sympoziumv1alpha1.NewStringTask("fan out")},
+		Status: sympoziumv1alpha1.AgentRunStatus{
+			Phase:  sympoziumv1alpha1.AgentRunPhaseSucceeded,
+			Result: "batch collated",
+		},
+	}
+	childRunA := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sub-parent-run-batch-a-1-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/subagent-batch-id": "batch-a",
+			},
+		},
+		Spec: sympoziumv1alpha1.AgentRunSpec{AgentRef: "team-architect", Task: sympoziumv1alpha1.NewStringTask("task a")},
+		Status: sympoziumv1alpha1.AgentRunStatus{
+			Phase:  sympoziumv1alpha1.AgentRunPhaseSucceeded,
+			Result: "a",
+		},
+	}
+	childRunB := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sub-parent-run-batch-a-1-2",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/subagent-batch-id": "batch-a",
+			},
+		},
+		Spec: sympoziumv1alpha1.AgentRunSpec{AgentRef: "team-architect", Task: sympoziumv1alpha1.NewStringTask("task b")},
+		Status: sympoziumv1alpha1.AgentRunStatus{
+			Phase:  sympoziumv1alpha1.AgentRunPhaseSucceeded,
+			Result: "b",
+		},
+	}
+
+	r := newAgentRunTestReconciler(t, sourceInst, targetInst, ensemble, parentRun, childRunA, childRunB)
+	ctx := context.Background()
+
+	if err := r.triggerSequentialSuccessors(ctx, logr.Discard(), childRunA); err != nil {
+		t.Fatalf("child A triggerSequentialSuccessors: %v", err)
+	}
+	if err := r.triggerSequentialSuccessors(ctx, logr.Discard(), childRunB); err != nil {
+		t.Fatalf("child B triggerSequentialSuccessors: %v", err)
+	}
+	if got := listSequentialRuns(t, r); len(got) != 0 {
+		t.Fatalf("expected no sequential runs from subagent children, got %d", len(got))
+	}
+
+	if err := r.triggerSequentialSuccessors(ctx, logr.Discard(), parentRun); err != nil {
+		t.Fatalf("parent triggerSequentialSuccessors: %v", err)
+	}
+	if got := listSequentialRuns(t, r); len(got) != 1 {
+		t.Fatalf("expected 1 sequential run from parent, got %d", len(got))
+	}
+
+	if err := r.triggerSequentialSuccessors(ctx, logr.Discard(), childRunA); err != nil {
+		t.Fatalf("child A re-triggerSequentialSuccessors: %v", err)
+	}
+	if got := listSequentialRuns(t, r); len(got) != 1 {
+		t.Fatalf("expected exactly 1 sequential run after child re-trigger, got %d", len(got))
+	}
+}

--- a/internal/controller/spawn_router_subagent_test.go
+++ b/internal/controller/spawn_router_subagent_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
@@ -164,5 +165,34 @@ func TestSubagentBatch_SequentialChildrenSettle(t *testing.T) {
 	}
 	if res.Results[1].Response != "done-b" {
 		t.Errorf("results[1] = %+v, want done-b", res.Results[1])
+	}
+}
+
+func TestSubagentBatch_ChildrenTaggedWithBatchID(t *testing.T) {
+	sr, _ := subagentBatchFixture(t)
+	ctx := context.Background()
+
+	reqData, err := json.Marshal(ipc.SubagentSpawnRequest{
+		BatchID:  "batch-tag",
+		Strategy: "parallel",
+		Tasks:    []ipc.SubagentTask{{ID: "a", Task: "task a"}, {ID: "b", Task: "task b"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	sr.handleSubagentRequest(ctx, subagentEvent("parent-run", string(reqData)))
+
+	children := batchChildren(t, sr, "batch-tag")
+	for _, childName := range children {
+		if childName == "" {
+			t.Fatalf("expected every child to be spawned, got %v", children)
+		}
+		var child sympoziumv1alpha1.AgentRun
+		if err := sr.Client.Get(ctx, types.NamespacedName{Name: childName, Namespace: "default"}, &child); err != nil {
+			t.Fatalf("get child %s: %v", childName, err)
+		}
+		if got := child.Labels["sympozium.ai/subagent-batch-id"]; got != "batch-tag" {
+			t.Fatalf("child %s batch label = %q, want %q", childName, got, "batch-tag")
+		}
 	}
 }

--- a/internal/orchestrator/spawner.go
+++ b/internal/orchestrator/spawner.go
@@ -139,8 +139,14 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 		"sympozium.ai/parent-run": req.ParentRunName,
 		"sympozium.ai/component":  "agent-run",
 	}
+	var annotations map[string]string
 	if req.BatchID != "" {
-		labels["sympozium.ai/subagent-batch-id"] = req.BatchID
+		// Label values are bounded (63 chars, restricted charset), so a raw
+		// caller-supplied BatchID can't go in directly; batchNameToken already
+		// sanitizes/bounds it for the run name. The unsanitized ID goes in an
+		// annotation, which has no such restriction.
+		labels["sympozium.ai/subagent-batch-id"] = batchNameToken(req.BatchID)
+		annotations = map[string]string{"sympozium.ai/subagent-batch-id-full": req.BatchID}
 	}
 
 	span.SetAttributes(attribute.String("run.name", runName))
@@ -148,9 +154,10 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 
 	agentRun := &sympoziumv1alpha1.AgentRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      runName,
-			Namespace: req.Namespace,
-			Labels:    labels,
+			Name:        runName,
+			Namespace:   req.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:   req.InstanceName,

--- a/internal/orchestrator/spawner.go
+++ b/internal/orchestrator/spawner.go
@@ -133,6 +133,16 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 	runName := buildSubagentRunName(req.ParentRunName, req.CurrentDepth+1, req.ChildIndex, req.BatchID)
 	sessionKey := sessionkey.ForSub(req.ParentSessionKey, runName)
 
+	labels := map[string]string{
+		"sympozium.ai/instance":   req.InstanceName,
+		"sympozium.ai/agent-id":   req.AgentID,
+		"sympozium.ai/parent-run": req.ParentRunName,
+		"sympozium.ai/component":  "agent-run",
+	}
+	if req.BatchID != "" {
+		labels["sympozium.ai/subagent-batch-id"] = req.BatchID
+	}
+
 	span.SetAttributes(attribute.String("run.name", runName))
 	log.Info("Spawning sub-agent", "runName", runName)
 
@@ -140,12 +150,7 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      runName,
 			Namespace: req.Namespace,
-			Labels: map[string]string{
-				"sympozium.ai/instance":   req.InstanceName,
-				"sympozium.ai/agent-id":   req.AgentID,
-				"sympozium.ai/parent-run": req.ParentRunName,
-				"sympozium.ai/component":  "agent-run",
-			},
+			Labels:    labels,
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:   req.InstanceName,

--- a/internal/orchestrator/spawner_labels_test.go
+++ b/internal/orchestrator/spawner_labels_test.go
@@ -1,0 +1,128 @@
+package orchestrator
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// k8sLabelValueRE mirrors the Kubernetes label value validation rule.
+var k8sLabelValueRE = regexp.MustCompile(`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`)
+
+func spawnerFixture(t *testing.T) *Spawner {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return &Spawner{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Log:    logf.Log,
+	}
+}
+
+// Regression guard: a batch ID containing characters invalid in a Kubernetes
+// label (e.g. a slash), or longer than the 63-char label limit, must not
+// break child creation. The label gets a sanitized, bounded token; the full
+// original ID is preserved in an annotation.
+func TestSpawn_BatchIDWithSlashDoesNotBreakLabel(t *testing.T) {
+	s := spawnerFixture(t)
+	batchID := "team/nightly-run/2026-09-09"
+
+	result, err := s.Spawn(context.Background(), SpawnRequest{
+		ParentRunName: "parent",
+		InstanceName:  "team-lead",
+		Namespace:     "default",
+		ChildIndex:    1,
+		BatchID:       batchID,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	var run sympoziumv1alpha1.AgentRun
+	if err := s.Client.Get(context.Background(), types.NamespacedName{Name: result.RunName, Namespace: "default"}, &run); err != nil {
+		t.Fatalf("get child: %v", err)
+	}
+
+	label := run.Labels["sympozium.ai/subagent-batch-id"]
+	if label == "" {
+		t.Fatal("expected a sanitized batch-id label")
+	}
+	if !k8sLabelValueRE.MatchString(label) {
+		t.Errorf("label value %q is not a valid Kubernetes label", label)
+	}
+	if strings.Contains(label, "/") {
+		t.Errorf("label value %q still contains a slash", label)
+	}
+
+	if got := run.Annotations["sympozium.ai/subagent-batch-id-full"]; got != batchID {
+		t.Errorf("annotation = %q, want full batch id %q", got, batchID)
+	}
+}
+
+func TestSpawn_LongBatchIDIsBoundedInLabel(t *testing.T) {
+	s := spawnerFixture(t)
+	batchID := strings.Repeat("a", 200)
+
+	result, err := s.Spawn(context.Background(), SpawnRequest{
+		ParentRunName: "parent",
+		InstanceName:  "team-lead",
+		Namespace:     "default",
+		ChildIndex:    1,
+		BatchID:       batchID,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	var run sympoziumv1alpha1.AgentRun
+	if err := s.Client.Get(context.Background(), types.NamespacedName{Name: result.RunName, Namespace: "default"}, &run); err != nil {
+		t.Fatalf("get child: %v", err)
+	}
+
+	label := run.Labels["sympozium.ai/subagent-batch-id"]
+	if len(label) > 63 {
+		t.Errorf("label length = %d, want <= 63", len(label))
+	}
+	if !k8sLabelValueRE.MatchString(label) {
+		t.Errorf("label value %q is not a valid Kubernetes label", label)
+	}
+
+	if got := run.Annotations["sympozium.ai/subagent-batch-id-full"]; got != batchID {
+		t.Errorf("annotation length = %d, want full %d-char batch id preserved", len(got), len(batchID))
+	}
+}
+
+func TestSpawn_EmptyBatchIDSetsNoLabelOrAnnotation(t *testing.T) {
+	s := spawnerFixture(t)
+
+	result, err := s.Spawn(context.Background(), SpawnRequest{
+		ParentRunName: "parent",
+		InstanceName:  "team-lead",
+		Namespace:     "default",
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	var run sympoziumv1alpha1.AgentRun
+	if err := s.Client.Get(context.Background(), types.NamespacedName{Name: result.RunName, Namespace: "default"}, &run); err != nil {
+		t.Fatalf("get child: %v", err)
+	}
+
+	if _, ok := run.Labels["sympozium.ai/subagent-batch-id"]; ok {
+		t.Error("expected no batch-id label for a non-batch spawn")
+	}
+	if _, ok := run.Annotations["sympozium.ai/subagent-batch-id-full"]; ok {
+		t.Error("expected no batch-id annotation for a non-batch spawn")
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes issue #415 where subagent children spawned by spawn_subagents could independently trigger downstream sequential edges before the parent completed collation.

## Root Cause
Sequential successor triggering ran on completed runs without distinguishing:

- parent orchestration runs
- subagent batch child runs

So each child completion could enter the sequential trigger path and fan out downstream runs prematurely.

## Changes
1. Tag batch-spawned child runs with sympozium.ai/subagent-batch-id during spawn.
2. In sequential successor triggering, skip runs carrying that batch label.
3. Keep sequential orchestration owned by the parent run only.

## Test
Add regression test coverage for:
1. child batch label propagation
2. child runs not triggering sequential successors
3. parent run triggering exactly one sequential successor

## Why this resolves the issue ?
The sequential handoff now occurs only from the parent orchestration point, after batch collation, preventing duplicate or premature downstream stage execution.