### PR TITLE
docs: remove redundant video caption link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
 </p>
 <p align="center">
   <b>The harness stays. The task cell goes.</b><br>
-  <a href="https://sympozium.ai/video/sympozium-harness-tasks.mp4">Watch the full-quality video</a> ·
   <a href="https://github.com/sympozium-ai/sympozium/discussions/472">Native cells release</a><br>
   <sub>Native Celln path: one active task at a time; live context does not survive a host crash.</sub>
 </p>


### PR DESCRIPTION
Remove the redundant “Watch the full-quality video” text beneath the README animation. The GIF itself remains linked to the video, and the release link remains in the caption.

Validation: inspected the one-line Markdown deletion and ran `git diff --check`. No code or media changes.
