### PR TITLE
fix(web): complete Agent execution-plane and tool creation flow

### DIFF
--- a/config/samples/agent-native-execution-defaults.yaml
+++ b/config/samples/agent-native-execution-defaults.yaml
@@ -1,0 +1,42 @@
+# Requires the native starter catalogue, qualified owner and explicit operator
+# grants bound to THIS Agent's identity/spec. This manifest grants no authority.
+apiVersion: sympozium.ai/v1alpha1
+kind: Agent
+metadata:
+  name: native-assistant
+  namespace: celln-agents
+spec:
+  runtimeRef: celln-native
+  agents:
+    default:
+      model: deepseek-chat
+  skills: [] # Native SkillPacks/sidecars are not supported.
+  memory:
+    enabled: false # Native context/files live only while the parent lives.
+  execution:
+    backend: celln
+    executionLifecycle: enduring
+    provider: deepseek
+    model: deepseek-chat
+    cellnSelection:
+      runtimeRef: celln-native
+      toolRefs: # Use [] to explicitly request no tools.
+        - name: workspace-read
+          revision: v1
+        - name: workspace-write
+          revision: v1
+    enduring:
+      leaseSeconds: 600
+      maxTurns: 8
+      maxModelRequests: 24
+      maxOutputTokens: 8192
+---
+# After operator approval: no need to repeat the plane or tool selection.
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRun
+metadata:
+  generateName: native-assistant-
+  namespace: celln-agents
+spec:
+  agentRef: native-assistant
+  task: Write violet to notes.txt with workspace-write, using revision 0.

--- a/docs/guides/celln-native-installation.md
+++ b/docs/guides/celln-native-installation.md
@@ -14,6 +14,37 @@ model credentials, a kernel, or a tenant-ready signed package.
 Kubernetes remains the default. Selecting a Harness on an Agent does not switch
 its runs to Celln.
 
+### Create an Agent with saved execution defaults
+
+Use **Create Agent → Harness / Run → Execution plane → SkillPacks**. The
+execution-plane step is always shown, including when you start with a preselected
+Harness. Choose Kubernetes for the built-in Run path or an OCI-compatible
+Harness; choose Celln with a compatible native Harness.
+
+For Celln, explicitly continue without SkillPacks (native SkillPacks are not
+supported yet), then choose **Borrow tools**. Workspace read/write and HTTPS
+fetch are marked as starter suggestions when installed. Select the exact
+catalogue revisions you need, or leave the list empty to request no tools.
+The wizard does not silently remove SkillPacks or automatically grant suggested
+tools. Native model credentials remain on the host, so this flow skips API-key,
+channel and heartbeat setup. Kubernetes retains those steps and its SkillPacks.
+
+The confirmation and YAML preview include the plane, runtime, lifecycle and
+tool revisions. Creation stores these in `Agent.spec.execution`; a subsequent
+run can inherit them without repeating the choices. Enduring defaults are a
+600-second lease, 8 turns, 24 model requests and 8192 output tokens. Review or
+edit limits on the Agent Harness tab before starting work.
+
+**Creating an Agent is not operator approval.** The Agent's new identity and
+specification must be covered by current grants and host registration. The
+effective-permission preview on its Harness tab is available after creation.
+Existing approvals for another Agent are not transferable. An unapproved run
+must remain unapproved rather than acquiring authority from wizard defaults.
+
+See [the paired Agent/AgentRun YAML example](../../config/samples/agent-native-execution-defaults.yaml).
+
+### Start a run or override its defaults
+
 1. Open **Runs → New Run**. You can also follow the run-creation link from an
    Agent’s **Harness** tab or the feed’s quick-task input; these carry the Agent
    selection into the form.
@@ -27,7 +58,9 @@ its runs to Celln.
 5. Review the permission preview and submit. The operator preparation below is
    still required; a catalogue entry or suggested toolbox is not a grant.
 
-The feed’s quick-send path still uses Kubernetes. Use New Run for Celln settings.
+The feed’s quick-send path inherits saved Agent execution defaults. Agents with
+no execution defaults still use Kubernetes. Use New Run for explicit overrides;
+incompatible overrides are rejected rather than silently dropping tools.
 The **Concepts** guide explains these choices first, with implementation and
 YAML terminology in an expandable glossary.
 

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -867,6 +867,17 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "name, provider, and model are required", http.StatusBadRequest)
 		return
 	}
+	// Reject invalid execution defaults before any credential Secret is written.
+	if req.Execution != nil {
+		if reason := req.Execution.Validate(); reason != "" {
+			http.Error(w, reason, http.StatusBadRequest)
+			return
+		}
+		if req.Execution.Backend == "celln" && len(req.Skills) > 0 {
+			http.Error(w, "Celln execution defaults cannot be combined with SkillPacks; choose Kubernetes or explicitly remove the SkillPacks", http.StatusBadRequest)
+			return
+		}
+	}
 
 	inst := &sympoziumv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1037,6 +1048,11 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 		}
 		// OCI HarnessSession auto-create is gated below when backend is celln.
 		inst.Spec.Execution = req.Execution.DeepCopy()
