### PR TITLE
fix(web): clarify Celln selection and topology ordering

### DIFF
--- a/docs/guides/celln-native-installation.md
+++ b/docs/guides/celln-native-installation.md
@@ -9,6 +9,28 @@ Track epic #464 and starter-tools #467 for the supported MLP and deferred work.
 Release archives contain binaries and example units, not pre-approved authority,
 model credentials, a kernel, or a tenant-ready signed package.
 
+## Choosing Celln in the UI
+
+Kubernetes remains the default. Selecting a Harness on an Agent does not switch
+its runs to Celln.
+
+1. Open **Runs → New Run**. You can also follow the run-creation link from an
+   Agent’s **Harness** tab or the feed’s quick-task input; these carry the Agent
+   selection into the form.
+2. Choose **Celln** in **Execution environment** at the top of the form. The
+   availability message reports host eligibility, not permission to execute.
+3. Select the Agent and a compatible native **Harness for this run**. Existing
+   OCI harnesses and SkillPack sidecars do not become native Celln tools.
+4. For a continuing conversation, enable **Enduring conversation**, review its
+   lifetime and usage limits, and select approved borrowed tools. For a one-off
+   task, leave enduring mode off.
+5. Review the permission preview and submit. The operator preparation below is
+   still required; a catalogue entry or suggested toolbox is not a grant.
+
+The feed’s quick-send path still uses Kubernetes. Use New Run for Celln settings.
+The **Concepts** guide explains these choices first, with implementation and
+YAML terminology in an expandable glossary.
+
 ## Architecture and boundaries
 
 The existing host Celln owner retains the live parent, admits warm motes, owns

--- a/web/cypress/e2e/concepts-execution-choice.cy.ts
+++ b/web/cypress/e2e/concepts-execution-choice.cy.ts
@@ -1,0 +1,47 @@
+// Read-only UX checks: opening help and configuring a form submits no runs.
+describe("Concepts and execution choice", () => {
+  it("explains the defaults and reveals technical terms on demand", () => {
+    cy.visit("/runs");
+    cy.get('button[aria-label="Concepts"]').click();
+    cy.get('[role="dialog"]').within(() => {
+      cy.contains("Start with an Agent. Give it work in a Run.").should("be.visible");
+      cy.contains("Kubernetes is the default").should("exist");
+      cy.get("details").should("not.have.attr", "open");
+      cy.get("summary").scrollIntoView().click();
+      cy.get("details").should("have.attr", "open");
+      cy.contains("AgentRuntime / AgentHarness").should("exist");
+      cy.contains("Parent loss is context loss").should("exist");
+    });
+    cy.get("body").type("{esc}");
+    cy.get('[role="dialog"]').should("not.exist");
+    cy.get('button[title="Collapse sidebar"]').click();
+    cy.get('button[aria-label="Concepts"]').click();
+    cy.contains("How Sympozium fits together").should("be.visible");
+  });
+
+  it("makes Celln an explicit choice at the start of New Run", () => {
+    cy.visit("/runs?create=1");
+    cy.get('[role="dialog"]').within(() => {
+      cy.get('[data-testid="execution-environment"]').should("be.visible");
+      cy.get('input[name="execution-environment"][value="job"]').should("be.checked");
+      cy.get('input[name="execution-environment"][value="celln"]').check();
+      cy.get('input[name="execution-environment"][value="celln"]').should("be.checked");
+      cy.get('[data-testid="execution-environment"] [role="status"]').should("be.visible");
+      cy.contains("Harness for this run").should("be.visible");
+      cy.get('input[name="execution-environment"][value="job"]').check();
+      cy.get('[data-testid="execution-environment"] [role="status"]').should("not.exist");
+    });
+  });
+
+  it("keeps the concepts dialog within a narrow viewport", () => {
+    cy.viewport(390, 740);
+    cy.visit("/runs");
+    cy.get('button[aria-label="Concepts"]').click();
+    cy.get('[role="dialog"]').then(($dialog) => {
+      const bounds = $dialog[0].getBoundingClientRect();
+      expect(bounds.left).to.be.at.least(0);
+      expect(bounds.right).to.be.at.most(390);
+      expect(bounds.height).to.be.at.most(740);
+    });
+  });
+});

--- a/web/cypress/e2e/topology-ordering.cy.ts
+++ b/web/cypress/e2e/topology-ordering.cy.ts
@@ -1,0 +1,54 @@
+import { applyDagreLayout, NODE_SIZES } from "../../src/lib/topology-layout";
+import type { Node, Edge } from "@xyflow/react";
+
+function fixture() {
+  const nodes: Node[] = [
+    ["provider", "cloudProvider"], ["harness", "harness"],
+    ["agent-a", "agent"], ["agent-b", "agent"], ["disconnected", "agent"],
+    ["run", "agentRun"], ["child", "agentRun"],
+  ].map(([id, type]) => ({ id, type, data: {}, position: { x: 0, y: 0 } }));
+  const edges: Edge[] = [
+    ["provider", "agent-a"], ["harness", "agent-a"],
+    ["harness", "agent-b"], ["agent-a", "run"], ["run", "child"],
+  ].map(([source, target]) => ({ id: `${source}-${target}`, source, target }));
+  return { nodes, edges };
+}
+
+describe("Topology semantic ordering", () => {
+  it("renders the live topology with the new configuration label", () => {
+    cy.visit("/topology");
+    cy.get(".react-flow__node-agent").should("have.length.greaterThan", 0);
+    cy.contains("default harness").should("exist");
+    cy.contains("executes with").should("not.exist");
+    cy.get(".react-flow__node-agent").should(($nodes) => {
+      const positions = [...$nodes].map((node) => node.style.transform.match(/translate\([^,]+,\s*([^)]+)\)/)?.[1]);
+      expect(new Set(positions).size).to.equal(1);
+    });
+  });
+
+  it("keeps shared configuration above agents, including disconnected agents", () => {
+    const { nodes, edges } = fixture();
+    applyDagreLayout(nodes, edges);
+    const y = (id: string) => nodes.find((node) => node.id === id)!.position.y;
+    expect(y("provider")).to.equal(y("harness"));
+    expect(y("agent-a")).to.equal(y("agent-b"));
+    expect(y("agent-a")).to.equal(y("disconnected"));
+    expect(y("harness")).to.be.lessThan(y("agent-a"));
+    expect(y("agent-a")).to.be.lessThan(y("run"));
+    expect(y("run")).to.be.lessThan(y("child"));
+    const agents = nodes.filter((node) => node.type === "agent").sort((a, b) => a.position.x - b.position.x);
+    for (let i = 1; i < agents.length; i++) {
+      expect(agents[i].position.x).to.be.greaterThan(agents[i - 1].position.x + NODE_SIZES.agent[0]);
+    }
+  });
+
+  it("is stable when API list order changes", () => {
+    const first = fixture();
+    const second = fixture();
+    applyDagreLayout(first.nodes, first.edges);
+    applyDagreLayout(second.nodes.reverse(), second.edges.reverse());
+    for (const node of first.nodes) {
+      expect(second.nodes.find((other) => other.id === node.id)!.position).to.deep.equal(node.position);
+    }
+  });
+});

