### PR TITLE
fix(web): offer persistent Pi and Hermes harnesses

### DIFF
--- a/web/cypress/e2e/persistent-harness-choice.cy.ts
+++ b/web/cypress/e2e/persistent-harness-choice.cy.ts
@@ -1,0 +1,36 @@
+// Exercise the installed catalogue without creating agents or model calls.
+describe("Persistent harness creation", () => {
+  for (const harness of ["Pi", "Hermes"]) {
+    it(`offers ${harness} and progresses directly to provider setup`, () => {
+      cy.visit("/agents?create=1");
+      cy.get('[role="dialog"]').within(() => {
+        cy.get('input[placeholder="my-agent"]').type("persistent-choice-check");
+        cy.contains("button", "Next").click();
+        cy.contains("Choose a persistent harness").should("be.visible");
+        cy.contains("button", "Next").should("be.disabled");
+        cy.get('[role="combobox"]').click();
+      });
+      cy.get('[role="option"]').should("have.length", 2);
+      cy.get('[role="option"]').each(($option) => {
+        expect($option.text()).to.match(/^(Pi|Hermes) — persistent chat$/);
+      });
+      cy.contains('[role="option"]', `${harness} — persistent chat`).click();
+      cy.get('[role="dialog"]').within(() => {
+        cy.contains(`Harness selected: ${harness}.`).should("be.visible");
+        cy.contains("persistent Kubernetes session").should("be.visible");
+        cy.contains("Default Celln lifecycle").should("not.exist");
+        cy.contains("button", "Next").click();
+        cy.contains("AI Provider").should("be.visible");
+      });
+    });
+  }
+  it("retains a preselected persistent harness while the catalogue loads", () => {
+    cy.visit("/agents?create=1&runtime=pi-session-v0-84-4&policy=harness-examples");
+    cy.get('[role="dialog"]').within(() => {
+      cy.get('input[placeholder="my-agent"]').type("preselected-choice-check");
+      cy.contains("button", "Next").click();
+      cy.contains("AI Provider").should("be.visible");
+      cy.contains("Choose a persistent harness").should("not.exist");
+    });
+  });
+});

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -13,6 +13,7 @@ import { Activity, LogOut, Wifi, WifiOff } from "lucide-react";
 import { useWebSocket } from "@/hooks/use-websocket";
 import { useState } from "react";
 import { formatAge } from "@/lib/utils";