+		if req.Execution.Backend == "celln" {
+			// Native files/context belong to the live parent, not the Kubernetes
+			// memory controller. Do not provision an unrelated memory service.
+			inst.Spec.Memory.Enabled = false
+		}
 	}
 
 	if len(req.Skills) > 0 {

--- a/internal/apiserver/server_agent_test.go
+++ b/internal/apiserver/server_agent_test.go
@@ -37,6 +37,57 @@ func newInstanceTestServer(t *testing.T) (*Server, *runtime.Scheme) {
 	return NewServer(cl, nil, nil, logr.Discard()), scheme
 }
 
+func TestCreateAgentNativeToolDefaultsRoundTrip(t *testing.T) {
+	srv, _ := newInstanceTestServer(t)
+	body := `{"name":"native-wizard","provider":"deepseek","model":"deepseek-chat","runtimeRef":"native","skills":[],"execution":{"backend":"celln","executionLifecycle":"enduring","provider":"deepseek","model":"deepseek-chat","cellnSelection":{"runtimeRef":"native","toolRefs":[{"name":"workspace-read","revision":"v1"}]},"enduring":{"leaseSeconds":600,"maxTurns":8,"maxModelRequests":24,"maxOutputTokens":8192}}}`
+	rec := httptest.NewRecorder()
+	srv.buildMux(nil, nil).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/agents?namespace=default", bytes.NewBufferString(body)))
+	if rec.Code >= 300 {
+		t.Fatalf("create: %d %s", rec.Code, rec.Body.String())
+	}
+	var agent sympoziumv1alpha1.Agent
+	if err := srv.client.Get(context.Background(), types.NamespacedName{Name: "native-wizard", Namespace: "default"}, &agent); err != nil {
+		t.Fatal(err)
+	}
+	if agent.Spec.Execution == nil || agent.Spec.Execution.CellnSelection.ToolRefs[0].Revision != "v1" || agent.Spec.Memory.Enabled || len(agent.Spec.Skills) != 0 || len(agent.Spec.AuthRefs) != 0 {
+		t.Fatalf("native defaults not preserved: %+v", agent.Spec)
+	}
+	var secrets corev1.SecretList
+	if err := srv.client.List(context.Background(), &secrets); err != nil || len(secrets.Items) != 0 {
+		t.Fatalf("native wizard created credentials: %v, count=%d", err, len(secrets.Items))
+	}
+	var sessions sympoziumv1alpha1.HarnessSessionList
+	if err := srv.client.List(context.Background(), &sessions); err != nil || len(sessions.Items) != 0 {
+		t.Fatalf("native wizard created OCI session: %v, count=%d", err, len(sessions.Items))
+	}
+	// A plain request must inherit the saved plane, lifecycle and exact tools.
+	rec = httptest.NewRecorder()
+	srv.buildMux(nil, nil).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/runs?namespace=default", bytes.NewBufferString(`{"agentRef":"native-wizard","task":"Read the workspace"}`)))
+	if rec.Code >= 300 {
+		t.Fatalf("run: %d %s", rec.Code, rec.Body.String())
+	}
+	var run sympoziumv1alpha1.AgentRun
+	if err := json.Unmarshal(rec.Body.Bytes(), &run); err != nil {
+		t.Fatal(err)
+	}
+	if run.Spec.Backend != "celln" || run.Spec.ExecutionLifecycle != "enduring" || run.Spec.CellnSelection == nil || run.Spec.CellnSelection.ToolRefs[0].Revision != "v1" {
+		t.Fatalf("run lost wizard defaults: %+v", run.Spec)
+	}
+}
+
+func TestCreateAgentInvalidNativeSkillsDoesNotWriteSecret(t *testing.T) {
+	srv, _ := newInstanceTestServer(t)
+	rec := httptest.NewRecorder()
+	srv.buildMux(nil, nil).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/agents?namespace=default", bytes.NewBufferString(`{"name":"invalid-native","provider":"deepseek","model":"deepseek-chat","apiKey":"test-not-a-real-key","skills":[{"skillPackRef":"k8s-ops"}],"execution":{"backend":"celln","cellnSelection":{"toolRefs":[]}}}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400: %d %s", rec.Code, rec.Body.String())
+	}
+	var secrets corev1.SecretList
+	if err := srv.client.List(context.Background(), &secrets); err != nil || len(secrets.Items) != 0 {
+		t.Fatalf("invalid request wrote credentials: %v, count=%d", err, len(secrets.Items))
+	}
+}
+
 func TestInstallDefaultRuntimes(t *testing.T) {
 	policy := &sympoziumv1alpha1.SympoziumPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "harness-examples", Namespace: "sympozium-system", Labels: map[string]string{"sympozium.ai/harness-example": "true"}},

