### PR TITLE
feat(web): Celln insecure model routes and native conversation UX

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -217,6 +217,10 @@ type ModelSpec struct {
 	// CredentialProfile is the independently approved opaque host mapping.
 	// +optional
 	CredentialProfile string `json:"credentialProfile,omitempty"`
+	// AllowInsecure is the operator opt-in for an HTTP or self-signed private
+	// model endpoint, carried from the selected connection.
+	// +optional
+	AllowInsecure bool `json:"allowInsecure,omitempty"`
 
 	// Provider is the AI provider (openai, anthropic, azure-openai, github-copilot, ollama, etc.).
 	// Omit when resolving a model connection.

--- a/api/v1alpha1/modelconnection_types.go
+++ b/api/v1alpha1/modelconnection_types.go
@@ -44,6 +44,11 @@ type ModelConnectionSpec struct {
 	// Disabled prevents new connection resolution. Host profile withdrawal stops live use.
 	// +optional
 	Disabled bool `json:"disabled,omitempty"`
+	// AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+	// address. This is an explicit operator opt-in that weakens the default
+	// public-HTTPS transport contract. It never bypasses host admission.
+	// +optional
+	AllowInsecure bool `json:"allowInsecure,omitempty"`
 }
 
 var modelConnectionIdentifier = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
@@ -66,7 +71,7 @@ func (s ModelConnectionSpec) Validate() error {
 		if s.SecretRef != "" {
 			return fmt.Errorf("choose a host credential profile or a Kubernetes Secret, not both")
 		}
-		if _, err := ModelEndpointOrigin(s.Endpoint); err != nil {
+		if _, err := ModelEndpointOriginInsecure(s.Endpoint, s.AllowInsecure); err != nil {
 			return err
 		}
 	}
@@ -86,11 +91,26 @@ func (s ModelConnectionSpec) Validate() error {
 // ModelEndpointOrigin matches the native host HTTPS transport: no userinfo,
 // query credentials, fragments, alternate ports or redirect-based endpoints.
 func ModelEndpointOrigin(endpoint string) (string, error) {
+	return ModelEndpointOriginInsecure(endpoint, false)
+}
+
+// ModelEndpointOriginInsecure returns the egress origin for a model endpoint.
+// The default keeps the public HTTPS transport contract; allowInsecure is an
+// explicit opt-in that also permits HTTP and an explicit port for a private or
+// self-signed endpoint.
+func ModelEndpointOriginInsecure(endpoint string, allowInsecure bool) (string, error) {
 	u, err := url.Parse(endpoint)
-	if err != nil || len(endpoint) > 2048 || u.Scheme != "https" || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Port() != "" || u.Path == "" || strings.ContainsAny(endpoint, "\r\n\x00") {
+	if err != nil || len(endpoint) > 2048 || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Path == "" || strings.ContainsAny(endpoint, "\r\n\x00") {
+		return "", fmt.Errorf("model endpoint must be an HTTP(S) URL without credentials, query or fragment")
+	}
+	if allowInsecure {
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return "", fmt.Errorf("model endpoint must be an HTTP(S) URL")
+		}
+	} else if u.Scheme != "https" || u.Port() != "" {
 		return "", fmt.Errorf("model endpoint must be a complete HTTPS URL without credentials, query, fragment or port")
 	}
-	return "https://" + u.Host, nil
+	return u.Scheme + "://" + u.Host, nil
 }
 
 // +kubebuilder:object:root=true

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -749,6 +749,11 @@ spec:
               model:
                 description: Model specifies the LLM configuration for this run.
                 properties:
+                  allowInsecure:
+                    description: |-
+                      AllowInsecure is the operator opt-in for an HTTP or self-signed private
+                      model endpoint, carried from the selected connection.
+                    type: boolean
                   authSecretRef:
                     description: AuthSecretRef references the secret containing the
                       API key.

--- a/charts/sympozium-crds/templates/sympozium.ai_modelconnections.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_modelconnections.yaml
@@ -40,6 +40,12 @@ spec:
             type: object
           spec:
             properties:
+              allowInsecure:
+                description: |-
+                  AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+                  address. This is an explicit operator opt-in that weakens the default
+                  public-HTTPS transport contract. It never bypasses host admission.
+                type: boolean
               credentialProfile:
                 description: CredentialProfile is an opaque host mapping name, never
                   an API key or file path.

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -749,6 +749,11 @@ spec:
               model:
                 description: Model specifies the LLM configuration for this run.
                 properties:
+                  allowInsecure:
+                    description: |-
+                      AllowInsecure is the operator opt-in for an HTTP or self-signed private
+                      model endpoint, carried from the selected connection.
+                    type: boolean
                   authSecretRef:
                     description: AuthSecretRef references the secret containing the
                       API key.

--- a/charts/sympozium/crds/sympozium.ai_modelconnections.yaml
+++ b/charts/sympozium/crds/sympozium.ai_modelconnections.yaml
@@ -40,6 +40,12 @@ spec:
             type: object
           spec:
             properties:
+              allowInsecure:
+                description: |-
+                  AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+                  address. This is an explicit operator opt-in that weakens the default
+                  public-HTTPS transport contract. It never bypasses host admission.
+                type: boolean
               credentialProfile:
                 description: CredentialProfile is an opaque host mapping name, never
                   an API key or file path.

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -749,6 +749,11 @@ spec:
               model:
                 description: Model specifies the LLM configuration for this run.
                 properties:
+                  allowInsecure:
+                    description: |-
+                      AllowInsecure is the operator opt-in for an HTTP or self-signed private
+                      model endpoint, carried from the selected connection.
+                    type: boolean
                   authSecretRef:
                     description: AuthSecretRef references the secret containing the
                       API key.

--- a/config/crd/bases/sympozium.ai_modelconnections.yaml
+++ b/config/crd/bases/sympozium.ai_modelconnections.yaml
@@ -40,6 +40,12 @@ spec:
             type: object
           spec:
             properties:
+              allowInsecure:
+                description: |-
+                  AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+                  address. This is an explicit operator opt-in that weakens the default
+                  public-HTTPS transport contract. It never bypasses host admission.
+                type: boolean
               credentialProfile:
                 description: CredentialProfile is an opaque host mapping name, never
                   an API key or file path.

--- a/internal/cellnauthority/execution.go
+++ b/internal/cellnauthority/execution.go
@@ -76,7 +76,7 @@ func (l ModelLoader) BuildExecution(ctx context.Context, frozen FrozenSelection,
 	if borrowed == nil {
 		borrowed = []api.CellnBorrowedTool{}
 	}
-	origin, err := api.ModelEndpointOrigin(approval.Policy.URL)
+	origin, err := api.ModelEndpointOriginInsecure(approval.Policy.URL, approval.Policy.AllowInsecure)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (l ModelLoader) BuildExecution(ctx context.Context, frozen FrozenSelection,
 		"invocation": api.CellnInvocation{Alias: frozen.Prepared.RuntimeEntryPoint},
 		"harness": map[string]any{"contractVersion": "celln.json-tools/v1", "modelGrant": api.CellnImmutableRef{Hash: "blake3:" + strings.Repeat("0", 64)}, "model": approval.Policy.Model, "task": task, "borrowedTools": borrowed,
 			"json": map[string]any{"system": s.SystemPrompt, "maxTurns": frozen.Prepared.JSON.MaxTurns, "maxCalls": frozen.Prepared.JSON.MaxCalls}},
-		"capabilities": map[string]any{"workspace": "none", "egress": []string{origin}, "timeoutMs": timeout, "memoryBytes": limits.MemoryBytes, "outputBytes": limits.OutputBytes},
+		"capabilities": map[string]any{"workspace": "none", "egress": []string{origin}, "allowInsecure": approval.Policy.AllowInsecure, "timeoutMs": timeout, "memoryBytes": limits.MemoryBytes, "outputBytes": limits.OutputBytes},
 		"execution":    map[string]any{"lane": "agent", "requireHardwareIsolation": true},
 	}
 	raw, err := json.Marshal(request)

--- a/internal/cellnauthority/model.go
+++ b/internal/cellnauthority/model.go
@@ -27,6 +27,7 @@ type ModelPolicyDocument struct {
 	Runtime              Subject `json:"runtime"`
 	Provider             string  `json:"provider"`
 	Protocol             string  `json:"protocol,omitempty"`
+	AllowInsecure        bool    `json:"allowInsecure,omitempty"`
 	Model                string  `json:"model"`
 	URL                  string  `json:"url"`
 	CredentialProfile    string  `json:"credentialProfile"`
@@ -57,14 +58,14 @@ func validModelPolicyRoute(doc ModelPolicyDocument) bool {
 	if doc.Protocol == "" {
 		return doc.Provider == "deepseek" && doc.URL == "https://api.deepseek.com/chat/completions"
 	}
-	return (api.ModelConnectionSpec{Provider: doc.Provider, Protocol: doc.Protocol, Endpoint: doc.URL, CredentialProfile: doc.CredentialProfile, Models: []string{doc.Model}}).Validate() == nil
+	return (api.ModelConnectionSpec{Provider: doc.Provider, Protocol: doc.Protocol, Endpoint: doc.URL, CredentialProfile: doc.CredentialProfile, Models: []string{doc.Model}, AllowInsecure: doc.AllowInsecure}).Validate() == nil
 }
 
 func modelPolicyMatches(m api.ModelSpec, doc ModelPolicyDocument) bool {
 	if doc.Protocol == "" {
-		return m.Protocol == "" && m.CredentialProfile == "" && (m.BaseURL == "" || m.BaseURL == "https://api.deepseek.com")
+		return m.Protocol == "" && m.CredentialProfile == "" && !m.AllowInsecure && (m.BaseURL == "" || m.BaseURL == "https://api.deepseek.com")
 	}
-	return m.BaseURL == doc.URL && m.Protocol == doc.Protocol && m.CredentialProfile == doc.CredentialProfile
+	return m.BaseURL == doc.URL && m.Protocol == doc.Protocol && m.CredentialProfile == doc.CredentialProfile && m.AllowInsecure == doc.AllowInsecure
 }
 
 func (l ModelLoader) Resolve(ctx context.Context, frozen FrozenSelection) (*ModelApproval, error) {

--- a/internal/cellnreview/issue.go
+++ b/internal/cellnreview/issue.go
@@ -95,6 +95,9 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 	if p.Protocol != "" {
 		profile["protocol"] = p.Protocol
 	}
+	if p.AllowInsecure {
+		profile["allowInsecure"] = true
+	}
 	profileBytes, err := json.Marshal(profile)
 	if err != nil {
 		return nil, err

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -134,11 +134,12 @@ type executionForge struct {
 }
 
 type executionCapability struct {
-	Workspace   string   `json:"workspace"`
-	Egress      []string `json:"egress,omitempty"`
-	TimeoutMs   uint64   `json:"timeoutMs"`
-	MemoryBytes uint64   `json:"memoryBytes"`
-	OutputBytes uint64   `json:"outputBytes"`
+	Workspace     string   `json:"workspace"`
+	Egress        []string `json:"egress,omitempty"`
+	AllowInsecure bool     `json:"allowInsecure,omitempty"`
+	TimeoutMs     uint64   `json:"timeoutMs"`
+	MemoryBytes   uint64   `json:"memoryBytes"`
+	OutputBytes   uint64   `json:"outputBytes"`
 }
 
 type executionPolicy struct {
@@ -215,10 +216,11 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 		},
 		Forge: &executionForge{Task: task},
 		Capabilities: executionCapability{
-			Workspace:   "none",
-			TimeoutMs:   uint64(cellnEffectiveTimeout(agentRun).Milliseconds()),
-			MemoryBytes: cellnMemoryBytes,
-			OutputBytes: cellnOutputBytes,
+			Workspace:     "none",
+			AllowInsecure: agentRun.Spec.Model.AllowInsecure,
+			TimeoutMs:     uint64(cellnEffectiveTimeout(agentRun).Milliseconds()),
+			MemoryBytes:   cellnMemoryBytes,
+			OutputBytes:   cellnOutputBytes,
 		},
 		Execution: executionPolicy{
 			Lane:                     "agent",
@@ -248,11 +250,12 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 			origin := "https://api.deepseek.com"
 			if agentRun.Spec.Model.Protocol != "" {
 				var err error
-				origin, err = sympoziumv1alpha1.ModelEndpointOrigin(agentRun.Spec.Model.BaseURL)
+				origin, err = sympoziumv1alpha1.ModelEndpointOriginInsecure(agentRun.Spec.Model.BaseURL, agentRun.Spec.Model.AllowInsecure)
 				if err != nil {
 					return ctrl.Result{}, r.failRun(ctx, agentRun, err.Error())
 				}
 			}
+			request.Capabilities.AllowInsecure = agentRun.Spec.Model.AllowInsecure
 			if len(request.Capabilities.Egress) != 1 || request.Capabilities.Egress[0] != origin {
 				return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln model endpoint differs from granted network origin")
 			}

--- a/internal/controller/celln_harness.go
+++ b/internal/controller/celln_harness.go
@@ -9,7 +9,7 @@ import (
 func cellnHarnessModelSupported(m sympoziumv1alpha1.ModelSpec) bool {
 	route := m.Provider == "deepseek" && m.Protocol == "" && (m.BaseURL == "" || m.BaseURL == "https://api.deepseek.com")
 	if m.Protocol != "" {
-		route = m.CredentialProfile != "" && (sympoziumv1alpha1.ModelConnectionSpec{Provider: m.Provider, Protocol: m.Protocol, Endpoint: m.BaseURL, CredentialProfile: m.CredentialProfile, Models: []string{m.Model}}).Validate() == nil
+		route = m.CredentialProfile != "" && (sympoziumv1alpha1.ModelConnectionSpec{Provider: m.Provider, Protocol: m.Protocol, Endpoint: m.BaseURL, CredentialProfile: m.CredentialProfile, Models: []string{m.Model}, AllowInsecure: m.AllowInsecure}).Validate() == nil
 	}
 	return route && m.AuthSecretRef == "" && (m.Thinking == "" || m.Thinking == "off") && len(m.ProviderHeaders) == 0 && m.ProviderHeadersSecretRef == "" && m.ModelRef == "" && len(m.NodeSelector) == 0
 }
@@ -22,7 +22,7 @@ func validCellnHarness(req executionRequest) bool {
 	if h == nil {
 		return req.APIVersion == "celln.dev/v1alpha1"
 	}
-	if !validCellnHarnessContract(req.APIVersion, h) || !cellnHash.MatchString(h.ModelGrant.Hash) || len(h.Model) == 0 || len(h.Model) > 128 || len(h.Task) > 2048 || strings.TrimSpace(h.Task) == "" || strings.ContainsRune(h.Task, '\x00') || req.Mote == nil || req.Forge != nil || len(req.Inputs) != 0 || len(req.Tools) != 1 || req.Tools[0].Closure == nil || req.Invocation == nil || len(req.Invocation.Args) != 0 || req.Execution.Lane != "agent" || !req.Execution.RequireHardwareIsolation || req.Capabilities.Workspace != "none" || len(req.Capabilities.Egress) != 1 || !validModelOrigin(req.Capabilities.Egress[0]) {
+	if !validCellnHarnessContract(req.APIVersion, h) || !cellnHash.MatchString(h.ModelGrant.Hash) || len(h.Model) == 0 || len(h.Model) > 128 || len(h.Task) > 2048 || strings.TrimSpace(h.Task) == "" || strings.ContainsRune(h.Task, '\x00') || req.Mote == nil || req.Forge != nil || len(req.Inputs) != 0 || len(req.Tools) != 1 || req.Tools[0].Closure == nil || req.Invocation == nil || len(req.Invocation.Args) != 0 || req.Execution.Lane != "agent" || !req.Execution.RequireHardwareIsolation || req.Capabilities.Workspace != "none" || len(req.Capabilities.Egress) != 1 || !validModelOrigin(req.Capabilities.Egress[0], req.Capabilities.AllowInsecure) {
 		return false
 	}
 	names, paths := map[string]bool{}, map[string]bool{}
@@ -69,7 +69,7 @@ func validCellnHarnessContract(version string, h *executionHarness) bool {
 	}
 }
 
-func validModelOrigin(origin string) bool {
-	got, err := sympoziumv1alpha1.ModelEndpointOrigin(origin + "/")
+func validModelOrigin(origin string, allowInsecure bool) bool {
+	got, err := sympoziumv1alpha1.ModelEndpointOriginInsecure(origin+"/", allowInsecure)
 	return err == nil && got == origin
 }

--- a/internal/modelconnection/resolve.go
+++ b/internal/modelconnection/resolve.go
@@ -50,7 +50,11 @@ func Resolve(ctx context.Context, reader client.Reader, namespace string, model 
 	if (model.Provider != "" && model.Provider != s.Provider) || (model.BaseURL != "" && model.BaseURL != s.Endpoint) || (model.Protocol != "" && model.Protocol != s.Protocol) || (model.CredentialProfile != "" && model.CredentialProfile != s.CredentialProfile) {
 		return model, fmt.Errorf("inline model settings differ from the selected connection")
 	}
+	if model.AllowInsecure && !s.AllowInsecure {
+		return model, fmt.Errorf("inline insecure setting is not authorized by the connection")
+	}
 	model.Provider, model.BaseURL, model.Protocol, model.CredentialProfile = s.Provider, s.Endpoint, s.Protocol, s.CredentialProfile
+	model.AllowInsecure = s.AllowInsecure
 	model.ConnectionRevision = revision
 	return model, nil
 }

--- a/web/cypress/e2e/agent-execution-flow.cy.ts
+++ b/web/cypress/e2e/agent-execution-flow.cy.ts
@@ -44,8 +44,8 @@ describe("Agent creation execution-plane flow", () => {
       cy.contains("label", "https-fetch@").find('input[type="checkbox"]').uncheck();
     });
     cy.wizardNext(); // provider (same list as the run flow)
-    cy.wizardNext(); // auth
-    cy.get('[role="dialog"]').find("input[placeholder='team-provider-key']").type("cypress-native-profile");
+    cy.wizardNext(); // auth (credential profile defaults to the provider)
+    cy.get('[role="dialog"]').should("contain", "keeps credentials on the host");
     cy.wizardNext(); // model
     cy.get("#native-model").should("have.value", "gpt-4o");
     cy.wizardNext(); // confirm

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-1sz71B1j.js"></script>
+    <script type="module" crossorigin src="/assets/index-HRMTfLYw.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D0L01iAY.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-DeZxHY5M.js"></script>
+    <script type="module" crossorigin src="/assets/index-1sz71B1j.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D0L01iAY.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-HRMTfLYw.js"></script>
+    <script type="module" crossorigin src="/assets/index-eN2QWgye.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D0L01iAY.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">

--- a/web/src/components/celln-agent-conversation.tsx
+++ b/web/src/components/celln-agent-conversation.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import type { Agent, AgentRun } from "@/lib/api";
+import { useCreateRun } from "@/hooks/use-api";
+import { CellnConversation } from "@/components/celln-conversation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const DEFAULT_ENDURING = {
+  leaseSeconds: 600,
+  maxTurns: 8,
+  maxModelRequests: 24,
+  maxOutputTokens: 8192,
+};
+
+/**
+ * Interactive chat for a native Celln Agent. The conversation is an enduring
+ * AgentRun (the host-native parent); the first message is the initial turn and
+ * follow-up turns are durable AgentRunTurn records. This mirrors Run detail,
+ * but starts or resumes the parent directly from the Agent's Harness tab.
+ */
+export function CellnAgentConversation({
+  agent,
+  parent,
+}: {
+  agent: Agent;
+  parent?: AgentRun;
+}) {
+  const createRun = useCreateRun();
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const execution = agent.spec.execution;
+  const runtimeRef =
+    agent.spec.runtimeRef || execution?.cellnSelection?.runtimeRef || "";
+  const toolRefs = execution?.cellnSelection?.toolRefs || [];
+  const model = execution?.model || agent.spec.agents?.default?.model || "";
+  const modelConnectionRef = execution?.modelConnectionRef;
+  const provider = modelConnectionRef ? undefined : execution?.provider;
+  const limits = execution?.enduring || DEFAULT_ENDURING;
+
+  // The newest live parent is the conversation; a terminal one is surfaced by
+  // CellnConversation so the operator can reconcile or delete it.
+  if (parent) {
+    return <CellnConversation run={parent} />;
+  }
+
+  function start() {
+    const text = message.trim();
+    if (!text || createRun.isPending) return;
+    setError("");
+    createRun.mutate(
+      {
+        agentRef: agent.metadata.name,
+        task: text,
+        backend: "celln",
+        model: model || undefined,
+        modelConnectionRef,
+        provider,
+        cellnSelection: { runtimeRef: runtimeRef || undefined, toolRefs },
+        timeout: `${limits.leaseSeconds}s`,
+        executionLifecycle: "enduring",
+        enduring: limits,
+      },
+      {
+        onSuccess: () => setMessage(""),
+        onError: (err) =>
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Could not start the conversation",
+          ),
+      },
+    );
+  }
+
+  return (
+    <Card data-testid="celln-agent-conversation">
+      <CardHeader>
+        <CardTitle className="text-base">
+          Persistent Celln conversation
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Start an enduring native parent. The first message runs as the initial
+          turn; each follow-up turn runs in a disposable child cell. This creates
+          a request — the host operator's parent registration must admit it.
+        </p>
+        <label className="block space-y-2">
+          <span className="text-sm font-medium">First message</span>
+          <textarea
+            data-testid="celln-agent-first-message"
+            className="min-h-24 w-full rounded border bg-background p-2 text-sm"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            disabled={createRun.isPending}
+            placeholder="Ask the parent a question to begin…"
+          />
+        </label>
+        <Button
+          data-testid="celln-agent-start"
+          onClick={start}
+          disabled={createRun.isPending || message.trim().length === 0}
+        >
+          {createRun.isPending ? "Starting…" : "Start conversation"}
+        </Button>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -705,9 +705,16 @@ export function OnboardingWizard({
   // execution plane can actually reach.
   const providerChoices = useMemo(() => {
     if (celln) {
-      // Same providers as the run/agent flow. Native Celln needs an HTTPS
-      // endpoint, which is validated when the connection is saved.
-      return PROVIDERS;
+      // The native Celln host transport only reaches public HTTPS endpoints.
+      // HTTP-only local providers and Bedrock are not offered because they can
+      // never satisfy the host egress contract.
+      return PROVIDERS.filter(
+        (p) =>
+          p.value === "openai" ||
+          p.value === "anthropic" ||
+          p.value === "azure-openai" ||
+          p.value === "custom",
+      );
     }
     if (mode === "agent" && creationKind === "agent" && form.runtimeRef) {
       // Persistent Kubernetes harnesses speak OpenAI-compatible chat.
@@ -1151,7 +1158,11 @@ export function OnboardingWizard({
                         executionLifecycle: value === "celln" ? "enduring" : "one-shot",
                         modelConnectionRef: value === form.executionBackend ? form.modelConnectionRef : undefined,
                         credentialProfile: "",
-                        provider: form.provider || "openai",
+                        provider:
+                          value === "celln" &&
+                          !["openai", "anthropic", "azure-openai", "custom"].includes(form.provider)
+                            ? "openai"
+                            : form.provider || "openai",
                         model: form.model || "gpt-4o",
                         apiKey: value === "celln" ? "" : form.apiKey,
                         secretName: value === "celln" ? "" : form.secretName,
@@ -1259,7 +1270,7 @@ export function OnboardingWizard({
                   <SelectValue placeholder="Select a provider…" />
                 </SelectTrigger>
                 <SelectContent>
-                  {readyModels.length > 0 && (
+                  {!celln && readyModels.length > 0 && (
                     <>
                       {readyModels.map((m) => (
                         <SelectItem
@@ -1288,6 +1299,12 @@ export function OnboardingWizard({
                 </SelectContent>
               </Select>
             </div>
+            {celln && (
+              <p className="text-xs text-muted-foreground">
+                Native Celln connects to public HTTPS endpoints only. Local
+                models are available on the Kubernetes execution plane.
+              </p>
+            )}
             {/* Inference mode toggle for local providers */}
             {isLocalProvider && (
               <div className="space-y-2">

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -224,6 +224,8 @@ export interface WizardResult {
   modelConnectionRef?: string;
   /** Opaque host credential mapping for a native Celln model connection. */
   credentialProfile?: string;
+  /** Explicit opt-in for an HTTP or self-signed private native model endpoint. */
+  allowInsecure?: boolean;
   executionBackend?: "job" | "celln";
   /** Default Celln lifecycle when executionBackend is celln. */
   executionLifecycle?: "one-shot" | "enduring";
@@ -600,6 +602,7 @@ function modelConnectionSpec(
     endpoint,
     models: [result.model],
     ...auth,
+    ...(celln && result.allowInsecure ? { allowInsecure: true } : {}),
   };
 }
 
@@ -705,9 +708,12 @@ export function OnboardingWizard({
   // execution plane can actually reach.
   const providerChoices = useMemo(() => {
     if (celln) {
-      // The native Celln host transport only reaches public HTTPS endpoints.
-      // HTTP-only local providers and Bedrock are not offered because they can
-      // never satisfy the host egress contract.
+      // The native Celln host transport only reaches public HTTPS endpoints by
+      // default. The explicit insecure opt-in also allows HTTP/self-signed
+      // local providers; Bedrock has no compatible protocol either way.
+      if (form.allowInsecure) {
+        return PROVIDERS.filter((p) => p.value !== "bedrock");
+      }
       return PROVIDERS.filter(
         (p) =>
           p.value === "openai" ||
@@ -723,7 +729,7 @@ export function OnboardingWizard({
       );
     }
     return PROVIDERS;
-  }, [celln, mode, creationKind, form.runtimeRef]);
+  }, [celln, mode, creationKind, form.runtimeRef, form.allowInsecure]);
   const staleTools = (form.borrowedTools || []).some((ref) => !(catalogue.data || []).some((tool) => tool.metadata.name === ref.name && tool.spec.revision === ref.revision && tool.spec.invocationABI === "celln.json-stdio/v1" && tool.spec.lane === "tool"));
   const [inferenceMode, setInferenceMode] = useState<"workload" | "node">(
     "workload",
@@ -869,7 +875,7 @@ export function OnboardingWizard({
       compatibleRuntime;
     if (persistentHarness || celln) {
       const spec = modelConnectionSpec(result, celln);
-      if (celln && !spec.endpoint.startsWith("https://")) {
+      if (celln && !result.allowInsecure && !spec.endpoint.startsWith("https://")) {
         setConnectionError(
           "Native Celln needs an HTTPS model endpoint. Configure an HTTPS gateway or choose OpenAI, Anthropic, Azure, or a custom HTTPS endpoint.",
         );
@@ -1300,10 +1306,21 @@ export function OnboardingWizard({
               </Select>
             </div>
             {celln && (
-              <p className="text-xs text-muted-foreground">
-                Native Celln connects to public HTTPS endpoints only. Local
-                models are available on the Kubernetes execution plane.
-              </p>
+              <label className="flex items-start gap-2 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={!!form.allowInsecure}
+                  onChange={(e) =>
+                    setForm({ ...form, allowInsecure: e.target.checked })
+                  }
+                />
+                <span>
+                  Allow an insecure model endpoint (HTTP or self-signed HTTPS)
+                  on a private address. This is an explicit operator opt-in;
+                  without it native Celln reaches public HTTPS endpoints only.
+                </span>
+              </label>
             )}
             {/* Inference mode toggle for local providers */}
             {isLocalProvider && (

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -588,7 +588,9 @@ function modelConnectionSpec(
       ? "anthropic-messages"
       : "openai-chat";
   const auth = celln
-    ? { credentialProfile: result.credentialProfile }
+    ? // The host operator maps the provider to a credential profile by default;
+      // the field is only overridden under Advanced.
+      { credentialProfile: result.credentialProfile || result.provider }
     : result.apiKey || !result.secretName
       ? {}
       : { secretRef: result.secretName };
@@ -723,6 +725,7 @@ export function OnboardingWizard({
   const [showYaml, setShowYaml] = useState(false);
   const [savingConnection, setSavingConnection] = useState(false);
   const [connectionError, setConnectionError] = useState("");
+  const [advancedAuth, setAdvancedAuth] = useState(false);
   const { data: capabilities } = useCapabilities();
   const { data: clusterModels } = useModels();
   const [usingLocalModel, setUsingLocalModel] = useState(false);
@@ -804,7 +807,7 @@ export function OnboardingWizard({
       case "tools":
         return !catalogue.isLoading && !catalogue.isError && !staleTools && (form.borrowedTools || []).length <= 16;
       case "apikey":
-        if (celln) return !!form.credentialProfile;
+        if (celln) return true;
         if (form.modelConnectionRef) return true;
         if (
           form.provider === "ollama" ||
@@ -1455,18 +1458,38 @@ export function OnboardingWizard({
             <div className="space-y-4">
               {celln ? (
                 <div className="space-y-2">
-                  <Label>Host credential profile</Label>
-                  <Input
-                    value={form.credentialProfile || ""}
-                    onChange={(e) =>
-                      setForm({ ...form, credentialProfile: e.target.value })
-                    }
-                    placeholder="team-provider-key"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    The host operator maps this profile to credentials. No key
-                    is stored in the cluster.
+                  <p className="text-sm text-muted-foreground">
+                    Native Celln keeps credentials on the host. The host
+                    operator maps this connection to a credential profile; no
+                    key is stored in the cluster.
                   </p>
+                  <button
+                    type="button"
+                    className="text-xs text-blue-400 hover:text-blue-300"
+                    onClick={() => setAdvancedAuth(!advancedAuth)}
+                  >
+                    {advancedAuth ? "Hide advanced" : "Advanced"}
+                  </button>
+                  {advancedAuth && (
+                    <div className="space-y-2">
+                      <Label>Host credential profile</Label>
+                      <Input
+                        value={form.credentialProfile || ""}
+                        onChange={(e) =>
+                          setForm({
+                            ...form,
+                            credentialProfile: e.target.value,
+                          })
+                        }
+                        placeholder={form.provider}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Defaults to the provider name. Set this only if your
+                        host operator configured a different credential
+                        mapping.
+                      </p>
+                    </div>
+                  )}
                 </div>
               ) : (
                 <>

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useModelList } from "@/hooks/use-model-list";
+import { useModelList, modelApiBaseURL } from "@/hooks/use-model-list";
 import { useProviderNodes } from "@/hooks/use-provider-nodes";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -40,10 +40,12 @@ import {
   Terminal,
   Settings,
   Wifi,
+  Info,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCapabilities, useModels, useCellnTools } from "@/hooks/use-api";
 import { persistentHarnesses, persistentHarnessName } from "@/lib/persistent-harness";
+import { modelConnectionName, modelConnectionEndpoint } from "@/lib/agent-execution";
 import { api } from "@/lib/api";
 import type { AgentRuntime, SympoziumPolicy, CellnSelection, ModelConnection } from "@/lib/api";
 import {
@@ -493,7 +495,7 @@ function CanaryConnectionTest({ baseURL }: { baseURL: string }) {
     try {
       // Use the same in-cluster proxy endpoint that model listing uses,
       // so the test exercises the real network path (pod → provider).
-      const res = await api.providers.models(baseURL);
+      const res = await api.providers.models(modelApiBaseURL(baseURL));
       setResult({
         reachable: true,
         models: res.models.length,
@@ -551,40 +553,15 @@ function CanaryConnectionTest({ baseURL }: { baseURL: string }) {
 // ── Model connection folding ─────────────────────────────────────────────────
 // Persistent Kubernetes harnesses and native Celln runs consume a reusable
 // ModelConnection instead of inline credentials. The wizard keeps the ordinary
-// Provider → Auth → Model steps and persists that selection as a connection,
-// so creating a route feels identical to creating a one-shot run.
-
-const CONNECTION_SUFFIX = "-connection";
-
-function modelConnectionName(agentName: string): string {
-  const max = 253 - CONNECTION_SUFFIX.length;
-  const base = agentName.length > max ? agentName.slice(0, max) : agentName;
-  return `${base.replace(/-+$/, "")}${CONNECTION_SUFFIX}`;
-}
-
-function defaultProviderEndpoint(provider: string): string {
-  switch (provider) {
-    case "openai":
-      return "https://api.openai.com/v1/chat/completions";
-    case "anthropic":
-      return "https://api.anthropic.com/v1/messages";
-    case "ollama":
-      return "http://ollama.default.svc:11434/v1";
-    case "lm-studio":
-      return "http://localhost:1234/v1";
-    case "llama-server":
-    case "unsloth":
-      return "http://localhost:8080/v1";
-    default:
-      return "";
-  }
-}
+// Provider → Auth → Model steps and persists that selection as a connection
+// named after the Agent, so creating a route feels identical to creating a
+// one-shot run.
 
 function modelConnectionSpec(
   result: WizardResult,
   celln: boolean,
 ): ModelConnection["spec"] {
-  const endpoint = result.baseURL || defaultProviderEndpoint(result.provider);
+  const endpoint = modelConnectionEndpoint(result.baseURL, result.provider);
   const protocol =
     celln && result.provider === "anthropic"
       ? "anthropic-messages"
@@ -628,6 +605,11 @@ export function OnboardingWizard({
   const defaultRuntimeRef = availableRuntimes.some(
     (runtime) => runtime.metadata.name === defaults?.runtimeRef,
   ) ? defaults?.runtimeRef || "" : "";
+  // Kubernetes (job) remains the default execution plane; Celln is an explicit
+  // opt-in in the plane step. Defaulting to Celln here surfaced a "no native
+  // runtime registered" warning in namespaces without a native runtime.
+  const defaultBackend = defaults?.executionBackend || "job";
+  const defaultLifecycle = defaults?.executionLifecycle || "one-shot";
   const [step, setStep] = useState<WizardStep>(mode === "agent" ? "name" : "provider");
   const [form, setForm] = useState<WizardResult>({
     name: defaults?.name || "",
@@ -660,8 +642,8 @@ export function OnboardingWizard({
     awsSessionToken: defaults?.awsSessionToken || "",
     runtimeRef: defaultRuntimeRef,
     policyRef: defaults?.policyRef || "",
-    executionBackend: defaults?.executionBackend || "job",
-    executionLifecycle: defaults?.executionLifecycle || "one-shot",
+    executionBackend: defaultBackend,
+    executionLifecycle: defaultLifecycle,
     borrowedTools: defaults?.borrowedTools || [],
   });
   // Skill compatibility can arrive after the form defaults or harness selection.
@@ -1366,7 +1348,15 @@ export function OnboardingWizard({
             {(form.provider === "azure-openai" ||
               (isLocalProvider && inferenceMode === "workload")) && (
               <div className="space-y-2">
-                <Label>Base URL</Label>
+                <Label className="flex items-center gap-1.5">
+                  Base URL
+                  <span
+                    className="inline-flex"
+                    title="API base URL. Sympozium assumes the OpenAI-compatible /v1/chat/completions path (Anthropic uses /v1/messages). A full request URL is accepted as-is."
+                  >
+                    <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                  </span>
+                </Label>
                 <Input
                   value={form.baseURL}
                   onChange={(e) =>
@@ -1374,14 +1364,23 @@ export function OnboardingWizard({
                   }
                   placeholder={
                     form.provider === "ollama"
-                      ? "http://ollama.default.svc:11434/v1"
+                      ? "http://ollama.default.svc:11434"
                       : form.provider === "lm-studio"
                         ? "http://localhost:1234/v1"
                         : form.provider === "unsloth"
                           ? "http://localhost:8080/v1"
-                          : "https://your-endpoint.openai.azure.com/v1"
+                          : form.provider === "custom"
+                            ? "http://your-host:8080/v1"
+                            : "https://your-endpoint.openai.azure.com/v1"
                   }
                 />
+                {form.provider === "custom" && (
+                  <p className="text-xs text-muted-foreground">
+                    API base URL of your OpenAI-compatible provider. The
+                    <code className="mx-1 rounded bg-muted px-1">/v1/chat/completions</code>
+                    path is assumed.
+                  </p>
+                )}
               </div>
             )}
 

--- a/web/src/components/yaml-panel.tsx
+++ b/web/src/components/yaml-panel.tsx
@@ -10,7 +10,7 @@ import { FileCode, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toYaml, type YamlValue } from "@/lib/yaml";
 import type { WizardResult } from "@/components/onboarding-wizard";
-import { executionFromWizard } from "@/lib/agent-execution";
+import { executionFromWizard, modelConnectionName, modelConnectionEndpoint } from "@/lib/agent-execution";
 import type { Agent, Ensemble } from "@/lib/api";
 
 // ── YAML builders ─────────────────────────────────────────────────────────────
@@ -43,7 +43,11 @@ export function instanceYamlFromWizard(result: WizardResult): string {
   });
 
   const agentConfig: Record<string, YamlValue> = { model: result.model };
-  if (result.baseURL) agentConfig.baseURL = result.baseURL;
+  // Native Celln routes the model through a namespaced ModelConnection; the
+  // Agent references it by name instead of carrying an inline endpoint.
+  const usesConnection = result.executionBackend === "celln";
+  const connectionName = modelConnectionName(result.name || "agent");
+  if (!usesConnection && result.baseURL) agentConfig.baseURL = result.baseURL;
   if (result.nodeSelector && Object.keys(result.nodeSelector).length > 0)
     agentConfig.nodeSelector = result.nodeSelector;
   if (result.agentSandboxEnabled)
@@ -57,6 +61,18 @@ export function instanceYamlFromWizard(result: WizardResult): string {
     authRefs.push({ provider: result.provider, secret: result.secretName });
   }
 
+  const execution = usesConnection
+    ? executionFromWizard({
+        executionBackend: result.executionBackend,
+        executionLifecycle: result.executionLifecycle,
+        borrowedTools: result.borrowedTools,
+        runtimeRef: result.runtimeRef,
+        model: result.model,
+        provider: result.provider,
+        modelConnectionRef: connectionName,
+      })
+    : executionFromWizard(result);
+
   const obj: Record<string, YamlValue> = {
     apiVersion: "sympozium.ai/v1alpha1",
     kind: "Agent",
@@ -66,14 +82,32 @@ export function instanceYamlFromWizard(result: WizardResult): string {
       skills,
       ...(result.runtimeRef ? { runtimeRef: result.runtimeRef } : {}),
       ...(result.policyRef ? { policyRef: result.policyRef } : {}),
-      execution: executionFromWizard(result) as unknown as YamlValue,
+      execution: execution as unknown as YamlValue,
       ...(channels.length > 0 ? { channels } : {}),
       ...(authRefs.length > 0 ? { authRefs } : {}),
       memory: { enabled: result.executionBackend !== "celln" },
     },
   };
 
-  return toYaml(obj);
+  const agentYaml = toYaml(obj);
+  if (!usesConnection) return agentYaml;
+
+  const connection: Record<string, YamlValue> = {
+    apiVersion: "sympozium.ai/v1alpha1",
+    kind: "ModelConnection",
+    metadata: { name: connectionName },
+    spec: {
+      provider: result.provider,
+      protocol:
+        result.provider === "anthropic" ? "anthropic-messages" : "openai-chat",
+      endpoint: modelConnectionEndpoint(result.baseURL, result.provider),
+      credentialProfile: result.credentialProfile || result.provider,
+      models: [result.model],
+      ...(result.allowInsecure ? { allowInsecure: true } : {}),
+    },
+  };
+
+  return `${toYaml(connection)}\n---\n${agentYaml}`;
 }
 
 /** Build a Ensemble activation YAML (the full Ensemble CR is already in the cluster;

--- a/web/src/hooks/use-model-list.ts
+++ b/web/src/hooks/use-model-list.ts
@@ -32,6 +32,17 @@ const BEDROCK_MODELS = [
 
 // ── Fetchers ─────────────────────────────────────────────────────────────────
 
+/**
+ * Native Celln model endpoints are full request URLs (`…/v1/chat/completions`
+ * or `…/v1/messages`), while model discovery lives at the API root
+ * (`…/v1/models`). Drop the trailing completion path so both shapes list models.
+ */
+export function modelApiBaseURL(endpoint: string): string {
+  return endpoint
+    .replace(/\/+$/, "")
+    .replace(/\/(chat\/completions|completions|messages)$/, "");
+}
+
 async function fetchOpenAIModels(apiKey: string): Promise<string[]> {
   const res = await fetch("https://api.openai.com/v1/models", {
     headers: { Authorization: `Bearer ${apiKey}` },
@@ -66,7 +77,7 @@ async function fetchAnthropicModels(apiKey: string): Promise<string[]> {
 async function fetchProviderModelsDirect(baseURL: string): Promise<string[]> {
   // Try fetching directly from the browser (works when the provider is on the
   // local network / same machine and CORS allows it or isn't enforced).
-  const modelsURL = baseURL.replace(/\/+$/, "") + "/models";
+  const modelsURL = modelApiBaseURL(baseURL) + "/models";
   const res = await fetch(modelsURL, { signal: AbortSignal.timeout(3000) });
   if (!res.ok) throw new Error(`Direct fetch failed: ${res.status}`);
   const data = await res.json();
@@ -96,12 +107,15 @@ async function fetchLocalProviderModels(
   baseURL: string,
   apiKey?: string,
 ): Promise<string[]> {
+  // Normalise a full request URL down to the API root before either path runs,
+  // so the proxy also builds `…/v1/models` rather than nesting another /v1.
+  const base = modelApiBaseURL(baseURL);
   // Try direct browser fetch first (works for LAN / localhost providers).
   // Falls back to in-cluster proxy if direct fails (CORS, network, etc.).
   try {
-    return await fetchProviderModelsDirect(baseURL);
+    return await fetchProviderModelsDirect(base);
   } catch {
-    return fetchProviderModelsViaProxy(baseURL, apiKey);
+    return fetchProviderModelsViaProxy(base, apiKey);
   }
 }
 

--- a/web/src/lib/agent-execution.ts
+++ b/web/src/lib/agent-execution.ts
@@ -29,6 +29,66 @@ export function executionFromWizard(form: WizardExecution): AgentExecutionDefaul
   };
 }
 
+const CONNECTION_SUFFIX = "-connection";
+
+/** Names the ModelConnection the wizard creates for an Agent's model route. */
+export function modelConnectionName(agentName: string): string {
+  const max = 253 - CONNECTION_SUFFIX.length;
+  const base = agentName.length > max ? agentName.slice(0, max) : agentName;
+  return `${base.replace(/-+$/, "")}${CONNECTION_SUFFIX}`;
+}
+
+/**
+ * Default API base URL for a provider, used when the operator leaves Base URL
+ * empty. completionEndpointFromBase turns it into the request URL.
+ */
+export function defaultProviderBaseURL(provider: string): string {
+  switch (provider) {
+    case "openai":
+      return "https://api.openai.com";
+    case "anthropic":
+      return "https://api.anthropic.com";
+    case "ollama":
+      return "http://ollama.default.svc:11434";
+    case "lm-studio":
+      return "http://localhost:1234";
+    case "llama-server":
+    case "unsloth":
+      return "http://localhost:8080";
+    default:
+      return "";
+  }
+}
+
+/**
+ * The Base URL field is an API root. Sympozium assumes the standard
+ * OpenAI-compatible completion path (Anthropic uses /v1/messages) and builds
+ * the exact URL the host transport posts to. A full request URL is accepted
+ * unchanged, so a pasted endpoint keeps working.
+ */
+export function completionEndpointFromBase(
+  baseURL: string,
+  provider: string,
+): string {
+  const base = baseURL.trim().replace(/\/+$/, "");
+  if (base === "") return base;
+  if (/\/(chat\/completions|completions|messages)$/.test(base)) return base;
+  const path = provider === "anthropic" ? "/messages" : "/chat/completions";
+  const rooted = /\/v\d+$/.test(base) ? base : `${base}/v1`;
+  return `${rooted}${path}`;
+}
+
+/** Full request URL for a provider's model connection. Azure carries its own
+ *  deployment path, so its base is used verbatim. */
+export function modelConnectionEndpoint(
+  baseURL: string,
+  provider: string,
+): string {
+  const base = baseURL || defaultProviderBaseURL(provider);
+  if (provider === "azure-openai") return base;
+  return completionEndpointFromBase(base, provider);
+}
+
 export function agentCreationSteps(celln: boolean) {
   return ["name", "plane", "runtime", ...(celln ? ["tools", "provider", "apikey", "model"] : ["skills", "provider", "apikey", "model", "heartbeat", "channels"]), "confirm", "channelAction"] as const;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -985,7 +985,7 @@ export interface CapabilitiesResponse {
 
 export interface ModelConnection {
   metadata: ObjectMeta;
-  spec: { provider: string; protocol: "openai-chat" | "anthropic-messages"; endpoint: string; credentialProfile?: string; secretRef?: string; models: string[]; disabled?: boolean };
+  spec: { provider: string; protocol: "openai-chat" | "anthropic-messages"; endpoint: string; credentialProfile?: string; secretRef?: string; models: string[]; disabled?: boolean; allowInsecure?: boolean };
 }
 
 export interface AgentExecutionDefaults {

--- a/web/src/pages/agent-detail.tsx
+++ b/web/src/pages/agent-detail.tsx
@@ -12,6 +12,7 @@ import {
   useRuns,
 } from "@/hooks/use-api";
 import { HarnessSessionChatDialog } from "@/components/harness-session-dialog";
+import { CellnAgentConversation } from "@/components/celln-agent-conversation";
 import { CellnStarterTools } from "@/components/celln-starter-tools";
 import { CellnPermissionPreview } from "@/components/celln-permission-preview";
 import { StatusBadge } from "@/components/status-badge";
@@ -142,6 +143,23 @@ export function AgentDetailPage() {
   const selectedRuntime = runtimes?.find((runtime) => runtime.metadata.name === inst.spec.runtimeRef);
   const agentName = inst.metadata.name;
   const persistentHarness = selectedRuntime?.spec.contractVersion === "v1alpha2" && selectedRuntime.spec.session?.protocol === "openai-chat";
+  // Native Celln conversations are enduring AgentRuns, not HarnessSessions.
+  const nativeCellnEnduring =
+    selectedRuntime?.spec.celln?.contractVersion === "celln.json-tools/v1" &&
+    inst.spec.execution?.backend === "celln" &&
+    inst.spec.execution?.executionLifecycle === "enduring";
+  const enduringParent = (allRuns || [])
+    .filter(
+      (run) =>
+        run.spec.agentRef === agentName &&
+        run.spec.executionLifecycle === "enduring" &&
+        !run.metadata.deletionTimestamp,
+    )
+    .sort((a, b) =>
+      (b.metadata.creationTimestamp || "").localeCompare(
+        a.metadata.creationTimestamp || "",
+      ),
+    )[0];
   const chatSession = harnessSessions?.find((session) => session.spec.agentRef === agentName && session.spec.runtimeRef === selectedRuntime?.metadata.name);
   function startChat() {
     if (!selectedRuntime) return;
@@ -272,6 +290,9 @@ export function AgentDetailPage() {
               </CardContent>
             </Card>
             <AgentRuntimeCard inst={inst} runtimes={runtimes || []} />
+            {nativeCellnEnduring && (
+              <CellnAgentConversation agent={inst} parent={enduringParent} />
+            )}
           </div>
         </TabsContent>
 
@@ -503,7 +524,8 @@ function AgentRuntimeCard({ inst, runtimes }: { inst: Agent; runtimes: import("@
   const selectedRuntime = runtimes.find((runtime) => runtime.metadata.name === (inst.spec.runtimeRef || ""));
   const execution = inst.spec.execution;
   const backend = execution?.backend || "job";
-  const lifecycle = execution?.executionLifecycle || "one-shot";
+  const lifecycle =
+    execution?.executionLifecycle || (backend === "celln" ? "enduring" : "one-shot");
   const tools = execution?.cellnSelection?.toolRefs || [];
   const compatibleHarness = selectedRuntime?.spec.celln?.contractVersion === "celln.json-tools/v1";
   const hasSkills = !!inst.spec.skills?.length;
@@ -540,14 +562,17 @@ function AgentRuntimeCard({ inst, runtimes }: { inst: Agent; runtimes: import("@
                     saveExecution({ backend: "job", executionLifecycle: "one-shot" });
                     return;
                   }
+                  // Switching to Celln defaults to the enduring native parent;
+                  // an explicit lifecycle already chosen for Celln is preserved.
+                  const nextLifecycle = backend === "celln" ? lifecycle : "enduring";
                   saveExecution({
                     backend: "celln",
-                    executionLifecycle: lifecycle === "enduring" ? "enduring" : "one-shot",
+                    executionLifecycle: nextLifecycle,
                     provider: execution?.modelConnectionRef ? undefined : execution?.provider || "deepseek",
                     modelConnectionRef: execution?.modelConnectionRef,
                     model: execution?.model || "deepseek-chat",
                     cellnSelection: { toolRefs: tools },
-                    enduring: lifecycle === "enduring" ? (execution?.enduring || { leaseSeconds: 600, maxTurns: 8, maxModelRequests: 24, maxOutputTokens: 8192 }) : undefined,
+                    enduring: nextLifecycle === "enduring" ? (execution?.enduring || { leaseSeconds: 600, maxTurns: 8, maxModelRequests: 24, maxOutputTokens: 8192 }) : undefined,
                   });
                 }}
               >


### PR DESCRIPTION
## Why

The native-Celln model route is HTTP/self-signed capable (sympozium #200ac4c threads `allowInsecure`; celln #101 generalises the harness to any OpenAI-compatible/Anthropic endpoint), but the web UX couldn't express it:

- The provider step rejected non-HTTPS endpoints and offered no opt-in.
- Model discovery broke when a full request URL was entered.
- Show YAML omitted the `ModelConnection` (and therefore the `allowInsecure` flag).
- Native Celln agents had no interactive conversation in the Harness tab.

## What

- **Provider step** — "Allow an insecure model endpoint" checkbox sets `allowInsecure` on the `ModelConnection`; the Celln provider list expands to local/HTTP providers when ticked.
- **Base URL** — accepts an API base URL and assumes the OpenAI-compatible completion path (info tooltip); model discovery normalises a full request URL to the `/v1/models` root.
- **Show YAML** — emits the `ModelConnection` (with `allowInsecure`) before the Agent, referenced via `execution.modelConnectionRef`.
- **Harness tab** — a persistent Celln conversation for native (`celln.json-tools/v1`) enduring agents, reusing the existing turn machinery (`CellnConversation`) plus a "start conversation" form.

## Note

Create-Agent keeps Kubernetes (`job`) as the default plane; Celln remains an explicit opt-in (the earlier default-to-Celln experiment was reverted after it surfaced the "no native runtime registered" warning).