+import { persistentHarnesses, persistentHarnessName } from "@/lib/persistent-harness";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { useNavigate } from "react-router-dom";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -116,11 +117,11 @@ export function Header() {
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>{choosingHarness ? "Choose a Harness" : "Create"}</DialogTitle>
-            <DialogDescription>{choosingHarness ? "Choose an approved runtime. Session-capable harnesses start a persistent session; one-shot harnesses configure a new Agent." : <>Choose what you want to create in namespace <span className="font-mono">{ns}</span>.</>}</DialogDescription>
+            <DialogDescription>{choosingHarness ? "Choose Pi or Hermes for a persistent conversation and workspace." : <>Choose what you want to create in namespace <span className="font-mono">{ns}</span>.</>}</DialogDescription>
           </DialogHeader>
           {choosingHarness ? (
             <div className="space-y-3">
-              {(runtimes || []).filter((runtime) => runtime.spec.contractVersion === "v1alpha2" && runtime.spec.session?.protocol === "openai-chat").length === 0 ? (
+              {persistentHarnesses(runtimes || []).length === 0 ? (
                 <div className="space-y-3 rounded-lg border border-border p-4">
                   <p className="text-sm">No approved harnesses are installed in this namespace.</p>
                   <p className="text-xs text-muted-foreground">Install the curated persistent runtimes plus their approving policy. This never accepts an arbitrary image.</p>
@@ -128,13 +129,13 @@ export function Header() {
                 </div>
               ) : (
                 <div className="space-y-2">
-                  {(runtimes || []).filter((runtime) => runtime.spec.contractVersion === "v1alpha2" && runtime.spec.session?.protocol === "openai-chat").map((runtime) => {
+                  {persistentHarnesses(runtimes || []).map((runtime) => {
                     return <button key={runtime.metadata.name} className="w-full rounded-lg border border-border p-3 text-left transition-colors hover:border-amber-500/60 hover:bg-amber-500/5" onClick={() => {
                       setCreateOpen(false);
                       setChoosingHarness(false);
                       navigate(`/agents?create=1&runtime=${encodeURIComponent(runtime.metadata.name)}&policy=harness-examples`);
                     }}>
-                      <div className="flex items-center gap-2"><Shield className="h-4 w-4 text-amber-500" /><span className="font-medium">{runtime.metadata.name}</span></div>
+                      <div className="flex items-center gap-2"><Shield className="h-4 w-4 text-amber-500" /><span className="font-medium">{persistentHarnessName(runtime)}</span></div>
                       <p className="mt-1 text-xs text-muted-foreground">Create an Agent and automatically start its persistent chat.</p>
                     </button>;
                   })}
@@ -147,7 +148,7 @@ export function Header() {
             <button className="rounded-lg border border-border p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5" onClick={() => { setCreateOpen(false); navigate("/agents?create=1"); }}>
               <Bot className="mb-3 h-5 w-5 text-primary" />
               <p className="font-medium">Agent</p>
-              <p className="mt-1 text-xs text-muted-foreground">Create an Agent using Sympozium’s built-in runner.</p>
+              <p className="mt-1 text-xs text-muted-foreground">Create an Agent with a persistent Pi or Hermes harness.</p>
             </button>
             <button className="rounded-lg border border-border p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5" onClick={() => setChoosingHarness(true)}>
               <Shield className="mb-3 h-5 w-5 text-amber-500" />

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -44,6 +44,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useCapabilities, useModels, useCellnTools } from "@/hooks/use-api";
 import { agentCreationSteps } from "@/lib/agent-execution";
+import { persistentHarnesses, persistentHarnessName } from "@/lib/persistent-harness";
 import { api } from "@/lib/api";
 import type { AgentRuntime, SympoziumPolicy, CellnSelection } from "@/lib/api";
 import {
@@ -271,12 +272,14 @@ type WizardStep =
 function stepsForMode(
   mode: "agent" | "persona" | "canary",
   celln = false,
+  runtimePreselected = false,
 ): WizardStep[] {
   if (mode === "canary") {
     return ["provider", "apikey", "model"];
   }
   if (mode === "agent") {
-    return [...agentCreationSteps(celln)] as WizardStep[];
+    if (celln) return [...agentCreationSteps(true)] as WizardStep[];
+    return ["name", ...(runtimePreselected ? [] : ["runtime"]), "provider", "apikey", "model", "skills", "heartbeat", "channels", "confirm", "channelAction"] as WizardStep[];
   }
   return [
     "provider",
@@ -301,7 +304,7 @@ function StepIndicator({
 }) {
   const labels: Record<WizardStep, string> = {
     name: "Name",
-    runtime: "Harness / Run",
+    runtime: "Harness",
     plane: "Execution plane",
     tools: "Borrow tools",
     provider: "Provider",
@@ -541,7 +544,7 @@ export function OnboardingWizard({
   onComplete,
   isPending,
 }: OnboardingWizardProps) {
-  const selectableRuntimes = availableRuntimes;
+  const selectableRuntimes = persistentHarnesses(availableRuntimes);
   const defaultRuntimeRef = selectableRuntimes.some(
     (runtime) => runtime.metadata.name === defaults?.runtimeRef,
   ) ? defaults?.runtimeRef || "" : "";
@@ -575,12 +578,12 @@ export function OnboardingWizard({
     awsSessionToken: defaults?.awsSessionToken || "",
     runtimeRef: defaultRuntimeRef,
     policyRef: defaults?.policyRef || "",
-    executionBackend: defaults?.executionBackend || "job",
+    executionBackend: mode === "agent" ? "job" : defaults?.executionBackend || "job",
     executionLifecycle: defaults?.executionLifecycle || "one-shot",
     borrowedTools: defaults?.borrowedTools || [],
   });
   const celln = mode === "agent" && form.executionBackend === "celln";
-  const steps = stepsForMode(mode, celln);
+  const steps = stepsForMode(mode, celln, !!defaultRuntimeRef);
   const catalogue = useCellnTools();
   const selectedRuntime = selectableRuntimes.find((runtime) => runtime.metadata.name === form.runtimeRef);
   const compatibleRuntime = celln
@@ -664,6 +667,8 @@ export function OnboardingWizard({
     switch (step) {
       case "name":
         return nameValid;
+      case "runtime":
+        return selectableRuntimes.some((runtime) => runtime.metadata.name === form.runtimeRef);
       case "provider":
         return !!form.provider;
       case "plane":
@@ -793,9 +798,9 @@ export function OnboardingWizard({
       awsAccessKeyId: d.awsAccessKeyId || "",
       awsSecretAccessKey: d.awsSecretAccessKey || "",
       awsSessionToken: d.awsSessionToken || "",
-      runtimeRef: d.runtimeRef || "",
+      runtimeRef: selectableRuntimes.some((runtime) => runtime.metadata.name === d.runtimeRef) ? d.runtimeRef : "",
       policyRef: d.policyRef || "",
-      executionBackend: d.executionBackend || "job",
+      executionBackend: mode === "agent" ? "job" : d.executionBackend || "job",
       executionLifecycle: d.executionLifecycle || "one-shot",
       borrowedTools: d.borrowedTools || [],
     });
@@ -809,7 +814,7 @@ export function OnboardingWizard({
     if (open) {
       resetWith(defaults || {});
     }
-  }, [open, defaultsKey]);
+  }, [open, defaultsKey, defaultRuntimeRef]);
 
   const titleIcon =
     mode === "agent" ? (
@@ -855,7 +860,7 @@ export function OnboardingWizard({
             {mode === "canary"
               ? "Choose a provider and model for the system health canary."
               : mode === "agent"
-                ? "Choose Harness or Run, execution plane, SkillPacks, and borrowed tools for Celln."
+                ? "Choose a persistent Pi or Hermes harness, provider, model, and skills."
                 : "Configure provider, model, skills, and channels to activate this ensemble."}
           </DialogDescription>
         </DialogHeader>
@@ -892,41 +897,41 @@ export function OnboardingWizard({
         {step === "runtime" && (
           <div className="space-y-4">
             <div>
-              <Label>Harness / Run</Label>
+              <Label>Choose a persistent harness</Label>
               <p className="mt-1 text-xs text-muted-foreground">
-                Choose the Agent's default execution runtime. Normal AgentRuns inherit this choice; a run may make a one-off override later.
+                Pi and Hermes keep a persistent conversation and workspace. Choose the harness for this Agent.
               </p>
             </div>
             <Select
-              value={form.runtimeRef || "builtin"}
+              value={form.runtimeRef || ""}
               onValueChange={(value) => {
-                const runtimeRef = value === "builtin" ? "" : value;
+                const runtimeRef = value;
                 const isDefaultCatalog = selectableRuntimes.some((runtime) => runtime.metadata.name === runtimeRef && runtime.metadata.labels?.["sympozium.ai/harness-example"] === "true");
                 setForm({
                   ...form,
                   runtimeRef,
+                  executionBackend: "job",
                   policyRef: runtimeRef && isDefaultCatalog ? "harness-examples" : runtimeRef ? form.policyRef : "",
                 });
               }}
             >
-              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectTrigger><SelectValue placeholder="Choose Pi or Hermes" /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="builtin">Run — built-in Kubernetes agent runner</SelectItem>
                 {selectableRuntimes.map((runtime) => (
                   <SelectItem key={runtime.metadata.name} value={runtime.metadata.name}>
-                    {runtime.metadata.name}{runtime.spec.celln ? " — native Celln" : runtime.spec.session?.protocol === "openai-chat" ? " — Kubernetes persistent chat" : " — Kubernetes one-shot"}{runtime.spec.supportOwner ? ` · ${runtime.spec.supportOwner}` : ""}
+                    {persistentHarnessName(runtime)} — persistent chat
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
             {form.runtimeRef ? (
               <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-muted-foreground">
-                <span className="font-medium text-foreground">Harness selected: {form.runtimeRef}.</span>{" "}
-                The execution plane in the next step must support this harness. Kubernetes adapters use the Agent’s configured provider; native Celln uses host-held model credentials and explicitly borrowed tools.
+                <span className="font-medium text-foreground">Harness selected: {selectedRuntime ? persistentHarnessName(selectedRuntime) : form.runtimeRef}.</span>{" "}
+                Your conversation runs in a persistent Kubernetes session. Choose its provider and model in the next steps.
               </div>
             ) : (
               <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
-                The built-in Agent runner will execute this Agent's runs.
+                Choose Pi or Hermes to continue. If neither is listed, install the default harnesses from Create → Harness.
               </div>
             )}
             {form.runtimeRef && !availablePolicies.some((policy) => policy.metadata.name === form.policyRef) && (

--- a/web/src/lib/persistent-harness.ts
+++ b/web/src/lib/persistent-harness.ts
@@ -1,0 +1,11 @@
+import type { AgentRuntime } from "./api";
+
+export function persistentHarnessName(runtime: AgentRuntime): "Pi" | "Hermes" | undefined {
+  if (runtime.spec.contractVersion !== "v1alpha2" || runtime.spec.session?.protocol !== "openai-chat") return undefined;
+  const adapter = runtime.spec.image?.match(/\/(pi|hermes)@sha256:/)?.[1];
+  return adapter === "pi" ? "Pi" : adapter === "hermes" ? "Hermes" : undefined;
+}
+
+export function persistentHarnesses(runtimes: AgentRuntime[]): AgentRuntime[] {
+  return runtimes.filter((runtime) => persistentHarnessName(runtime) !== undefined);
+}

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -159,9 +159,9 @@ export function RunsPage() {
 
   const spend = sumEffectiveCosts(filtered);
 
-  const cellnUnavailable =
-    capabilities.data && !capabilities.data.celln.available;
-  const hasCellnRuns = sorted.some((r) => r.spec.backend === "celln");
+  const oneShotCapability = capabilities.data?.celln.oneShot || capabilities.data?.celln;
+  const cellnUnavailable = oneShotCapability && !oneShotCapability.available;
+  const hasCellnRuns = sorted.some((r) => r.spec.backend === "celln" && r.spec.executionLifecycle !== "enduring");
 
   const handleCreate = () => {
     if (blockedSelection || jobIncompatible || invalidParent || parentRequested) return;
@@ -421,27 +421,10 @@ export function RunsPage() {
         <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-400" data-testid="celln-capability-banner">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
           <div>
-            <p className="font-medium">
-              {capabilities.data?.celln.state === "transport_invalid"
-                ? "Celln transport configuration needs attention"
-                : capabilities.data?.celln.state === "not_installed"
-                  ? "Celln one-shot capabilities are not installed on the configured router"
-                  : capabilities.data?.celln.state === "unreachable"
-                    ? "Celln one-shot router is unreachable"
-                    : capabilities.data?.celln.state === "disabled"
-                      ? "Celln is disabled in this API process"
-                      : "Celln readiness could not be confirmed"}
-            </p>
+            <p className="font-medium">Celln one-shot router needs attention</p>
             <p className="text-xs text-amber-400/80 mt-0.5">
-              {capabilities.data?.celln.reason ||
-                "One-shot router preflight did not succeed."}{" "}
-              This does not prove Celln is absent, and it does not rewrite the
-              observed status of existing runs. Native enduring readiness is
-              checked separately
-              {capabilities.data?.celln.enduring?.reason
-                ? ` (${capabilities.data.celln.enduring.reason})`
-                : ""}.
-              Per-run admission still applies.
+              {oneShotCapability?.reason || "One-shot router preflight did not succeed."}
+              {" "}Existing run statuses are unchanged. Native enduring runs use their own parent controller.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Agent creation allowed selecting a persistent Pi or Hermes Kubernetes harness and then an incompatible Celln execution plane, leaving the user unable to continue. Offer persistent Pi and Hermes choices, route them directly into provider setup, and retain a preselected harness when the catalogue finishes loading.

Show one-shot Celln router warnings only for one-shot runs and remove repeated enduring-readiness text. Native Celln runtime and tool APIs remain available; this does not add native Pi/Hermes adapters or change installer defaults.

Validation: production frontend build and all three Cypress creation-flow tests passed after rebasing onto current main. The persistent-session API creation test also passed during implementation.