--- a/web/cypress/e2e/agent-execution-flow.cy.ts
+++ b/web/cypress/e2e/agent-execution-flow.cy.ts
@@ -1,0 +1,85 @@
+import { agentCreationSteps, executionFromWizard } from "../../src/lib/agent-execution";
+
+// Requires the native starter catalogue in celln-agents. No fabricated API
+// responses: the wizard creates a real Agent, reads it back and deletes it.
+const namespace = "celln-agents";
+const name = `cypress-native-flow-${Date.now()}`;
+function request(method: string, path: string, body?: object) {
+  return cy.request({ method, url: `/api/v1/${path}?namespace=${namespace}`, body,
+    headers: { Authorization: `Bearer ${Cypress.env("API_TOKEN")}` }, failOnStatusCode: false });
+}
+function visit(path: string) {
+  cy.visit(path, { onBeforeLoad(win) { win.localStorage.setItem("sympozium_namespace", namespace); } });
+}
+
+describe("Agent creation execution-plane flow", () => {
+  after(() => { request("DELETE", `agents/${name}`); });
+
+  it("uses the requested order and keeps native selections out of Kubernetes defaults", () => {
+    expect(agentCreationSteps(true).slice(0, 5)).to.deep.equal(["name", "runtime", "plane", "skills", "tools"]);
+    expect(agentCreationSteps(false)).not.to.include("tools");
+    expect(executionFromWizard({ executionBackend: "job", model: "test", borrowedTools: [{ name: "stale", revision: "v1" }] })).to.deep.equal({ backend: "job", executionLifecycle: "one-shot" });
+  });
+
+  it("does not bypass the plane step for a preselected harness", () => {
+    visit("/agents?create=1&runtime=celln-native");
+    cy.get('input[placeholder="my-agent"]').type(name);
+    cy.wizardNext();
+    cy.contains("label", "Harness / Run").should("be.visible");
+    cy.wizardNext();
+    cy.get('[data-testid="create-agent-execution-environment"]').should("be.visible");
+    cy.contains("This harness has no Kubernetes image").should("be.visible");
+    cy.get('[role="dialog"]').contains("button", "Next").should("be.disabled");
+  });
+
+  it("creates a native Agent with pinned borrowed tools and matching YAML", () => {
+    visit("/agents?create=1&runtime=celln-native");
+    cy.get('input[placeholder="my-agent"]').type(name);
+    cy.wizardNext();
+    cy.wizardNext();
+    cy.get('[data-testid="create-agent-execution-environment"]').contains("button", "Celln").click();
+    cy.contains("label", "enduring").find("input").check();
+    cy.wizardNext();
+    cy.get('[data-testid="native-skill-compatibility"]').should("be.visible");
+    cy.get('[role="dialog"]').contains("button", "Next").should("be.disabled");
+    cy.contains("button", "Continue without SkillPacks").click();
+    cy.wizardNext();
+    cy.get('[data-testid="create-agent-borrowed-tools"]').within(() => {
+      cy.contains("label", "workspace-read@").find('input[type="checkbox"]').check();
+      cy.contains("label", "workspace-write@").find('input[type="checkbox"]').check();
+    });
+    cy.wizardNext();
+    cy.get("#native-model").should("have.value", "deepseek-chat");
+    cy.wizardNext();
+    cy.get('[data-testid="execution-confirmation"]').should("contain", "workspace-read@v1").and("contain", "workspace-write@v1");
+    cy.contains("button", "YAML").click();
+    cy.get('[role="dialog"]').last().should("contain", "backend: celln").and("contain", "toolRefs:").and("contain", "workspace-write").and("not.contain", "skillPackRef: memory");
+    cy.get("body").type("{esc}");
+    cy.get('[role="dialog"]').contains("button", /Create\s*$/).click();
+    cy.get('[role="dialog"]').should("not.exist");
+    request("GET", `agents/${name}`).then(({ status, body }) => {
+      expect(status).to.equal(200);
+      expect(body.spec.execution.backend).to.equal("celln");
+      expect(body.spec.execution.executionLifecycle).to.equal("enduring");
+      expect(body.spec.execution.cellnSelection.toolRefs).to.deep.equal([{ name: "workspace-read", revision: "v1" }, { name: "workspace-write", revision: "v1" }]);
+      expect(body.spec.skills || []).to.have.length(0);
+      expect(body.spec.authRefs || []).to.have.length(0);
+      expect(body.spec.memory.enabled).to.equal(false);
+    });
+  });
+
+  it("keeps SkillPacks in the Kubernetes flow and omits borrowing", () => {
+    visit("/agents?create=1");
+    cy.get('input[placeholder="my-agent"]').type("cypress-kubernetes-flow");
+    cy.wizardNext();
+    cy.contains("label", "Harness / Run").should("be.visible");
+    cy.wizardNext();
+    cy.get('[data-testid="create-agent-execution-environment"]').contains("Kubernetes");
+    cy.wizardNext();
+    cy.contains("Select SkillPacks to attach").should("be.visible");
+    cy.get('[data-testid="native-skill-compatibility"]').should("not.exist");
+    cy.wizardNext();
+    cy.get('[data-testid="create-agent-borrowed-tools"]').should("not.exist");
+    cy.contains("label", "AI Provider").should("exist");
+  });
+});

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -42,9 +42,10 @@ import {
   Wifi,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useCapabilities, useModels } from "@/hooks/use-api";