--- a/web/src/components/feed-pane.tsx
+++ b/web/src/components/feed-pane.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -458,6 +459,12 @@ export function FeedPane({
 
           {/* Input */}
           <div className="border-t border-border/50 p-3">
+            <p className="mb-2 text-xs text-muted-foreground">
+              Quick tasks use Kubernetes. {" "}
+              <Link className="text-primary underline" to={`/runs?create=1&agent=${encodeURIComponent(activeTab)}`}>
+                Choose Celln, harness and tools in New Run
+              </Link>
+            </p>
             <div className="flex items-center gap-2">
               <Input
                 value={message}

--- a/web/src/components/ontology-modal.tsx
+++ b/web/src/components/ontology-modal.tsx
@@ -1,346 +1,118 @@
-/**
- * OntologyModal — explains the core Sympozium concepts and how they relate.
- */
-
-import { useState } from "react";
+/** Shared concepts guide for both navigation layouts. */
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
+  Dialog, DialogContent, DialogDescription, DialogHeader,
+  DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { HelpCircle, ArrowRight } from "lucide-react";
+import { HelpCircle } from "lucide-react";
 
-interface Concept {
-  name: string;
-  icon: string;
-  short: string;
-  detail: string;
-  relates?: string;
-}
-
-const CONCEPTS: Concept[] = [
-  {
-    name: "Model",
-    icon: "M",
-    short: "A local LLM running inside the cluster",
-    detail:
-      "A Model CRD declares a GGUF model to be downloaded, served via llama-server, and exposed as an OpenAI-compatible endpoint. Models are auto-placed on the best node via llmfit. No external API keys required.",
-    relates: "Referenced by Ensembles and AgentRuns via modelRef",
-  },
-  {
-    name: "Ensemble",
-    icon: "E",
-    short: "A team of AI agents bundled together",
-    detail:
-      "An Ensemble is a Helm-like bundle that defines a group of Agent Configs, their relationships (delegation, sequential, supervision), shared memory, and the AI provider they use. Activating an Ensemble stamps out Agents, Schedules, and memory for each Agent Config.",
-    relates: "Contains Agent Configs, creates Agents when activated",
-  },
-  {
-    name: "Agent Config",
-    icon: "C",
-    short: "A role definition within an Ensemble",
-    detail:
-      "An Agent Config defines an agent's identity: its name, system prompt, model, skills, and schedule. Each Agent Config in an Ensemble becomes an Agent when the Ensemble is activated. Agent Configs can have different models and provider overrides.",
-    relates: "Lives inside an Ensemble, becomes an Agent",
-  },
-  {
-    name: "Agent",
-    icon: "A",
-    short: "An agent identity and its configuration",
-    detail:
-      "An Agent holds model and provider settings, credential references, skills, an optional runtime reference, memory settings and channel bindings. It is configuration, not proof that a process is running. Agents can be created directly or from Ensembles.",
-    relates: "Created from an Agent Config, runs AgentRuns",
-  },
-  {
-    name: "AgentRun",
-    icon: "R",
-    short: "An execution with its own lifecycle",
-    detail:
-      "An AgentRun records requested work, execution settings, status and results. It can be one-shot or enduring. The backend determines where it executes: the usual Kubernetes path uses pods; Celln uses sealed cells. A one-shot can invoke a deterministic tool without an LLM or harness.",
-    relates: "Uses an Agent; lifecycle and backend are separate choices",
-  },
-  {
-    name: "Harness / AgentRuntime",
-    icon: "H",
-    short: "How the agent reasons and uses tools",
-    detail:
-      "A harness implements the model and tool-use loop. AgentRuntime is the Kubernetes resource describing an operator-configured runtime and its supported contracts. It may describe an OCI adapter, a native Celln profile, or both. Selecting a harness does not choose a lifecycle or grant tool permissions. AgentHarness is a design term, not a separate resource in this path.",
-    relates: "Selected through runtimeRef or cellnSelection.runtimeRef; compatibility is backend-specific",
-  },
-  {
-    name: "Execution environment / Backend",
-    icon: "B",
-    short: "Where the work runs",
-    detail:
-      "The Kubernetes execution path runs containers in pods. The Celln backend runs work in hardware-isolated cells while Kubernetes still orchestrates the AgentRun. Harness and tool support varies by backend: choosing Celln does not automatically make existing SkillPack sidecars or MCP integrations available.",
-    relates: "AgentRun.spec.backend selects Celln with celln; omitted uses the default path",
-  },
-  {
-    name: "Lifecycle: one-shot / Enduring",
-    icon: "L",
-    short: "How long an execution lives",
-    detail:
-      "A one-shot performs its work and finishes; on Celln its cell is disposable. An enduring native Celln run keeps a parent cell alive for multiple turns, with a fresh disposable child for each turn. YAML uses executionLifecycle: enduring and an enduring block of limits. A harness is optional for one-shots.",
-    relates: "Duration is separate from harness and execution environment",
-  },
-  {
-    name: "Persistent context / Lease",
-    icon: "P",
-    short: "Live continuity, not crash recovery",
-    detail:
-      "The native parent retains bounded conversation context and run-owned files between turns. A lease limits its lifetime; turn, model-request and output-token budgets also apply. Current native context is approximately 2 KiB. Parent loss destroys this live state: persistence does not mean checkpointing, pause/resume or recovery after a host restart. Saved conversation history is not a restorable parent.",
-    relates: "Controller/API restarts are different from losing the host parent",
-  },
-  {
-    name: "Turn / AgentRunTurn",
-    icon: "T",
-    short: "One message within an enduring run",
-    detail:
-      "A turn submits work to the same live parent. The first message is tracked on AgentRun; later messages have AgentRunTurn resources with their own identities and results. Cancelling a turn requests that its child stop; cancellation is not confirmed until teardown is reported, and is distinct from stopping the parent.",
-    relates: "Multiple turns belong to one enduring AgentRun",
-  },
-  {
-    name: "Workflow",
-    icon: "W",
-    short: "How Agent Configs coordinate within an Ensemble",
-    detail:
-      "Workflows define relationships between Agent Configs: delegation (one agent asks another for help), sequential pipelines (output flows to next), and supervision (one agent oversees another). Visualised on the interactive canvas.",
-    relates: "Defined by Ensemble relationships, visible on the canvas",
-  },
-  {
-    name: "Skill",
-    icon: "S",
-    short: "Instructions for doing a job",
-    detail:
-      "A skill gives an agent instructions, domain knowledge or a workflow, such as investigating Kubernetes health. It may require tools, but instructions are not executable tools or permission to use them. A diagnostic skill still needs access to the relevant cluster operations.",
-    relates: "Skills guide behaviour; tools perform operations",
-  },
-  {
-    name: "SkillPack",
-    icon: "SP",
-    short: "Packaged skills and optional tooling",
-    detail:
-      "A SkillPack bundles skill instructions and may also declare a tool sidecar, dependencies and Kubernetes RBAC. Existing examples include k8s-ops, GitHub GitOps and SRE observability. Not every skill needs a sidecar. These packages are not automatically portable to native Celln, which currently rejects run-level SkillPacks.",
-    relates: "Selected on Agents through skills; tool access depends on the execution path",
-  },
-  {
-    name: "Tool / Borrowed tool",
-    icon: "TL",
-    short: "An operation the agent can perform",
-    detail:
-      "Tools read files, write files, fetch URLs or perform other operations. A borrowed Celln tool is an explicitly selected, reviewed executable revision with bounded inputs, outputs and permissions. Selection requests access; it does not grant authority by itself. Tools cannot currently be added to an already-live native parent.",
-    relates: "Harnesses invoke tools; skills explain when and how to use them",
-  },
-  {
-    name: "Tool catalogue / CellnTool",
-    icon: "CT",
-    short: "Reviewed tool identities and revisions",
-    detail:
-      "CellnTool records a tool revision, signed artifact identities, JSON schemas and declared limits. Runs select these using cellnSelection.toolRefs. A catalogue entry is not proof that the host has admitted the tool or is ready to execute it. The native starter currently offers workspace-read, workspace-write and https-fetch, not arbitrary shell, Python or Kubernetes administration.",
-    relates: "Catalogue metadata, permission approval and execution readiness are separate",
-  },
-  {
-    name: "Permission grant / Preview",
-    icon: "G",
-    short: "What selected tools are allowed to do",
-    detail:
-      "Native tool access must fit the operator, runtime and agent grants together. Limits can bound operations, file sizes and HTTPS destinations. The permission preview explains effective access without issuing execution authority or proving host readiness. Selecting a skill or tool never overrides these limits.",
-    relates: "Authority can only shrink during execution; it cannot expand itself",
-  },
-  {
-    name: "Run-owned workspace",
-    icon: "F",
-    short: "Files belonging to one live native parent",
-    detail:
-      "workspace-read and workspace-write operate on bounded logical files owned by the native run, not arbitrary host paths, a mounted repository or a Kubernetes persistent volume. Writes use revisions to detect conflicting updates. Files survive child turns but are lost when the parent is destroyed. https-fetch is separately restricted to operator-approved destinations.",
-    relates: "Live run storage is distinct from durable Agent memory or chat history",
-  },
-  {
-    name: "MCP server",
-    icon: "MCP",
-    short: "An integration exposing tools over MCP",
-    detail:
-      "Model Context Protocol servers expose tools and other context to compatible clients. An MCP integration is neither a skill nor automatic permission to access a service. Existing MCP connections are not automatically borrowed Celln tools; the native starter does not yet support arbitrary MCP integrations.",
-    relates: "Availability depends on harness, backend and approved access",
-  },
-  {
-    name: "Celln / Cell / Mote",
-    icon: "C",
-    short: "Execution plane, live unit and substrate",
-    detail:
-      "Celln is the execution plane. A mote is the substrate at rest: a stripped kernel and pilot supervisor. A cell is a live, sealed, tool-loaned mote; every cell is a sealed mote. Spawn uses a copy-on-write fork of a warm mote, rather than booting a guest in the hot path. Cell and mote are not interchangeable names.",
-    relates: "Kubernetes orchestrates runs; Celln executes their isolated work",
-  },
-  {
-    name: "Parent cell / Sub-cell",
-    icon: "PC",
-    short: "Retained context and disposable turn work",
-    detail:
-      "An enduring native run has a persistent parent cell for live context and disposable child cells, also called sub-cells, for per-turn work. A sub-cell is a separate cell, not an AI sub-agent or a nested VM inside the parent. A completed child is torn down; the parent can accept another turn within its remaining limits.",
-    relates: "One-shot cells remain disposable and need no persistent parent",
-  },
-  {
-    name: "Assay / Warden / Pilot",
-    icon: "A/W/P",
-    short: "Celln host, isolation and guest components",
-    detail:
-      "Assay is the host daemon and distribution layer. Warden is the per-cell virtual-machine monitor: one warden, one microVM, one cell. Pilot is the in-cell supervisor. The native host broker mediates bounded model and tool requests; model credentials remain host-side rather than entering the guest.",
-    relates: "These are infrastructure components, not extra user-selectable skills",
-  },
-  {
-    name: "Policy",
-    icon: "G",
-    short: "Governance rules for agent behaviour",
-    detail:
-      "A SympoziumPolicy enforces sandbox requirements, resource limits, sub-agent depth, tool gating, network isolation, and model access restrictions. Policies are bound to Agents and validated by an admission webhook.",
-    relates: "Bound to Agents via policyRef",
-  },
+const CHOICES = [
+  ["Who?", "Agent", "The identity and defaults: instructions, model settings, skills and approved access. Creating an Agent does not start a process. You can create one directly; an Ensemble is optional."],
+  ["How?", "Harness", "The program that manages the model conversation and tool use. Choose an approved harness, or use the built-in runner where supported. A one-shot tool job may need neither a harness nor a model."],
+  ["Where?", "Execution environment", "Kubernetes is the default and runs work in containers. Celln is opt-in and runs work in hardware-isolated cells. Choosing a harness does not switch the environment. Harness and tool support must match the environment."],
+  ["How long?", "Run lifecycle", "A one-shot completes a task and finishes. An enduring native run stays available for more messages within its limits. Both are AgentRuns—not different kinds of Agent."],
+  ["With what access?", "Skills, tools and policy", "Skills explain how to do a job. Tools perform actions. Policy and permission grants limit which actions are allowed. Selecting a skill or tool requests access; it does not grant permission."],
 ];
 
-export function OntologyModal() {
-  const [open, setOpen] = useState(false);
+const GLOSSARY = [
+  ["AgentRun", "The record of an execution: its task, settings, lifecycle, status and results. One Agent can have multiple runs."],
+  ["AgentRuntime / AgentHarness", "AgentRuntime is the operator-managed resource describing an approved harness and its supported contracts. AgentHarness is the product/design term, not another resource you need to create. Harness selection does not choose a lifecycle or grant tools."],
+  ["Model", "The language model used for reasoning. Agents can use configured external providers or cluster-hosted models. A Model resource describes managed model serving; it is not a prerequisite for every Agent."],
+  ["Ensemble / Agent Config / Workflow", "An Ensemble bundles a team. Its Agent Configs are templates used to create Agents. A Workflow describes how the team coordinates, such as delegation or a sequential pipeline. None is required for a standalone Agent."],
+  ["Skill / SkillPack", "A skill supplies instructions or domain knowledge. A SkillPack packages those instructions and may include tooling and access requirements. Kubernetes administration and observability packs still depend on their supported tools; they are not automatically available in native Celln."],
+  ["Tool / CellnTool / Borrowed tool", "A tool performs an operation. CellnTool describes a reviewed native tool revision and its limits. Borrowing means selecting that revision for a run, subject to grants and host readiness. Tools cannot be added to an already-live native parent."],
+  ["Policy / Permission grant / Preview", "Policy sets constraints. A grant bounds allowed access, such as file sizes or HTTPS destinations. A preview explains effective access; it neither issues permission nor proves host readiness. A native cell cannot expand its own authority."],
+  ["MCP server", "An integration exposing tools and context through Model Context Protocol. It requires a compatible execution path and approved access. An MCP connection is not automatically a borrowed Celln tool."],
+  ["Turn / AgentRunTurn", "A message and its work within a continuing run. In native Celln, the first message is recorded on AgentRun; later messages use AgentRunTurn. Cancelling a turn stops its work once teardown is confirmed; it is different from ending the parent run."],
+  ["Parent cell / Sub-cell", "The native parent keeps live context between turns. Each turn uses a disposable child cell, also called a sub-cell. A child is a separate cell—not an AI sub-agent or a VM nested inside the parent."],
+  ["Persistent context / Workspace / Lease", "The native parent retains bounded conversation context and logical run-owned files between turns. These are not arbitrary host files or durable Agent memory. A lease limits the parent’s lifetime. Losing the parent loses this live state; saved chat history is not a checkpoint."],
+  ["Celln / Cell / Mote", "Celln is the execution plane. A mote is the substrate at rest: a stripped kernel and pilot supervisor. A cell is a live, sealed, tool-loaned mote. Spawn forks a warm mote instead of booting a guest in the hot path."],
+  ["Assay / Warden / Pilot", "Infrastructure, not user-selectable skills: assay is the host daemon and distribution layer; warden is the per-cell virtual-machine monitor (one warden, one microVM, one cell); pilot is the in-cell supervisor."],
+];
 
+function ConceptsGuide() {
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <div className="space-y-6 text-sm">
+      <section aria-labelledby="concepts-start">
+        <h3 id="concepts-start" className="font-semibold">Start with an Agent. Give it work in a Run.</h3>
+        <p className="mt-2 text-muted-foreground leading-relaxed">
+          The Agent holds the configuration. The Run is the execution.
+          A native enduring conversation is one run with multiple turns.
+        </p>
+        <dl className="mt-4 divide-y divide-border rounded-md border px-4">
+          {CHOICES.map(([question, name, detail]) => (
+            <div key={name} className="py-3">
+              <dt className="font-medium"><span className="text-muted-foreground">{question}</span> {name}</dt>
+              <dd className="mt-1 text-muted-foreground leading-relaxed">{detail}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+      <section aria-labelledby="concepts-example" className="rounded-md bg-muted/30 p-4 space-y-2">
+        <h3 id="concepts-example" className="font-semibold">Example: keep talking, contain each turn’s work</h3>
+        <p className="text-muted-foreground leading-relaxed">
+          Choose an approved native Harness, Celln and an enduring lifecycle.
+          Select the permitted workspace read/write and HTTPS fetch tools you need.
+          A parent cell keeps the live conversation context. Each turn does its
+          work in a disposable child cell, returns a result and is cleaned up.
+        </p>
+        <p className="text-muted-foreground leading-relaxed">
+          For a one-off Celln task, choose one-shot instead. Its cell finishes and
+          is cleaned up; no persistent parent is needed.
+        </p>
+      </section>
+      <section aria-labelledby="concepts-limits" className="space-y-2">
+        <h3 id="concepts-limits" className="font-semibold">What native Celln supports today</h3>
+        <ul className="list-disc space-y-2 pl-5 text-muted-foreground leading-relaxed">
+          <li>Opt-in Linux amd64/KVM execution with a single owner, one active turn, a small context budget (about 2 KiB), and finite lifetime and usage limits.</li>
+          <li>Approved workspace read/write and allowlisted HTTPS fetch. Model credentials stay on the host. Default tool suggestions are not permission grants.</li>
+          <li>Live context and workspace files last only as long as the parent. Parent loss is context loss—not automatic recovery. Native checkpoints and pause/resume are not available.</li>
+          <li>Existing Kubernetes agents and OCI harnesses remain available. Native Celln does not run arbitrary OCI/Pi/Hermes harnesses, shell, Python, SkillPack sidecars or arbitrary MCP integrations.</li>
+        </ul>
+      </section>
+      <details className="rounded-md border p-4">
+        <summary className="cursor-pointer font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary">Technical glossary and YAML names</summary>
+        <p className="mt-3 text-muted-foreground leading-relaxed">
+          AgentRun defaults to Kubernetes when <code>spec.backend</code> is omitted.
+          Select Celln with <code>backend: celln</code>. Native continuing runs use
+          {" "}<code>executionLifecycle: enduring</code> with an <code>enduring</code> limits block.
+          Native selections use <code>cellnSelection.runtimeRef</code> and <code>cellnSelection.toolRefs</code>;
+          the ordinary harness path uses <code>runtimeRef</code>. These fields are not a complete installation manifest.
+        </p>
+        <dl className="mt-4 space-y-4">
+          {GLOSSARY.map(([name, detail]) => (
+            <div key={name}>
+              <dt className="font-medium">{name}</dt>
+              <dd className="mt-1 text-muted-foreground leading-relaxed">{detail}</dd>
+            </div>
+          ))}
+        </dl>
+      </details>
+    </div>
+  );
+}
+
+function ConceptsDialog({ expanded = false }: { expanded?: boolean }) {
+  return (
+    <Dialog>
       <DialogTrigger asChild>
-        <button
-          title="Concepts"
-          className="flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:bg-white/5 hover:text-foreground transition-colors"
-        >
-          <HelpCircle className="h-4 w-4" />
+        <button aria-label="Concepts" title="Concepts"
+          className={expanded
+            ? "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-white/5 hover:text-foreground transition-colors"
+            : "flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:bg-white/5 hover:text-foreground transition-colors"}>
+          <HelpCircle className="h-4 w-4" aria-hidden="true" />
+          {expanded && "Concepts"}
         </button>
       </DialogTrigger>
-      <DialogContent className="max-w-lg max-h-[80vh]">
-        <DialogHeader>
-          <DialogTitle className="text-lg">Sympozium Concepts</DialogTitle>
-          <p className="text-sm text-muted-foreground">
-            Skills guide behaviour; tools perform operations. Harness, execution
-            environment and lifecycle are separate choices.
-          </p>
+      <DialogContent className="flex max-h-[85dvh] w-[calc(100%-2rem)] max-w-2xl flex-col overflow-hidden">
+        <DialogHeader className="shrink-0 pr-5">
+          <DialogTitle>How Sympozium fits together</DialogTitle>
+          <DialogDescription>A short guide to agents, runs and the choices that connect them.</DialogDescription>
         </DialogHeader>
-        <ScrollArea className="max-h-[60vh] pr-2">
-          <div className="space-y-4">
-            {/* Relationship diagram */}
-            <div className="rounded-md border border-border/50 bg-muted/20 px-4 py-3 text-xs font-mono text-muted-foreground">
-              <div className="flex items-center justify-center gap-1 flex-wrap">
-                <span className="text-violet-400">Model</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-blue-400">Ensemble</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-cyan-400">Agent Config</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-emerald-400">Agent</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-amber-400">AgentRun</span>
-              </div>
-              <p className="text-center mt-1 text-[10px]">
-                Skills guide Agents. Policies govern access. Each AgentRun
-                selects an execution environment and lifecycle.
-              </p>
-            </div>
-
-            {/* Concept cards */}
-            {CONCEPTS.map((c) => (
-              <div
-                key={c.name}
-                className="rounded-md border border-border/50 px-4 py-3 space-y-1"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="flex items-center justify-center h-6 w-6 rounded bg-primary/10 text-primary text-xs font-bold">
-                    {c.icon}
-                  </span>
-                  <h3 className="font-semibold text-sm">{c.name}</h3>
-                  <span className="text-xs text-muted-foreground ml-auto">
-                    {c.short}
-                  </span>
-                </div>
-                <p className="text-xs text-muted-foreground leading-relaxed">
-                  {c.detail}
-                </p>
-                {c.relates && (
-                  <p className="text-[10px] text-primary/70 italic">
-                    {c.relates}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
+        <div className="min-h-0 overflow-y-auto pr-2"><ConceptsGuide /></div>
       </DialogContent>
     </Dialog>
   );
 }
 
-/** Expanded variant for the sidebar (shows label text). */
-export function OntologyModalExpanded() {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <button className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-white/5 hover:text-foreground transition-colors w-full">
-          <HelpCircle className="h-3.5 w-3.5" />
-          Concepts
-        </button>
-      </DialogTrigger>
-      <DialogContent className="max-w-lg max-h-[80vh]">
-        <DialogHeader>
-          <DialogTitle className="text-lg">Sympozium Concepts</DialogTitle>
-          <p className="text-sm text-muted-foreground">
-            Skills guide behaviour; tools perform operations. Harness, execution
-            environment and lifecycle are separate choices.
-          </p>
-        </DialogHeader>
-        <ScrollArea className="max-h-[60vh] pr-2">
-          <div className="space-y-4">
-            <div className="rounded-md border border-border/50 bg-muted/20 px-4 py-3 text-xs font-mono text-muted-foreground">
-              <div className="flex items-center justify-center gap-1 flex-wrap">
-                <span className="text-violet-400">Model</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-blue-400">Ensemble</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-cyan-400">Agent Config</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-emerald-400">Agent</span>
-                <ArrowRight className="h-3 w-3" />
-                <span className="text-amber-400">AgentRun</span>
-              </div>
-              <p className="text-center mt-1 text-[10px]">
-                Skills guide Agents. Policies govern access. Each AgentRun
-                selects an execution environment and lifecycle.
-              </p>
-            </div>
-
-            {CONCEPTS.map((c) => (
-              <div
-                key={c.name}
-                className="rounded-md border border-border/50 px-4 py-3 space-y-1"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="flex items-center justify-center h-6 w-6 rounded bg-primary/10 text-primary text-xs font-bold">
-                    {c.icon}
-                  </span>
-                  <h3 className="font-semibold text-sm">{c.name}</h3>
-                  <span className="text-xs text-muted-foreground ml-auto">
-                    {c.short}
-                  </span>
-                </div>
-                <p className="text-xs text-muted-foreground leading-relaxed">
-                  {c.detail}
-                </p>
-                {c.relates && (
-                  <p className="text-[10px] text-primary/70 italic">
-                    {c.relates}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
-      </DialogContent>
-    </Dialog>
-  );
-}
+export function OntologyModal() { return <ConceptsDialog />; }
+export function OntologyModalExpanded() { return <ConceptsDialog expanded />; }

--- a/web/src/lib/topology-layout.ts
+++ b/web/src/lib/topology-layout.ts
@@ -1,0 +1,79 @@
+import Dagre from "@dagrejs/dagre";
+import type { Node, Edge } from "@xyflow/react";
+
+/** Estimated node dimensions for dagre layout (width, height). */
+export const NODE_SIZES: Record<string, [number, number]> = {
+  gateway:       [220, 70],
+  k8sNode:       [280, 110],
+  cloudProvider: [180, 50],
+  model:         [200, 70],
+  ensemble:      [200, 50],
+  stimulus:      [140, 40],
+  persona:       [150, 50],
+  agent:         [240, 56],
+  agentRun:      [140, 40],
+  harness:       [260, 56],
+};
+
+/** Run dagre layout on nodes and edges, positioning top-to-bottom. */
+export function applyDagreLayout(nodes: Node[], edges: Edge[]): void {
+  const g = new Dagre.graphlib.Graph({ compound: true })
+    .setDefaultEdgeLabel(() => ({}))
+    .setGraph({
+      rankdir: "TB",
+      nodesep: 60,
+      ranksep: 100,
+      edgesep: 30,
+    });
+
+  for (const node of [...nodes].sort((a, b) => a.id.localeCompare(b.id))) {
+    const [w, h] = NODE_SIZES[node.type || ""] || [160, 50];
+    if (node.parentId) continue; // skip children of compound nodes
+    g.setNode(node.id, { width: w, height: h });
+  }
+
+  for (const edge of [...edges].sort((a, b) => a.id.localeCompare(b.id))) {
+    // Only add edges between nodes that exist in the graph (skip child-only edges).
+    if (g.hasNode(edge.source) && g.hasNode(edge.target)) {
+      g.setEdge(edge.source, edge.target);
+    }
+  }
+
+  Dagre.layout(g);
+
+  // Graph depth is not resource hierarchy: disconnected agents must not float
+  // beside providers, and a shared runtime is configuration, not a child run.
+  // Use Dagre for horizontal ordering, then pack consistent semantic rows.
+  const levels: Record<string, number> = {
+    gateway: 0, k8sNode: 1, model: 2, cloudProvider: 2, harness: 2,
+    ensemble: 3, stimulus: 4, agent: 5, persona: 5, agentRun: 6,
+  };
+  const topLevel = nodes.filter((node) => !node.parentId);
+  const byId = new Map(topLevel.map((node) => [node.id, node]));
+  function level(node: Node, visited = new Set<string>()): number {
+    const base = levels[node.type || ""] ?? 5;
+    if (node.type !== "agentRun" || visited.has(node.id)) return base;
+    const next = new Set(visited).add(node.id);
+    const parents = edges.filter((edge) => edge.target === node.id)
+      .map((edge) => byId.get(edge.source))
+      .filter((parent): parent is Node => parent?.type === "agentRun" && !next.has(parent.id));
+    return Math.max(base, ...parents.map((parent) => level(parent, next) + 1));
+  }
+  const rows = new Map<number, Node[]>();
+  for (const node of topLevel) {
+    const rank = level(node);
+    rows.set(rank, [...(rows.get(rank) || []), node]);
+  }
+  let y = 0;
+  for (const [, row] of [...rows].sort(([a], [b]) => a - b)) {
+    row.sort((a, b) => g.node(a.id).x - g.node(b.id).x || a.id.localeCompare(b.id));
+    const size = (node: Node) => NODE_SIZES[node.type || ""] || [160, 50];
+    const width = row.reduce((sum, node) => sum + size(node)[0], 0) + (row.length - 1) * 60;
+    let x = -width / 2;
+    for (const node of row) {
+      node.position = { x, y };
+      x += size(node)[0] + 60;
+    }
+    y += Math.max(...row.map((node) => size(node)[1])) + 100;
+  }
+}

--- a/web/src/pages/agent-detail.tsx
+++ b/web/src/pages/agent-detail.tsx
@@ -504,6 +504,10 @@ function AgentRuntimeCard({ inst, runtimes }: { inst: Agent; runtimes: import("@
         <p className="text-sm text-muted-foreground">
           Administrator-approved runtime inherited by channels, schedules, and ordinary AgentRuns. A New Run choice can override it once.
         </p>
+        <p className="text-sm text-muted-foreground">
+          Choosing a harness does not select Celln. Kubernetes remains the default.
+          {" "}<Link className="text-primary underline" to={`/runs?create=1&agent=${encodeURIComponent(inst.metadata.name)}`}>Create a run and choose Kubernetes or Celln</Link>, then select the lifecycle and supported tools.
+        </p>
         <Select
           value={selected}
           onValueChange={(value) => patchAgent.mutate({

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -120,6 +120,8 @@ export function RunsPage() {
 
   useEffect(() => {
     if (searchParams.get("create") === "1") {
+      const agentRef = searchParams.get("agent") || "";
+      setForm((current) => ({ ...current, agentRef }));
       setOpen(true);
       setSearchParams({}, { replace: true });
     }
@@ -193,12 +195,31 @@ export function RunsPage() {
             <DialogHeader>
               <DialogTitle>Create Run</DialogTitle>
               <DialogDescription>
-                Task an agent instance to perform work.
+                Choose where the work runs, then select an Agent and a compatible harness.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-4 pt-2">
+              <fieldset className="space-y-2 rounded-md border p-3" data-testid="execution-environment">
+                <legend className="px-1 text-sm font-medium">Execution environment</legend>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {[["job", "Kubernetes", "Default · containers and OCI harnesses"], ["celln", "Celln", "Opt-in · hardware-isolated cells"]].map(([value, title, description]) => (
+                    <label key={value} className={`cursor-pointer rounded-md border p-3 ${form.backend === value ? "border-primary bg-primary/5" : "border-border"}`}>
+                      <span className="flex items-center gap-2 font-medium">
+                        <input type="radio" name="execution-environment" value={value} checked={form.backend === value}
+                          onChange={() => { setForm({ ...form, backend: value, model: value === "celln" && !form.model ? "deepseek-chat" : form.model }); setLentTools([]); }} />
+                        {title}
+                      </span>
+                      <span className="mt-1 block text-xs text-muted-foreground">{description}</span>
+                    </label>
+                  ))}
+                </div>
+                <p className="text-xs text-muted-foreground">Harness selection does not change the execution environment.</p>
+                {form.backend === "celln" && <p className="text-xs text-muted-foreground" role="status">
+                  {capabilities.isLoading ? "Checking Celln availability…" : capabilities.isError ? "Cannot check Celln availability. Operator setup and admission are required." : capabilities.data?.celln.available ? "Celln host eligibility detected. Your harness, tools and permissions still need approval." : `Celln needs operator setup: ${capabilities.data?.celln.reason || "no eligible host reported"}`}
+                </p>}
+              </fieldset>
               <div className="space-y-2">
-                <Label>Instance</Label>
+                <Label>Agent</Label>
                 <Select
                   value={form.agentRef}
                   onValueChange={(v) => { setForm({ ...form, agentRef: v, runtimeRef: "" }); setLentTools([]); }}
@@ -228,7 +249,7 @@ export function RunsPage() {
                 />
               </div>
               <div className="space-y-2">
-                <Label>One-run harness override (advanced)</Label>
+                <Label>Harness for this run</Label>
                 <Select
                   value={form.runtimeRef || "inherit"}
                   onValueChange={(v) => { setForm({ ...form, runtimeRef: v === "inherit" ? "" : v }); setLentTools([]); }}
@@ -246,7 +267,7 @@ export function RunsPage() {
                   </SelectContent>
                 </Select>
                 <p className="text-xs text-muted-foreground">
-                  This is normally not needed: runs inherit <span className="font-mono">{selectedAgent?.spec.runtimeRef || "the built-in runner"}</span> from the selected Agent. Choose another approved harness only for this run.
+                  Inherits <span className="font-mono">{selectedAgent?.spec.runtimeRef || "the built-in runner"}</span> from the Agent. Choose another approved harness for this run if needed. Celln requires a compatible native harness for an enduring conversation.
                 </p>
               </div>
               <div className="grid grid-cols-2 gap-4">
@@ -273,19 +294,6 @@ export function RunsPage() {
                 </div>
               </div>
               <div className="space-y-2">
-                <Label>Backend</Label>
-                <Select
-                  value={form.backend}
-                  onValueChange={(v) => { setForm({ ...form, backend: v, model: v === "celln" && !form.model ? "deepseek-chat" : form.model }); setLentTools([]); }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Standard (Kubernetes Job)" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="job">Standard — Kubernetes Job</SelectItem>
-                    <SelectItem value="celln">Celln — hermetic, hardware-isolated</SelectItem>
-                  </SelectContent>
-                </Select>
                 {jobIncompatible && <p role="alert" className="text-xs text-red-400">This Harness has no OCI image for the Job backend. Select Celln or choose an OCI-compatible Harness.</p>}
                 {form.backend === "celln" && (
                   <>

--- a/web/src/pages/topology.tsx
+++ b/web/src/pages/topology.tsx
@@ -84,7 +84,8 @@ import type {
 import { taskText } from "@/lib/utils";
 import { Link } from "react-router-dom";
 import { useArrowKeyPan, KeyboardGuide } from "@/hooks/use-arrow-key-pan";
-import Dagre from "@dagrejs/dagre";
+import { applyDagreLayout } from "@/lib/topology-layout";
+export { NODE_SIZES, applyDagreLayout } from "@/lib/topology-layout";
 
 // ── Custom node components ────────────────────────────────────────────────────
 
@@ -323,7 +324,7 @@ function StandaloneAgentNode({ data }: NodeProps<Node<StandaloneAgentNodeData>>)
         : "bg-muted-foreground/40";
 
   return (
-    <div className="border border-primary/30 bg-card px-3 py-2 shadow-sm min-w-[150px]">
+    <div className="border border-primary/30 bg-card px-3 py-2 shadow-sm w-[240px]">
       <Handle type="target" position={Position.Top} className="!bg-primary !w-1.5 !h-1.5" />
       <Handle type="source" position={Position.Bottom} className="!bg-primary !w-1.5 !h-1.5" />
       <div className="flex items-center gap-1.5">
@@ -360,14 +361,14 @@ interface HarnessNodeData {
 
 function HarnessNode({ data }: NodeProps<Node<HarnessNodeData>>) {
   return (
-    <div className="border border-amber-500/40 bg-amber-500/5 px-3 py-2 shadow-sm min-w-[150px]">
+    <div className="border border-amber-500/40 bg-amber-500/5 px-3 py-2 shadow-sm w-[260px]">
       <Handle type="target" position={Position.Top} className="!bg-amber-400 !w-1.5 !h-1.5" />
       <Handle type="source" position={Position.Bottom} className="!bg-amber-400 !w-1.5 !h-1.5" />
       <div className="flex items-center gap-1.5">
         <Shield className="h-3.5 w-3.5 text-amber-400 shrink-0" />
         <Link to={`/harnesses/${data.name}`} className="text-[11px] font-medium hover:underline truncate">{data.name}</Link>
       </div>
-      <p className="mt-0.5 text-[9px] text-muted-foreground">{data.ready ? "Ready" : "Not ready"}{data.owner ? ` · ${data.owner}` : ""}</p>
+      <p className="mt-0.5 text-[9px] text-muted-foreground truncate">{data.ready ? "Ready" : "Not ready"}{data.owner ? ` · ${data.owner}` : ""}</p>
     </div>
   );
 }
@@ -556,56 +557,6 @@ export const nodeTypes = {
 
 // ── Layout ────────────────────────────────────────────────────────────────────
 
-/** Estimated node dimensions for dagre layout (width, height). */
-export const NODE_SIZES: Record<string, [number, number]> = {
-  gateway:       [220, 70],
-  k8sNode:       [280, 110],
-  cloudProvider: [180, 50],
-  model:         [200, 70],
-  ensemble:      [200, 50],
-  stimulus:      [140, 40],
-  persona:       [150, 50],
-  agent:         [170, 56],
-  agentRun:      [140, 40],
-  harness:       [170, 56],
-};
-
-/** Run dagre layout on nodes and edges, positioning top-to-bottom. */
-export function applyDagreLayout(nodes: Node[], edges: Edge[]): void {
-  const g = new Dagre.graphlib.Graph({ compound: true })
-    .setDefaultEdgeLabel(() => ({}))
-    .setGraph({
-      rankdir: "TB",
-      nodesep: 60,
-      ranksep: 100,
-      edgesep: 30,
-    });
-
-  for (const node of nodes) {
-    const [w, h] = NODE_SIZES[node.type || ""] || [160, 50];
-    if (node.parentId) continue; // skip children of compound nodes
-    g.setNode(node.id, { width: w, height: h });
-  }
-
-  for (const edge of edges) {
-    // Only add edges between nodes that exist in the graph (skip child-only edges).
-    if (g.hasNode(edge.source) && g.hasNode(edge.target)) {
-      g.setEdge(edge.source, edge.target);
-    }
-  }
-
-  Dagre.layout(g);
-
-  for (const node of nodes) {
-    if (node.parentId) continue;
-    const pos = g.node(node.id);
-    if (pos) {
-      const [w, h] = NODE_SIZES[node.type || ""] || [160, 50];
-      // dagre returns center positions; ReactFlow uses top-left.
-      node.position = { x: pos.x - w / 2, y: pos.y - h / 2 };
-    }
-  }
-}
 
 /** Build a stable fingerprint from entity IDs so we know when layout needs recomputing. */
 function entityFingerprint(
@@ -622,7 +573,7 @@ function entityFingerprint(
     (draNodes || []).map((n) => n.nodeName).sort().join(","),
     models.map((m) => m.metadata.name).sort().join(","),
     ensembles.map((e) => e.metadata.name).sort().join(","),
-    agents.map((a) => a.metadata.name).sort().join(","),
+    agents.map((a) => JSON.stringify([a.metadata.name, a.spec.runtimeRef, a.spec.agents])).sort().join(","),
     runtimes.map((r) => r.metadata.name).sort().join(","),
     hasGateway ? "gw" : "",
   ];
@@ -912,11 +863,11 @@ function buildTopology(
     if (agent.spec.runtimeRef && runtimes.some((runtime) => runtime.metadata.name === agent.spec.runtimeRef)) {
       edges.push({
         id: `e-${agentId}-harness-${agent.spec.runtimeRef}`,
-        source: agentId,
-        target: `harness-${agent.spec.runtimeRef}`,
+        source: `harness-${agent.spec.runtimeRef}`,
+        target: agentId,
         style: { stroke: "#f59e0b", strokeWidth: 1.5, strokeDasharray: "4 3" },
         markerEnd: { type: MarkerType.ArrowClosed, color: "#f59e0b" },
-        label: "executes with",
+        label: "default harness",
         labelStyle: { fontSize: 9, fill: "#8a8c82" },
         labelBgStyle: { fill: "#09090b", fillOpacity: 0.8 },
         labelBgPadding: [4, 2] as [number, number],
@@ -1259,7 +1210,9 @@ function buildTopology(
 
 // ── Inner component (needs ReactFlowProvider above it) ────────────────────────
 
-const TOPO_POSITIONS_KEY = "sympozium_topology_positions";
+// Keep the previous saved layout intact, but do not apply its old graph-depth
+// ordering to the new semantic rows. Manual positions remain supported here.
+const TOPO_POSITIONS_KEY = "sympozium_topology_positions_v2";
 const TOPO_LOCKED_KEY = "sympozium_topology_locked";
 
 function savePositions(nodes: Node[]) {


### PR DESCRIPTION
## Summary
- Rework Concepts into an agent-first guide with an expandable technical glossary and explicit Kubernetes defaults / native Celln limits.
- Put Kubernetes vs Celln at the start of New Run; link Agent Harness and feed users into the selection flow and retain operator admission checks.
- Place topology resources in consistent semantic rows, describe harness links as defaults, and stabilize ordering independently of API list order.
- Keep both changes as separate commits; preserve unrelated local generated assets and communications files.

## Validation
- TypeScript type-check and production Vite build passed on the implementation worktree.
- Three Concepts/execution-choice browser tests passed against Framework.
- Three topology tests passed, including live rendering, resource order and shuffled-list stability.
- Clean main-based worktree verification is being repeated before merge.

Follow-up UX polish for #464 and discussion #472. No backend defaults or execution authority changes.