+import { useCapabilities, useModels, useCellnTools } from "@/hooks/use-api";
+import { agentCreationSteps } from "@/lib/agent-execution";
 import { api } from "@/lib/api";
-import type { AgentRuntime, SympoziumPolicy } from "@/lib/api";
+import type { AgentRuntime, SympoziumPolicy, CellnSelection } from "@/lib/api";
 import {
   YamlModal,
   instanceYamlFromWizard,
@@ -223,6 +224,8 @@ export interface WizardResult {
   executionBackend?: "job" | "celln";
   /** Default Celln lifecycle when executionBackend is celln. */
   executionLifecycle?: "one-shot" | "enduring";
+  /** Immutable catalogue revisions requested as defaults; never permission grants. */
+  borrowedTools?: CellnSelection["toolRefs"];
 }
 
 interface OnboardingWizardProps {
@@ -254,6 +257,8 @@ interface OnboardingWizardProps {
 type WizardStep =
   | "name"
   | "runtime"
+  | "plane"
+  | "tools"
   | "provider"
   | "apikey"
   | "model"
@@ -265,27 +270,13 @@ type WizardStep =
 
 function stepsForMode(
   mode: "agent" | "persona" | "canary",
-  runtimePreselected = false,
+  celln = false,
 ): WizardStep[] {
   if (mode === "canary") {
     return ["provider", "apikey", "model"];
   }
   if (mode === "agent") {
-    const steps: WizardStep[] = [
-      "name",
-      "provider",
-      "apikey",
-      "model",
-      "skills",
-      "heartbeat",
-      "channels",
-      "confirm",
-      "channelAction",
-    ];
-    // The dedicated Create → Agent Harness flow has already selected a
-    // persistent runtime. Do not make the user confirm the same decision.
-    if (!runtimePreselected) steps.splice(1, 0, "runtime");
-    return steps;
+    return [...agentCreationSteps(celln)] as WizardStep[];
   }
   return [
     "provider",
@@ -310,7 +301,9 @@ function StepIndicator({
 }) {
   const labels: Record<WizardStep, string> = {
     name: "Name",
-    runtime: "Execution",
+    runtime: "Harness / Run",
+    plane: "Execution plane",
+    tools: "Borrow tools",
     provider: "Provider",
     apikey: "Auth",
     model: "Model",
@@ -323,6 +316,8 @@ function StepIndicator({
   const icons: Record<WizardStep, React.ReactNode> = {
     name: <Server className="h-3.5 w-3.5" />,
     runtime: <Terminal className="h-3.5 w-3.5" />,
+    plane: <Server className="h-3.5 w-3.5" />,
+    tools: <Wrench className="h-3.5 w-3.5" />,
     provider: <Bot className="h-3.5 w-3.5" />,
     apikey: <Key className="h-3.5 w-3.5" />,
     model: <Sparkles className="h-3.5 w-3.5" />,
@@ -550,8 +545,7 @@ export function OnboardingWizard({
   const defaultRuntimeRef = selectableRuntimes.some(
     (runtime) => runtime.metadata.name === defaults?.runtimeRef,
   ) ? defaults?.runtimeRef || "" : "";
-  const steps = stepsForMode(mode, !!defaultRuntimeRef);
-  const [step, setStep] = useState<WizardStep>(steps[0]);
+  const [step, setStep] = useState<WizardStep>(mode === "agent" ? "name" : "provider");
   const [form, setForm] = useState<WizardResult>({
     name: defaults?.name || "",
     provider: defaults?.provider || "",
@@ -583,7 +577,16 @@ export function OnboardingWizard({
     policyRef: defaults?.policyRef || "",
     executionBackend: defaults?.executionBackend || "job",
     executionLifecycle: defaults?.executionLifecycle || "one-shot",
+    borrowedTools: defaults?.borrowedTools || [],
   });
+  const celln = mode === "agent" && form.executionBackend === "celln";
+  const steps = stepsForMode(mode, celln);
+  const catalogue = useCellnTools();
+  const selectedRuntime = selectableRuntimes.find((runtime) => runtime.metadata.name === form.runtimeRef);
+  const compatibleRuntime = celln
+    ? selectedRuntime?.spec.celln?.contractVersion === "celln.json-tools/v1"
+    : !form.runtimeRef || !!selectedRuntime?.spec.image;
+  const staleTools = (form.borrowedTools || []).some((ref) => !(catalogue.data || []).some((tool) => tool.metadata.name === ref.name && tool.spec.revision === ref.revision && tool.spec.invocationABI === "celln.json-stdio/v1" && tool.spec.lane === "tool"));
   const [inferenceMode, setInferenceMode] = useState<"workload" | "node">(
     "workload",
   );
@@ -663,6 +666,10 @@ export function OnboardingWizard({
         return nameValid;
       case "provider":
         return !!form.provider;
+      case "plane":
+        return compatibleRuntime;
+      case "tools":
+        return !catalogue.isLoading && !catalogue.isError && !staleTools && (form.borrowedTools || []).length <= 16;
       case "apikey":
         if (
           form.provider === "ollama" ||
@@ -682,7 +689,7 @@ export function OnboardingWizard({
       case "model":
         return !!form.model;
       case "skills":
-        return true;
+        return celln ? form.skills.length === 0 : !form.runtimeRef || !form.skills.some((skill) => harnessIncompatibleSkills.includes(skill));
       case "channelAction":
         return true;
       default:
@@ -697,6 +704,7 @@ export function OnboardingWizard({
   const hasActionChannels = actionChannels.length > 0;
 
   function completeWithDefaults() {
+    if (mode === "agent" && (!compatibleRuntime || (celln && (form.skills.length > 0 || catalogue.isLoading || catalogue.isError || staleTools)))) return;
     // Apply default baseURL for local providers if the user left it empty.
     const result = { ...form };
     if (!result.baseURL) {
@@ -730,7 +738,7 @@ export function OnboardingWizard({
     let nextIdx = stepIdx + 1;
     while (
       nextIdx < steps.length &&
-      usingLocalModel &&
+      !celln && usingLocalModel &&
       (steps[nextIdx] === "apikey" || steps[nextIdx] === "model")
     ) {
       nextIdx++;
@@ -746,7 +754,7 @@ export function OnboardingWizard({
     let prevIdx = stepIdx - 1;
     while (
       prevIdx >= 0 &&
-      usingLocalModel &&
+      !celln && usingLocalModel &&
       (steps[prevIdx] === "apikey" || steps[prevIdx] === "model")
     ) {
       prevIdx--;
@@ -789,6 +797,7 @@ export function OnboardingWizard({
       policyRef: d.policyRef || "",
       executionBackend: d.executionBackend || "job",
       executionLifecycle: d.executionLifecycle || "one-shot",
+      borrowedTools: d.borrowedTools || [],
     });
     setStep(steps[0]);
     setChannelActionIdx(0);
@@ -846,7 +855,7 @@ export function OnboardingWizard({
             {mode === "canary"
               ? "Choose a provider and model for the system health canary."
               : mode === "agent"
-                ? "Configure a new Agent with provider, model, and skills."
+                ? "Choose Harness or Run, execution plane, SkillPacks, and borrowed tools for Celln."
                 : "Configure provider, model, skills, and channels to activate this ensemble."}
           </DialogDescription>
         </DialogHeader>
@@ -883,7 +892,7 @@ export function OnboardingWizard({
         {step === "runtime" && (
           <div className="space-y-4">
             <div>
-              <Label>How will this Agent execute?</Label>
+              <Label>Harness / Run</Label>
               <p className="mt-1 text-xs text-muted-foreground">
                 Choose the Agent's default execution runtime. Normal AgentRuns inherit this choice; a run may make a one-off override later.
               </p>
@@ -897,18 +906,15 @@ export function OnboardingWizard({
                   ...form,
                   runtimeRef,
                   policyRef: runtimeRef && isDefaultCatalog ? "harness-examples" : runtimeRef ? form.policyRef : "",
-                  skills: runtimeRef
-                    ? form.skills.filter((skill) => !harnessIncompatibleSkills.includes(skill))
-                    : form.skills,
                 });
               }}
             >
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="builtin">Built-in Agent runner — recommended default</SelectItem>
+                <SelectItem value="builtin">Run — built-in Kubernetes agent runner</SelectItem>
                 {selectableRuntimes.map((runtime) => (
                   <SelectItem key={runtime.metadata.name} value={runtime.metadata.name}>
-                    {runtime.metadata.name}{runtime.spec.session?.protocol === "openai-chat" ? " — persistent chat" : " — one-shot"}{runtime.spec.supportOwner ? ` · ${runtime.spec.supportOwner}` : ""}
+                    {runtime.metadata.name}{runtime.spec.celln ? " — native Celln" : runtime.spec.session?.protocol === "openai-chat" ? " — Kubernetes persistent chat" : " — Kubernetes one-shot"}{runtime.spec.supportOwner ? ` · ${runtime.spec.supportOwner}` : ""}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -916,7 +922,7 @@ export function OnboardingWizard({
             {form.runtimeRef ? (
               <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-muted-foreground">
                 <span className="font-medium text-foreground">Harness selected: {form.runtimeRef}.</span>{" "}
-                This external adapter becomes the primary process for this Agent's runs. Your provider, model, endpoint, and credential selected in the next steps remain the Agent configuration passed to it. Sympozium still enforces identity, policy, mounts, NATS permissions, and lifecycle.
+                The execution plane in the next step must support this harness. Kubernetes adapters use the Agent’s configured provider; native Celln uses host-held model credentials and explicitly borrowed tools.
               </div>
             ) : (
               <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
@@ -926,8 +932,13 @@ export function OnboardingWizard({
             {form.runtimeRef && !availablePolicies.some((policy) => policy.metadata.name === form.policyRef) && (
               <p className="text-xs text-amber-500">The selected harness needs an approving policy. Install the default harnesses for this namespace, or ask an administrator to provide one.</p>
             )}
+
+          </div>
+        )}
+
+        {step === "plane" && <div className="space-y-3">
             <div className="space-y-2" data-testid="create-agent-execution-environment">
-              <Label>Default execution environment</Label>
+              <Label>Execution plane</Label>
               <p className="text-xs text-muted-foreground">Kubernetes remains the product default. Celln is a privileged opt-in. Harness selection alone does not choose Celln or grant tools.</p>
               <div className="grid gap-2 sm:grid-cols-2">
                 {([["job", "Kubernetes", "Default · containers and OCI"], ["celln", "Celln", "Opt-in · hardware-isolated"]] as const).map(([value, title, description]) => (
@@ -939,9 +950,15 @@ export function OnboardingWizard({
                       ...form,
                       executionBackend: value,
                       executionLifecycle: value === "celln" ? form.executionLifecycle || "one-shot" : "one-shot",
-                      skills: value === "celln" ? [] : form.skills,
                       provider: value === "celln" ? "deepseek" : form.provider,
-                      model: value === "celln" && !form.model ? "deepseek-chat" : form.model,
+                      model: value === "celln" ? "deepseek-chat" : form.model,
+                      apiKey: value === "celln" ? "" : form.apiKey,
+                      secretName: value === "celln" ? "" : form.secretName,
+                      baseURL: value === "celln" ? "" : form.baseURL,
+                      modelRef: value === "celln" ? undefined : form.modelRef,
+                      agentSandboxEnabled: value === "celln" ? false : form.agentSandboxEnabled,
+                      channels: value === "celln" ? [] : form.channels,
+                      heartbeatInterval: value === "celln" ? "" : form.heartbeatInterval,
                     })}
                   >
                     <p className="text-sm font-medium">{title}</p>
@@ -961,13 +978,39 @@ export function OnboardingWizard({
                     ))}
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Approved tools can be set after creation on the Agent harness tab (with starter suggestions and an effective-permissions preview). An explicit empty tool list is distinct from inheritance. {capabilities?.celln?.available ? (capabilities.celln.oneShot?.reason || capabilities.celln.reason) : `Celln readiness: ${capabilities?.celln?.state || "unknown"} — ${capabilities?.celln?.reason || "not confirmed"}.`}
+                    You will choose borrowed tools before creating this Agent. An empty selection explicitly lends no tools. Model credentials stay on the host; this flow does not create a model-key Secret or configure channels/heartbeats. {capabilities?.celln?.available ? capabilities.celln.reason : `Celln readiness: ${capabilities?.celln?.state || "unknown"} — ${capabilities?.celln?.reason || "not confirmed"}.`}
                   </p>
                 </div>
               )}
             </div>
-          </div>
-        )}
+          {!compatibleRuntime && <p role="alert" className="text-sm text-red-400">{celln ? "Choose a native Celln harness in the previous step. The built-in Kubernetes runner and OCI-only harnesses cannot run in Celln." : "This harness has no Kubernetes image. Go back to select a Kubernetes-compatible harness, or choose Celln."}</p>}
+        </div>}
+
+        {step === "tools" && <div className="space-y-3" data-testid="create-agent-borrowed-tools">
+          <h3 className="font-medium">Borrow tools for Celln</h3>
+          <p className="text-sm text-muted-foreground">Select installed, reviewed revisions to request for this Agent’s runs. This saves defaults, not permission grants. Effective operator/runtime/Agent permissions can be previewed on the Harness tab after the Agent exists and are checked again before execution.</p>
+          {catalogue.isLoading && <p>Loading tool catalogue…</p>}
+          {catalogue.isError && <p role="alert">Cannot load the tool catalogue. Retry before creating this Agent.</p>}
+          {catalogue.isError && <Button type="button" onClick={() => catalogue.refetch()}>Retry catalogue</Button>}
+          {!catalogue.isLoading && !catalogue.isError && catalogue.data?.length === 0 && <p>No tools installed in this namespace. An empty selection lends no tools.</p>}
+          {(catalogue.data || []).map((tool) => {
+            const selected = (form.borrowedTools || []).some((ref) => ref.name === tool.metadata.name && ref.revision === tool.spec.revision);
+            const supported = tool.spec.invocationABI === "celln.json-stdio/v1" && tool.spec.lane === "tool";
+            const suggested = ["workspace-read", "workspace-write", "https-fetch"].includes(tool.metadata.name);
+            return <label key={tool.metadata.name} className="block rounded border p-3 text-sm">
+              <span className="flex items-center gap-2">
+                <input type="checkbox" disabled={!supported || (!selected && (form.borrowedTools || []).length >= 16)} checked={selected}
+                  onChange={() => setForm({ ...form, borrowedTools: selected ? (form.borrowedTools || []).filter((ref) => ref.name !== tool.metadata.name) : [...(form.borrowedTools || []), { name: tool.metadata.name, revision: tool.spec.revision }] })} />
+                {tool.metadata.name}@{tool.spec.revision}{suggested ? " — starter suggestion" : ""}{!supported ? " — unsupported ABI/lane" : ""}
+              </span>
+              <span className="mt-1 block text-xs text-muted-foreground">{tool.spec.description}</span>
+              <span className="block text-xs text-muted-foreground">Limit: {tool.spec.limits.timeoutMillis} ms · workspace: {tool.spec.limits.workspace} · effects: {tool.spec.limits.effects}</span>
+            </label>;
+          })}
+          <p className="text-xs">{(form.borrowedTools || []).length}/16 selected. No shell, Python, host mounts or unrestricted network access is included.</p>
+          {staleTools && <p role="alert">The catalogue changed. Clear the selection and choose current revisions.</p>}
+          {!!form.borrowedTools?.length && <Button type="button" variant="outline" onClick={() => setForm({ ...form, borrowedTools: [] })}>Lend no tools</Button>}
+        </div>}
 
         {/* ── Provider step ─────────────────────────────────────────── */}
         {step === "provider" && (
@@ -1324,7 +1367,11 @@ export function OnboardingWizard({
         {/* ── Model step ────────────────────────────────────────────── */}
         {step === "model" && (
           <div className="space-y-2">
-            <ModelSelector
+            {celln ? <>
+              <Label htmlFor="native-model">Model (host-approved DeepSeek route)</Label>
+              <Input id="native-model" value={form.model} onChange={(event) => setForm({ ...form, model: event.target.value })} placeholder="deepseek-chat" />
+              <p className="text-xs text-muted-foreground">The owner must approve this model. Credentials remain on the host; no API key is requested here.</p>
+            </> : <ModelSelector
               provider={form.provider}
               apiKey={form.apiKey}
               baseURL={form.baseURL}
@@ -1340,7 +1387,7 @@ export function OnboardingWizard({
                     }
                   : undefined
               }
-            />
+            />}
             {mode === "persona" && agentConfigCount !== undefined && (
               <p className="text-xs text-muted-foreground">
                 Applied to all{" "}
@@ -1360,6 +1407,10 @@ export function OnboardingWizard({
               <p className="text-sm text-muted-foreground">
                 Select SkillPacks to attach.
               </p>
+              {celln && <div className="space-y-2 rounded border p-3 text-sm" data-testid="native-skill-compatibility">
+                <p>Native Celln does not support SkillPacks yet, including memory and Kubernetes administration sidecars. Borrowed tools are selected next. Existing Kubernetes SkillPacks remain available on the Kubernetes plane.</p>
+                {form.skills.length > 0 && <Button type="button" variant="outline" onClick={() => setForm({ ...form, skills: [] })}>Continue without SkillPacks</Button>}
+              </div>}
               {availableSkills.length === 0 ? (
                 <p className="rounded-md border border-border/50 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
                   No SkillPacks found in cluster.
@@ -1372,7 +1423,7 @@ export function OnboardingWizard({
                       .map((skill) => {
                         const selected = form.skills.includes(skill);
                         const locked = skill === "memory";
-                        const incompatible = !!form.runtimeRef && harnessIncompatibleSkills.includes(skill);
+                        const incompatible = celln || (!!form.runtimeRef && harnessIncompatibleSkills.includes(skill));
                         return (
                           <button
                             key={skill}
@@ -1752,6 +1803,14 @@ export function OnboardingWizard({
                   <span className="font-mono text-blue-400">{form.name}</span>
                 </div>
               )}
+              {mode === "agent" && <div className="space-y-2" data-testid="execution-confirmation">
+                <p>Execution plane: {celln ? "Celln" : "Kubernetes"}</p>
+                {celln && <>
+                  <p>Lifecycle: {form.executionLifecycle}</p>
+                  <p>Borrowed tools: {(form.borrowedTools || []).map((tool) => `${tool.name}@${tool.revision}`).join(", ") || "none (explicit empty selection)"}</p>
+                  <p className="text-xs text-muted-foreground">This saves requested defaults, not grants. {form.executionLifecycle === "enduring" ? "Parent defaults: 600-second lease, 8 turns, 24 model requests, 8192 output tokens. Context and files are lost with the parent." : "Each run uses a disposable cell."}</p>
+                </>}
+              </div>}
               {mode === "agent" && (
                 <div className="flex justify-between gap-4">
                   <span className="text-muted-foreground">Execution</span>

--- a/web/src/components/yaml-panel.tsx
+++ b/web/src/components/yaml-panel.tsx
@@ -10,6 +10,7 @@ import { FileCode, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toYaml, type YamlValue } from "@/lib/yaml";
 import type { WizardResult } from "@/components/onboarding-wizard";
+import { executionFromWizard } from "@/lib/agent-execution";
 import type { Agent, Ensemble } from "@/lib/api";
 
 // ── YAML builders ─────────────────────────────────────────────────────────────
@@ -31,8 +32,7 @@ export function instanceYamlFromWizard(result: WizardResult): string {
       return ref;
     });
 
-  // Always include the memory skill
-  skills.unshift({ skillPackRef: "memory" });
+  if (result.skills.includes("memory")) skills.unshift({ skillPackRef: "memory" });
 
   const channels = result.channels.map((type) => {
     const ch: Record<string, YamlValue> = { type };
@@ -64,9 +64,12 @@ export function instanceYamlFromWizard(result: WizardResult): string {
     spec: {
       agents: { default: agentConfig },
       skills,
+      ...(result.runtimeRef ? { runtimeRef: result.runtimeRef } : {}),
+      ...(result.policyRef ? { policyRef: result.policyRef } : {}),
+      execution: executionFromWizard(result) as unknown as YamlValue,
       ...(channels.length > 0 ? { channels } : {}),
       ...(authRefs.length > 0 ? { authRefs } : {}),
-      memory: { enabled: true },
+      memory: { enabled: result.executionBackend !== "celln" },
     },
   };
 
@@ -140,6 +143,8 @@ export function instanceYamlFromResource(inst: Agent): string {
     spec.authRefs = inst.spec.authRefs as unknown as YamlValue;
   if (inst.spec.memory) spec.memory = inst.spec.memory as unknown as YamlValue;
   if (inst.spec.policyRef) spec.policyRef = inst.spec.policyRef;
+  if (inst.spec.runtimeRef) spec.runtimeRef = inst.spec.runtimeRef;
+  if (inst.spec.execution) spec.execution = inst.spec.execution as unknown as YamlValue;
 
   const obj: Record<string, YamlValue> = {
     apiVersion: "sympozium.ai/v1alpha1",

--- a/web/src/lib/agent-execution.ts
+++ b/web/src/lib/agent-execution.ts
@@ -1,0 +1,31 @@
+import type { AgentExecutionDefaults, CellnSelection } from "./api";
+
+export interface WizardExecution {
+  executionBackend?: "job" | "celln";
+  executionLifecycle?: "one-shot" | "enduring";
+  borrowedTools?: CellnSelection["toolRefs"];
+  runtimeRef?: string;
+  model: string;
+}
+
+// Shared by API creation and YAML preview: neither may silently lose tool refs.
+export function executionFromWizard(form: WizardExecution): AgentExecutionDefaults {
+  if (form.executionBackend !== "celln") return { backend: "job", executionLifecycle: "one-shot" };
+  return {
+    backend: "celln",
+    executionLifecycle: form.executionLifecycle || "one-shot",
+    provider: "deepseek",
+    model: form.model,
+    cellnSelection: {
+      runtimeRef: form.runtimeRef || undefined,
+      toolRefs: (form.borrowedTools || []).map((tool) => ({ ...tool })),
+    },
+    ...(form.executionLifecycle === "enduring" ? {
+      enduring: { leaseSeconds: 600, maxTurns: 8, maxModelRequests: 24, maxOutputTokens: 8192 },
+    } : {}),
+  };
+}
+
+export function agentCreationSteps(celln: boolean) {
+  return ["name", "runtime", "plane", "skills", ...(celln ? ["tools", "model"] : ["provider", "apikey", "model", "heartbeat", "channels"]), "confirm", "channelAction"] as const;
+}

--- a/web/src/pages/agents.tsx
+++ b/web/src/pages/agents.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { executionFromWizard } from "@/lib/agent-execution";
 import {
   useAgents,
   useDeleteAgent,
@@ -74,14 +75,7 @@ export function AgentsPage() {
         awsSessionToken: result.awsSessionToken || undefined,
         runtimeRef: result.runtimeRef || undefined,
         policyRef: result.policyRef || undefined,
-        execution: result.executionBackend === "celln" ? {
-          backend: "celln",
-          executionLifecycle: result.executionLifecycle || "one-shot",
-          provider: "deepseek",
-          model: result.model || "deepseek-chat",
-          cellnSelection: { toolRefs: [] },
-          enduring: result.executionLifecycle === "enduring" ? { leaseSeconds: 600, maxTurns: 8, maxModelRequests: 24, maxOutputTokens: 8192 } : undefined,
-        } : undefined,
+        execution: executionFromWizard(result),
         skills: result.skills.map((skillPackRef) => {
           if (skillPackRef === "web-endpoint") {
             const params: Record<string, string> = {};


### PR DESCRIPTION
## Changes
- Create Agent now follows Harness / Run → Execution plane → SkillPacks → Borrow tools (Celln only), including preselected harnesses.
- Native SkillPack incompatibility requires explicit removal; tools are pinned before creation, not deferred to editing.
- Share execution-default construction between API submission and YAML preview; include runtime, policy, plane, lifecycle and tool revisions in exported Agent YAML.
- Native creation skips Kubernetes model credentials, channels and heartbeat setup, disables unrelated Kubernetes memory, and rejects invalid SkillPacks before Secret writes.
- Add paired Agent/AgentRun YAML and operator-approval guidance.

## Validation
- Four live-browser wizard tests passed against Framework using this branch API: actual Agent creation/readback, tool revisions/YAML, preselected harness and Kubernetes flow.
- API create→inherited-run tests and invalid-selection/no-Secret tests pass.
- TypeScript type-check and production build pass.
- Broader local race tests run before merge; GitHub checks report separately.

## Live environment caveat
Full native execution was attempted but Framework general controller (controller:pr478-verify) currently has only --leader-elect, without the celln-agents namespace exclusion. It rejected test run celln-agent-dlqf9 with “Celln enduring lifecycle is not yet available on this controller”, despite the dedicated parent controller running. This is NOT a passed native E2E; restore documented namespace separation before hands-on verification. No live grants or journals were changed.

Follow-up to #477 / #478. User will perform final hands-on verification.