### PR TITLE
feat(install): deploy the Celln backend by default

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -217,6 +217,10 @@ type ModelSpec struct {
 	// CredentialProfile is the independently approved opaque host mapping.
 	// +optional
 	CredentialProfile string `json:"credentialProfile,omitempty"`
+	// AllowInsecure is the operator opt-in for an HTTP or self-signed private
+	// model endpoint, carried from the selected connection.
+	// +optional
+	AllowInsecure bool `json:"allowInsecure,omitempty"`
 
 	// Provider is the AI provider (openai, anthropic, azure-openai, github-copilot, ollama, etc.).
 	// Omit when resolving a model connection.

--- a/api/v1alpha1/modelconnection_types.go
+++ b/api/v1alpha1/modelconnection_types.go
@@ -44,6 +44,11 @@ type ModelConnectionSpec struct {
 	// Disabled prevents new connection resolution. Host profile withdrawal stops live use.
 	// +optional
 	Disabled bool `json:"disabled,omitempty"`
+	// AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+	// address. This is an explicit operator opt-in that weakens the default
+	// public-HTTPS transport contract. It never bypasses host admission.
+	// +optional
+	AllowInsecure bool `json:"allowInsecure,omitempty"`
 }
 
 var modelConnectionIdentifier = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
@@ -66,7 +71,7 @@ func (s ModelConnectionSpec) Validate() error {
 		if s.SecretRef != "" {
 			return fmt.Errorf("choose a host credential profile or a Kubernetes Secret, not both")
 		}
-		if _, err := ModelEndpointOrigin(s.Endpoint); err != nil {
+		if _, err := ModelEndpointOriginInsecure(s.Endpoint, s.AllowInsecure); err != nil {
 			return err
 		}
 	}
@@ -86,11 +91,26 @@ func (s ModelConnectionSpec) Validate() error {
 // ModelEndpointOrigin matches the native host HTTPS transport: no userinfo,
 // query credentials, fragments, alternate ports or redirect-based endpoints.
 func ModelEndpointOrigin(endpoint string) (string, error) {
+	return ModelEndpointOriginInsecure(endpoint, false)
+}
+
+// ModelEndpointOriginInsecure returns the egress origin for a model endpoint.
+// The default keeps the public HTTPS transport contract; allowInsecure is an
+// explicit opt-in that also permits HTTP and an explicit port for a private or
+// self-signed endpoint.
+func ModelEndpointOriginInsecure(endpoint string, allowInsecure bool) (string, error) {
 	u, err := url.Parse(endpoint)
-	if err != nil || len(endpoint) > 2048 || u.Scheme != "https" || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Port() != "" || u.Path == "" || strings.ContainsAny(endpoint, "\r\n\x00") {
+	if err != nil || len(endpoint) > 2048 || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Path == "" || strings.ContainsAny(endpoint, "\r\n\x00") {
+		return "", fmt.Errorf("model endpoint must be an HTTP(S) URL without credentials, query or fragment")
+	}
+	if allowInsecure {
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return "", fmt.Errorf("model endpoint must be an HTTP(S) URL")
+		}
+	} else if u.Scheme != "https" || u.Port() != "" {
 		return "", fmt.Errorf("model endpoint must be a complete HTTPS URL without credentials, query, fragment or port")
 	}
-	return "https://" + u.Host, nil
+	return u.Scheme + "://" + u.Host, nil
 }
 
 // +kubebuilder:object:root=true

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -749,6 +749,11 @@ spec:
               model:
                 description: Model specifies the LLM configuration for this run.
                 properties:
+                  allowInsecure:
+                    description: |-
+                      AllowInsecure is the operator opt-in for an HTTP or self-signed private
+                      model endpoint, carried from the selected connection.
+                    type: boolean
                   authSecretRef:
                     description: AuthSecretRef references the secret containing the
                       API key.

--- a/charts/sympozium-crds/templates/sympozium.ai_modelconnections.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_modelconnections.yaml
@@ -40,6 +40,12 @@ spec:
             type: object
           spec:
             properties:
+              allowInsecure:
+                description: |-
+                  AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+                  address. This is an explicit operator opt-in that weakens the default
+                  public-HTTPS transport contract. It never bypasses host admission.
+                type: boolean
               credentialProfile:
                 description: CredentialProfile is an opaque host mapping name, never
                   an API key or file path.

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -749,6 +749,11 @@ spec:
               model:
                 description: Model specifies the LLM configuration for this run.
                 properties:
+                  allowInsecure:
+                    description: |-
+                      AllowInsecure is the operator opt-in for an HTTP or self-signed private
+                      model endpoint, carried from the selected connection.
+                    type: boolean
                   authSecretRef:
                     description: AuthSecretRef references the secret containing the
                       API key.

--- a/charts/sympozium/crds/sympozium.ai_modelconnections.yaml
+++ b/charts/sympozium/crds/sympozium.ai_modelconnections.yaml
@@ -40,6 +40,12 @@ spec:
             type: object
           spec:
             properties:
+              allowInsecure:
+                description: |-
+                  AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+                  address. This is an explicit operator opt-in that weakens the default
+                  public-HTTPS transport contract. It never bypasses host admission.
+                type: boolean
               credentialProfile:
                 description: CredentialProfile is an opaque host mapping name, never
                   an API key or file path.

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -1,4 +1,32 @@
 {{- if .Values.celln.enabled }}
+{{- $bootstrap := .Values.celln.bootstrap | default dict }}
+{{- $clientSecret := $bootstrap.clientTokenSecret | default "celln-router-client" }}
+{{- $backendSecret := $bootstrap.backendTokenSecret | default "celln-dispatcher-backend" }}
+{{- $capabilitySecret := $bootstrap.capabilityTokenSecret | default "celln-discovery" }}
+{{- $ownershipClaim := $bootstrap.ownershipClaim | default "celln-router-ownership" }}
+{{- $routerImage := "" }}
+{{- if not .Values.celln.router.external }}
+{{- if .Values.celln.router.image.digest }}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.celln.router.image.digest) }}
+{{- fail "celln.router.image.digest must be a sha256 digest when set" }}
+{{- end }}
+{{- $routerImage = printf "%s@%s" .Values.celln.router.image.repository .Values.celln.router.image.digest }}
+{{- else if .Values.celln.router.image.tag }}
+{{- $routerImage = printf "%s:%s" .Values.celln.router.image.repository .Values.celln.router.image.tag }}
+{{- else }}
+{{- fail "celln.router.image.digest (recommended) or celln.router.image.tag is required" }}
+{{- end }}
+{{- end }}
+{{- $dispatcher := .Values.celln.dispatcher | default dict }}
+{{- $dispatcherImage := $dispatcher.image | default dict }}
+{{- $dispatcherRepo := $dispatcherImage.repository | default .Values.celln.image.repository | default "ghcr.io/sympozium-ai/celln-installer" }}
+{{- $dispatcherTag := $dispatcherImage.tag | default .Values.celln.image.tag | default "v0.4.13" }}
+{{- $clientToken := randAlphaNum 32 }}
+{{- with lookup "v1" "Secret" .Release.Namespace $clientSecret }}{{ $clientToken = index .data "token" | b64dec }}{{ end }}
+{{- $backendToken := randAlphaNum 32 }}
+{{- with lookup "v1" "Secret" "celln-system" $backendSecret }}{{ $backendToken = index .data "token" | b64dec }}{{ end }}
+{{- $capabilityToken := randAlphaNum 32 }}
+{{- with lookup "v1" "Secret" .Release.Namespace $capabilitySecret }}{{ $capabilityToken = index .data "token" | b64dec }}{{ end }}
 {{- if and (not (hasPrefix "https://" .Values.celln.routerUrl)) (not .Values.celln.allowInsecureHttp) }}
 {{- fail "Celln requires an HTTPS routerUrl or explicit celln.allowInsecureHttp acknowledgement" }}
 {{- end }}
@@ -10,9 +38,6 @@
 {{- fail "external Celln router cannot enable the legacy host installer" }}
 {{- end }}
 {{- else }}
-{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.celln.router.image.digest) }}
-{{- fail "celln.router.image.digest must pin a router supporting client auth and durable ownership" }}
-{{- end }}
 {{- if not .Values.celln.router.backends }}
 {{- fail "celln.router.backends must contain the complete stable dispatcher endpoint list" }}
 {{- end }}
@@ -46,6 +71,80 @@ metadata:
   name: celln-system
   labels:
     app.kubernetes.io/part-of: sympozium
+{{- if $bootstrap.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $clientSecret }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: sympozium
+type: Opaque
+stringData:
+  token: {{ $clientToken | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $clientSecret }}
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+type: Opaque
+stringData:
+  token: {{ $clientToken | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $backendSecret }}
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+type: Opaque
+stringData:
+  token: {{ $backendToken | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $capabilitySecret }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: sympozium
+type: Opaque
+stringData:
+  token: {{ $capabilityToken | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $capabilitySecret }}
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+type: Opaque
+stringData:
+  token: {{ $capabilityToken | quote }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $ownershipClaim }}
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+spec:
+  accessModes:
+  - {{ $bootstrap.ownershipAccessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ $bootstrap.ownershipStorage | default "1Gi" }}
+  {{- with $bootstrap.ownershipStorageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
 {{- if .Values.celln.installer.enabled }}
 ---
 apiVersion: v1
@@ -150,6 +249,121 @@ spec:
         operator: Exists
         effect: NoSchedule
 {{- end }}
+{{- if $dispatcher.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celln-dispatcher
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/name: celln-dispatcher
+    app.kubernetes.io/part-of: sympozium
+spec:
+  replicas: {{ $dispatcher.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: celln-dispatcher
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: celln-dispatcher
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        celln.dev/kvm: "true"
+      containers:
+      - name: dispatcher
+        image: {{ printf "%s:%s" $dispatcherRepo $dispatcherTag | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/usr/local/bin/celln"]
+        args:
+        - dispatcher
+        - --listen
+        - 0.0.0.0:8787
+        - --unsafe-non-loopback
+        - --token-file
+        - /etc/celln/backend/token
+        - --root
+        - /var/lib/celln
+        - --mote-store
+        - /var/lib/celln/motes
+        - --tool-store
+        - /var/lib/celln/tools
+        - --node-name
+        - $(NODE_NAME)
+        {{- range $dispatcher.allowEgressHosts | default (list "api.deepseek.com") }}
+        - --allow-egress-host
+        - {{ . | quote }}
+        {{- end }}
+        - --egress-slots
+        - {{ $dispatcher.egressSlots | default 1 | quote }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: backend
+          mountPath: /etc/celln/backend
+          readOnly: true
+        - name: state
+          mountPath: /var/lib/celln
+        - name: kvm
+          mountPath: /dev/kvm
+        - name: boot
+          mountPath: /boot
+          readOnly: true
+        - name: modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: backend
+        secret:
+          secretName: {{ $backendSecret }}
+          defaultMode: 0440
+      - name: state
+        hostPath:
+          path: {{ $dispatcher.statePath | default "/var/lib/celln" }}
+          type: Directory
+      - name: kvm
+        hostPath:
+          path: /dev/kvm
+          type: CharDevice
+      - name: boot
+        hostPath:
+          path: /boot
+          type: Directory
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: celln-dispatcher
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/name: celln-dispatcher
+    app.kubernetes.io/part-of: sympozium
+spec:
+  selector:
+    app.kubernetes.io/name: celln-dispatcher
+  ports:
+  - name: http
+    port: 8787
+    targetPort: 8787
+    protocol: TCP
+{{- end }}
+{{- if not .Values.celln.router.external }}
 ---
 # Every replica sees the same backend identities and durable owner ledger.
 apiVersion: apps/v1
@@ -180,7 +394,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: router
-        image: {{ printf "%s@%s" .Values.celln.router.image.repository .Values.celln.router.image.digest | quote }}
+        image: {{ $routerImage | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/celln"]
         args:
@@ -260,5 +474,6 @@ spec:
     port: 8787
     targetPort: 8788
     protocol: TCP
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -482,6 +482,37 @@ celln:
     # -- Legacy privileged host mutation is a separate, deliberate opt-in.
     # Disabling/removing this DaemonSet does NOT undo host installation.
     enabled: false
+  # -- In-cluster dispatcher (pod-based). Runs the celln dispatcher as a
+  # privileged pod with /dev/kvm, reachable by the router over a ClusterIP
+  # Service. This is the reachable-by-default execution path; the host installer
+  # DaemonSet (above) is the bare-metal alternative that stays loopback-only.
+  dispatcher:
+    enabled: false
+    replicas: 1
+    # -- Image carrying the celln binary + runtime assets (and Rust for the
+    # forge compile step). Defaults to celln.image when empty.
+    image:
+      repository: ""
+      tag: ""
+    # -- hostPath directory on the node for motes/tools/cells state.
+    statePath: /var/lib/celln
+    # -- Hosts the dispatcher permits for egress (model API and bounded fetch).
+    allowEgressHosts:
+      - api.deepseek.com
+    egressSlots: 1
+  # -- One-command bootstrap for a fresh Celln install. Generates the
+  # controller/router/backend/capability bearer Secrets and a router ownership
+  # PVC, then the CLI points celln.tokenSecret, celln.capabilityTokenSecret and
+  # celln.router.*Secret at them. Router backends (KVM node dispatcher
+  # endpoints) and ownership storage class remain operator inputs.
+  bootstrap:
+    enabled: false
+    clientTokenSecret: celln-router-client
+    backendTokenSecret: celln-dispatcher-backend
+    capabilityTokenSecret: celln-discovery
+    ownershipClaim: celln-router-ownership
+    ownershipStorageClass: ""
+    ownershipStorage: 1Gi
   # -- URL of the celln-router Service. The controller POSTs here.
   routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
   # -- Existing Secret in the controller namespace, key `token`, containing
@@ -541,10 +572,11 @@ celln:
     # POSIX flock, atomic publication and directory fsync, not just an RWX label.
     ownershipClaim: ""
     image:
-      repository: "ghcr.io/sympozium-ai/celln-router"
-      # -- Digest of an image implementing client auth + durable ownership
-      # (Celln PRs #70 and #75). Old v0.4.13 images are incompatible.
+      repository: "ghcr.io/sympozium-ai/celln"
+      # -- Prefer a digest for a pinned router. `tag` is a fallback for the
+      # bootstrap path and is less tamper-resistant.
       digest: ""
+      tag: ""
 
 # -- Persona delegation behavior.
 delegation:

--- a/cmd/sympozium/install_celln_test.go
+++ b/cmd/sympozium/install_celln_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSplitImageRef(t *testing.T) {
+	cases := []struct {
+		in     string
+		repo   string
+		ref    string
+		digest bool
+	}{
+		{"", "ghcr.io/sympozium-ai/celln", "v0.5.8", false},
+		{"ghcr.io/sympozium-ai/celln:v0.5.8", "ghcr.io/sympozium-ai/celln", "v0.5.8", false},
+		{"ghcr.io/sympozium-ai/celln@sha256:abcdef", "ghcr.io/sympozium-ai/celln", "sha256:abcdef", true},
+		{"localhost:5000/celln", "localhost:5000/celln", "v0.5.8", false},
+		{"localhost:5000/celln:v1", "localhost:5000/celln", "v1", false},
+	}
+	for _, c := range cases {
+		repo, ref, digest := splitImageRef(c.in, "ghcr.io/sympozium-ai/celln", "v0.5.8")
+		if repo != c.repo || ref != c.ref || digest != c.digest {
+			t.Fatalf("splitImageRef(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, repo, ref, digest, c.repo, c.ref, c.digest)
+		}
+	}
+}
+
+func TestCellnInstallSetValues(t *testing.T) {
+	vals, err := cellnInstallSetValues(
+		context.Background(),
+		"ghcr.io/sympozium-ai/celln:v0.5.8",
+		"",
+		[]string{"http://10.0.0.1:8787"},
+		1,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("cellnInstallSetValues: %v", err)
+	}
+	// The generated values must be parseable by the same strvals path Helm uses.
+	helmVals, err := buildHelmValues("", vals)
+	if err != nil {
+		t.Fatalf("buildHelmValues: %v", err)
+	}
+	celln, ok := helmVals["celln"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("celln values missing: %#v", helmVals["celln"])
+	}
+	for _, key := range []string{"enabled", "installer", "bootstrap", "dispatcher", "router", "tokenSecret", "capabilityTokenSecret"} {
+		if _, ok := celln[key]; !ok {
+			t.Fatalf("celln.%s missing from %#v", key, celln)
+		}
+	}
+	bootstrap, _ := celln["bootstrap"].(map[string]interface{})
+	if bootstrap["enabled"] != true {
+		t.Fatalf("bootstrap.enabled = %v, want true", bootstrap["enabled"])
+	}
+	installer, _ := celln["installer"].(map[string]interface{})
+	if installer["enabled"] != true {
+		t.Fatalf("installer.enabled = %v, want true (hostInstaller=true)", installer["enabled"])
+	}
+	dispatcher, _ := celln["dispatcher"].(map[string]interface{})
+	if dispatcher["enabled"] != true {
+		t.Fatalf("dispatcher.enabled = %v, want true", dispatcher["enabled"])
+	}
+	router, _ := celln["router"].(map[string]interface{})
+	if router["external"] != false {
+		t.Fatalf("router.external = %v, want false", router["external"])
+	}
+	if router["image"].(map[string]interface{})["tag"] != "v0.5.8" {
+		t.Fatalf("router.image.tag = %v, want v0.5.8", router["image"])
+	}
+	backends, ok := router["backends"].([]interface{})
+	if !ok || len(backends) != 1 || backends[0] != "http://10.0.0.1:8787" {
+		t.Fatalf("router.backends = %#v, want [http://10.0.0.1:8787]", router["backends"])
+	}
+}
+
+func TestCellnInstallSetValuesDefaultBackends(t *testing.T) {
+	vals, err := cellnInstallSetValues(
+		context.Background(),
+		"ghcr.io/sympozium-ai/celln:v0.5.8",
+		"",
+		nil,
+		1,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("cellnInstallSetValues: %v", err)
+	}
+	helmVals, err := buildHelmValues("", vals)
+	if err != nil {
+		t.Fatalf("buildHelmValues: %v", err)
+	}
+	celln := helmVals["celln"].(map[string]interface{})
+	router := celln["router"].(map[string]interface{})
+	backends := router["backends"].([]interface{})
+	if len(backends) != 1 || backends[0] != "http://celln-dispatcher.celln-system.svc.cluster.local:8787" {
+		t.Fatalf("router.backends = %#v, want the in-cluster dispatcher Service", backends)
+	}
+	if _, has := celln["installer"]; has {
+		installer := celln["installer"].(map[string]interface{})
+		if installer["enabled"] == true {
+			t.Fatalf("installer.enabled should be false when hostInstaller=false")
+		}
+	}
+}

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -46,6 +46,7 @@ import (
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/agentedit"
+	"github.com/sympozium-ai/sympozium/internal/cellninstall"
 	"github.com/sympozium-ai/sympozium/internal/helmchart"
 )
 
@@ -1248,38 +1249,145 @@ func newInstallCmd() *cobra.Command {
 	var imageTag string
 	var setValues []string
 	var enableHermeticWorkloads bool
+	var noCelln bool
+	var cellnBackends []string
+	var cellnRouterImage string
+	var cellnInstallerImage string
+	var cellnRouterReplicas int
+	var cellnHostInstaller bool
+	var cellnNative bool
+	var cellnNativeApprove bool
+	var nativeOpts cellninstall.Options
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install Sympozium into the current Kubernetes cluster",
 		Long: `Installs Sympozium using the embedded Helm chart. This sets up CRDs,
 the controller manager, API server, admission webhook, RBAC rules,
-network policies, and default SkillPacks/Policies/Ensembles.
+network policies, default SkillPacks/Policies/Ensembles, and the Celln backend.
 
-Use --image-tag to override the container image tag, for example when
-you have sideloaded images into Kind with a custom tag.
+Celln is deployed by default: an in-cluster (pod-based) dispatcher, an
+unprivileged router, and generated router/backend/capability credentials plus
+the ownership PVC. The router reaches the dispatcher over the celln-dispatcher
+Service; override with --celln-backend for an external dispatcher. Pass
+--celln-host-installer to also run the privileged host-installer DaemonSet
+(bare-metal dispatcher), which mounts the host root filesystem and is a
+materially different trust boundary. Pass --no-celln to skip Celln entirely.
+See docs/concepts/celln-backend.md before relying on it.
+
+Use --image-tag to override the container image tag, for example when you have
+sideloaded images into Kind with a custom tag.
 
 Use --set to override arbitrary Helm values (e.g. --set controller.replicas=2).
 
-Use --enable-hermetic-workloads to opt into the Celln backend (spec.backend:
-"celln" on AgentRuns): hardware-isolated, single-task execution in a sealed
-KVM cell instead of a Kubernetes Job. This is off by default because it
-deploys a DaemonSet that installs a host-level dispatcher on KVM-capable
-nodes, running privileged with hostPID and a read-write mount of the host
-root filesystem — necessary to set up KVM on the host, but a materially
-different trust boundary than the rest of Sympozium's pods. See
-docs/concepts/celln-backend.md before enabling it.`,
+Use --celln-native to also install the native Celln starter catalogue and grant
+layers (enduring native parents); it requires the operator-reviewed
+--celln-native-* inputs and --celln-native-approve-starter-tools.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if enableHermeticWorkloads {
-				setValues = append(setValues, "celln.enabled=true")
+			if !noCelln {
+				cellnValues, err := cellnInstallSetValues(cmd.Context(), cellnRouterImage, cellnInstallerImage, cellnBackends, cellnRouterReplicas, cellnHostInstaller)
+				if err != nil {
+					return err
+				}
+				setValues = append(setValues, cellnValues...)
 			}
-			return runInstall(imageTag, setValues)
+			if err := runInstall(imageTag, setValues); err != nil {
+				return err
+			}
+			if cellnNative {
+				if !cellnNativeApprove {
+					return fmt.Errorf("--celln-native requires --celln-native-approve-starter-tools: grants include run-owned read/write and bounded example.com HTTPS")
+				}
+				nativeOpts.Namespace = namespace
+				if err := cellninstall.Install(cmd.Context(), k8sClient, nativeOpts); err != nil {
+					return err
+				}
+				fmt.Printf("  Installed native Celln catalogue and grants in %s; no run submitted, execution readiness remains unverified.\n", nativeOpts.Namespace)
+			}
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&imageTag, "image-tag", "", "Override image tag (e.g. 'latest')")
 	cmd.Flags().StringArrayVar(&setValues, "set", nil, "Set Helm values (key=value, can be repeated)")
-	cmd.Flags().BoolVar(&enableHermeticWorkloads, "enable-hermetic-workloads", false,
-		"Opt into the Celln backend: hardware-isolated execution via a privileged host-installer DaemonSet on KVM-capable nodes")
+	cmd.Flags().BoolVar(&enableHermeticWorkloads, "enable-hermetic-workloads", false, "Deprecated: Celln is enabled by default; use --no-celln to skip it")
+	cmd.Flags().BoolVar(&noCelln, "no-celln", false, "Do not deploy the Celln backend (dispatcher, router, credentials, ownership PVC)")
+	cmd.Flags().BoolVar(&cellnHostInstaller, "celln-host-installer", false, "Also deploy the privileged host-installer DaemonSet (bare-metal dispatcher); requires --celln-backend pointing at the dispatcher/proxy")
+	cmd.Flags().StringArrayVar(&cellnBackends, "celln-backend", nil, "Celln router dispatcher origin(s) http://host:port (repeatable); defaults to the in-cluster celln-dispatcher Service")
+	cmd.Flags().StringVar(&cellnRouterImage, "celln-router-image", "", "Celln router image repo:tag or repo@sha256:... (default ghcr.io/sympozium-ai/celln:v0.5.8)")
+	cmd.Flags().StringVar(&cellnInstallerImage, "celln-installer-image", "", "Celln host-installer image repo:tag (default ghcr.io/sympozium-ai/celln-installer:v0.5.8)")
+	cmd.Flags().IntVar(&cellnRouterReplicas, "celln-router-replicas", 1, "Celln router replicas for the generated ReadWriteOnce ownership PVC")
+	cmd.Flags().BoolVar(&cellnNative, "celln-native", false, "Also install the native Celln starter catalogue and grant layers (requires the operator --celln-native-* inputs)")
+	cmd.Flags().BoolVar(&cellnNativeApprove, "celln-native-approve-starter-tools", false, "Explicitly approve the three bounded starter tool grants for --celln-native")
+	cmd.Flags().StringVar(&nativeOpts.ConfigurationDir, "celln-native-configuration-dir", "", "Absolute operator configuration produced by 'celln starter-configure'")
+	cmd.Flags().StringVar(&nativeOpts.OutputDir, "celln-native-output-dir", "", "New absolute private output directory")
+	cmd.Flags().StringVar(&nativeOpts.StatePath, "celln-native-state-path", "", "Existing dedicated host state path")
+	cmd.Flags().StringVar(&nativeOpts.OwnerTarget, "celln-native-owner-target", "", "Stable verified HTTPS owner origin")
+	cmd.Flags().StringVar(&nativeOpts.Scope, "celln-native-scope", "", "Stable installation identity; never change to renew consumed authority")
+	cmd.Flags().StringVar(&nativeOpts.PackageHash, "celln-native-package-hash", "", "Exact operator-approved package BLAKE3 identity")
 	return cmd
+}
+
+// cellnInstallSetValues builds the Helm --set values that deploy the one-shot
+// Celln stack: generated credentials, ownership PVC, router and installer.
+func cellnInstallSetValues(ctx context.Context, routerImage, installerImage string, backends []string, replicas int, hostInstaller bool) ([]string, error) {
+	if replicas <= 0 {
+		replicas = 1
+	}
+	routerRepo, routerRef, routerIsDigest := splitImageRef(routerImage, "ghcr.io/sympozium-ai/celln", "v0.5.8")
+	installerRepo, installerTag, _ := splitImageRef(installerImage, "ghcr.io/sympozium-ai/celln-installer", "v0.5.8")
+
+	// Default execution path is the in-cluster (pod-based) dispatcher, reached
+	// by the router over the celln-dispatcher Service. `--celln-backend`
+	// overrides the backend origins (e.g. an external/host-installed dispatcher).
+	vals := []string{
+		"celln.enabled=true",
+		"celln.allowInsecureHttp=true",
+		"celln.bootstrap.enabled=true",
+		"celln.dispatcher.enabled=true",
+		"celln.tokenSecret=celln-router-client",
+		"celln.capabilityTokenSecret=celln-discovery",
+		"celln.router.external=false",
+		"celln.router.replicas=" + strconv.Itoa(replicas),
+		"celln.router.clientTokenSecret=celln-router-client",
+		"celln.router.backendTokenSecret=celln-dispatcher-backend",
+		"celln.router.capabilityTokenSecret=celln-discovery",
+		"celln.router.allowInsecureBackends=true",
+		"celln.router.ownershipClaim=celln-router-ownership",
+		"celln.router.image.repository=" + routerRepo,
+		// The full image (celln binary + runtime assets + Rust) serves both the
+		// in-cluster dispatcher and, optionally, the host installer DaemonSet.
+		"celln.image.repository=" + installerRepo,
+		"celln.image.tag=" + installerTag,
+	}
+	if len(backends) == 0 {
+		backends = []string{"http://celln-dispatcher.celln-system.svc.cluster.local:8787"}
+	}
+	vals = append(vals, "celln.router.backends={"+strings.Join(backends, ",")+"}")
+	if hostInstaller {
+		vals = append(vals, "celln.installer.enabled=true")
+	}
+	if routerIsDigest {
+		vals = append(vals, "celln.router.image.digest="+routerRef)
+	} else {
+		vals = append(vals, "celln.router.image.tag="+routerRef)
+	}
+	return vals, nil
+}
+
+// splitImageRef splits "repo:tag" or "repo@sha256:..." and reports whether the
+// reference is a digest. A bare repository falls back to defaultTag.
+func splitImageRef(ref, defaultRepo, defaultTag string) (repo, reference string, isDigest bool) {
+	if ref == "" {
+		return defaultRepo, defaultTag, false
+	}
+	if at := strings.LastIndex(ref, "@"); at != -1 {
+		return ref[:at], ref[at+1:], true
+	}
+	slash := strings.LastIndex(ref, "/")
+	colon := strings.LastIndex(ref, ":")
+	if colon > slash {
+		return ref[:colon], ref[colon+1:], false
+	}
+	return ref, defaultTag, false
 }
 
 func newUninstallCmd() *cobra.Command {

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -749,6 +749,11 @@ spec:
               model:
                 description: Model specifies the LLM configuration for this run.
                 properties:
+                  allowInsecure:
+                    description: |-
+                      AllowInsecure is the operator opt-in for an HTTP or self-signed private
+                      model endpoint, carried from the selected connection.
+                    type: boolean
                   authSecretRef:
                     description: AuthSecretRef references the secret containing the
                       API key.

--- a/config/crd/bases/sympozium.ai_modelconnections.yaml
+++ b/config/crd/bases/sympozium.ai_modelconnections.yaml
@@ -40,6 +40,12 @@ spec:
             type: object
           spec:
             properties:
+              allowInsecure:
+                description: |-
+                  AllowInsecure permits an HTTP or self-signed HTTPS endpoint on a private
+                  address. This is an explicit operator opt-in that weakens the default
+                  public-HTTPS transport contract. It never bypasses host admission.
+                type: boolean
               credentialProfile:
                 description: CredentialProfile is an opaque host mapping name, never
                   an API key or file path.

--- a/internal/cellnauthority/execution.go
+++ b/internal/cellnauthority/execution.go
@@ -76,7 +76,7 @@ func (l ModelLoader) BuildExecution(ctx context.Context, frozen FrozenSelection,
 	if borrowed == nil {
 		borrowed = []api.CellnBorrowedTool{}
 	}
-	origin, err := api.ModelEndpointOrigin(approval.Policy.URL)
+	origin, err := api.ModelEndpointOriginInsecure(approval.Policy.URL, approval.Policy.AllowInsecure)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (l ModelLoader) BuildExecution(ctx context.Context, frozen FrozenSelection,
 		"invocation": api.CellnInvocation{Alias: frozen.Prepared.RuntimeEntryPoint},
 		"harness": map[string]any{"contractVersion": "celln.json-tools/v1", "modelGrant": api.CellnImmutableRef{Hash: "blake3:" + strings.Repeat("0", 64)}, "model": approval.Policy.Model, "task": task, "borrowedTools": borrowed,
 			"json": map[string]any{"system": s.SystemPrompt, "maxTurns": frozen.Prepared.JSON.MaxTurns, "maxCalls": frozen.Prepared.JSON.MaxCalls}},
-		"capabilities": map[string]any{"workspace": "none", "egress": []string{origin}, "timeoutMs": timeout, "memoryBytes": limits.MemoryBytes, "outputBytes": limits.OutputBytes},
+		"capabilities": map[string]any{"workspace": "none", "egress": []string{origin}, "allowInsecure": approval.Policy.AllowInsecure, "timeoutMs": timeout, "memoryBytes": limits.MemoryBytes, "outputBytes": limits.OutputBytes},
 		"execution":    map[string]any{"lane": "agent", "requireHardwareIsolation": true},
 	}
 	raw, err := json.Marshal(request)

--- a/internal/cellnauthority/model.go
+++ b/internal/cellnauthority/model.go
@@ -27,6 +27,7 @@ type ModelPolicyDocument struct {
 	Runtime              Subject `json:"runtime"`
 	Provider             string  `json:"provider"`
 	Protocol             string  `json:"protocol,omitempty"`
+	AllowInsecure        bool    `json:"allowInsecure,omitempty"`
 	Model                string  `json:"model"`
 	URL                  string  `json:"url"`
 	CredentialProfile    string  `json:"credentialProfile"`
@@ -57,14 +58,14 @@ func validModelPolicyRoute(doc ModelPolicyDocument) bool {
 	if doc.Protocol == "" {
 		return doc.Provider == "deepseek" && doc.URL == "https://api.deepseek.com/chat/completions"
 	}
-	return (api.ModelConnectionSpec{Provider: doc.Provider, Protocol: doc.Protocol, Endpoint: doc.URL, CredentialProfile: doc.CredentialProfile, Models: []string{doc.Model}}).Validate() == nil
+	return (api.ModelConnectionSpec{Provider: doc.Provider, Protocol: doc.Protocol, Endpoint: doc.URL, CredentialProfile: doc.CredentialProfile, Models: []string{doc.Model}, AllowInsecure: doc.AllowInsecure}).Validate() == nil
 }
 
 func modelPolicyMatches(m api.ModelSpec, doc ModelPolicyDocument) bool {
 	if doc.Protocol == "" {
-		return m.Protocol == "" && m.CredentialProfile == "" && (m.BaseURL == "" || m.BaseURL == "https://api.deepseek.com")
+		return m.Protocol == "" && m.CredentialProfile == "" && !m.AllowInsecure && (m.BaseURL == "" || m.BaseURL == "https://api.deepseek.com")
 	}
-	return m.BaseURL == doc.URL && m.Protocol == doc.Protocol && m.CredentialProfile == doc.CredentialProfile
+	return m.BaseURL == doc.URL && m.Protocol == doc.Protocol && m.CredentialProfile == doc.CredentialProfile && m.AllowInsecure == doc.AllowInsecure
 }
 
 func (l ModelLoader) Resolve(ctx context.Context, frozen FrozenSelection) (*ModelApproval, error) {

--- a/internal/cellnreview/issue.go
+++ b/internal/cellnreview/issue.go
@@ -95,6 +95,9 @@ func issue(ctx context.Context, l cellnauthority.ModelLoader, frozen cellnauthor
 	if p.Protocol != "" {
 		profile["protocol"] = p.Protocol
 	}
+	if p.AllowInsecure {
+		profile["allowInsecure"] = true
+	}
 	profileBytes, err := json.Marshal(profile)
 	if err != nil {
 		return nil, err

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -134,11 +134,12 @@ type executionForge struct {
 }
 
 type executionCapability struct {
-	Workspace   string   `json:"workspace"`
-	Egress      []string `json:"egress,omitempty"`
-	TimeoutMs   uint64   `json:"timeoutMs"`
-	MemoryBytes uint64   `json:"memoryBytes"`
-	OutputBytes uint64   `json:"outputBytes"`
+	Workspace     string   `json:"workspace"`
+	Egress        []string `json:"egress,omitempty"`
+	AllowInsecure bool     `json:"allowInsecure,omitempty"`
+	TimeoutMs     uint64   `json:"timeoutMs"`
+	MemoryBytes   uint64   `json:"memoryBytes"`
+	OutputBytes   uint64   `json:"outputBytes"`
 }
 
 type executionPolicy struct {
@@ -215,10 +216,11 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 		},
 		Forge: &executionForge{Task: task},
 		Capabilities: executionCapability{
-			Workspace:   "none",
-			TimeoutMs:   uint64(cellnEffectiveTimeout(agentRun).Milliseconds()),
-			MemoryBytes: cellnMemoryBytes,
-			OutputBytes: cellnOutputBytes,
+			Workspace:     "none",
+			AllowInsecure: agentRun.Spec.Model.AllowInsecure,
+			TimeoutMs:     uint64(cellnEffectiveTimeout(agentRun).Milliseconds()),
+			MemoryBytes:   cellnMemoryBytes,
+			OutputBytes:   cellnOutputBytes,
 		},
 		Execution: executionPolicy{
 			Lane:                     "agent",
@@ -248,11 +250,12 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 			origin := "https://api.deepseek.com"
 			if agentRun.Spec.Model.Protocol != "" {
 				var err error
-				origin, err = sympoziumv1alpha1.ModelEndpointOrigin(agentRun.Spec.Model.BaseURL)
+				origin, err = sympoziumv1alpha1.ModelEndpointOriginInsecure(agentRun.Spec.Model.BaseURL, agentRun.Spec.Model.AllowInsecure)
 				if err != nil {
 					return ctrl.Result{}, r.failRun(ctx, agentRun, err.Error())
 				}
 			}
+			request.Capabilities.AllowInsecure = agentRun.Spec.Model.AllowInsecure
 			if len(request.Capabilities.Egress) != 1 || request.Capabilities.Egress[0] != origin {
 				return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln model endpoint differs from granted network origin")
 			}

--- a/internal/controller/celln_harness.go
+++ b/internal/controller/celln_harness.go
@@ -9,7 +9,7 @@ import (
 func cellnHarnessModelSupported(m sympoziumv1alpha1.ModelSpec) bool {
 	route := m.Provider == "deepseek" && m.Protocol == "" && (m.BaseURL == "" || m.BaseURL == "https://api.deepseek.com")
 	if m.Protocol != "" {
-		route = m.CredentialProfile != "" && (sympoziumv1alpha1.ModelConnectionSpec{Provider: m.Provider, Protocol: m.Protocol, Endpoint: m.BaseURL, CredentialProfile: m.CredentialProfile, Models: []string{m.Model}}).Validate() == nil
+		route = m.CredentialProfile != "" && (sympoziumv1alpha1.ModelConnectionSpec{Provider: m.Provider, Protocol: m.Protocol, Endpoint: m.BaseURL, CredentialProfile: m.CredentialProfile, Models: []string{m.Model}, AllowInsecure: m.AllowInsecure}).Validate() == nil
 	}
 	return route && m.AuthSecretRef == "" && (m.Thinking == "" || m.Thinking == "off") && len(m.ProviderHeaders) == 0 && m.ProviderHeadersSecretRef == "" && m.ModelRef == "" && len(m.NodeSelector) == 0
 }
@@ -22,7 +22,7 @@ func validCellnHarness(req executionRequest) bool {
 	if h == nil {
 		return req.APIVersion == "celln.dev/v1alpha1"
 	}
-	if !validCellnHarnessContract(req.APIVersion, h) || !cellnHash.MatchString(h.ModelGrant.Hash) || len(h.Model) == 0 || len(h.Model) > 128 || len(h.Task) > 2048 || strings.TrimSpace(h.Task) == "" || strings.ContainsRune(h.Task, '\x00') || req.Mote == nil || req.Forge != nil || len(req.Inputs) != 0 || len(req.Tools) != 1 || req.Tools[0].Closure == nil || req.Invocation == nil || len(req.Invocation.Args) != 0 || req.Execution.Lane != "agent" || !req.Execution.RequireHardwareIsolation || req.Capabilities.Workspace != "none" || len(req.Capabilities.Egress) != 1 || !validModelOrigin(req.Capabilities.Egress[0]) {
+	if !validCellnHarnessContract(req.APIVersion, h) || !cellnHash.MatchString(h.ModelGrant.Hash) || len(h.Model) == 0 || len(h.Model) > 128 || len(h.Task) > 2048 || strings.TrimSpace(h.Task) == "" || strings.ContainsRune(h.Task, '\x00') || req.Mote == nil || req.Forge != nil || len(req.Inputs) != 0 || len(req.Tools) != 1 || req.Tools[0].Closure == nil || req.Invocation == nil || len(req.Invocation.Args) != 0 || req.Execution.Lane != "agent" || !req.Execution.RequireHardwareIsolation || req.Capabilities.Workspace != "none" || len(req.Capabilities.Egress) != 1 || !validModelOrigin(req.Capabilities.Egress[0], req.Capabilities.AllowInsecure) {
 		return false
 	}
 	names, paths := map[string]bool{}, map[string]bool{}
@@ -69,7 +69,7 @@ func validCellnHarnessContract(version string, h *executionHarness) bool {
 	}
 }
 
-func validModelOrigin(origin string) bool {
-	got, err := sympoziumv1alpha1.ModelEndpointOrigin(origin + "/")
+func validModelOrigin(origin string, allowInsecure bool) bool {
+	got, err := sympoziumv1alpha1.ModelEndpointOriginInsecure(origin+"/", allowInsecure)
 	return err == nil && got == origin
 }

--- a/internal/modelconnection/resolve.go
+++ b/internal/modelconnection/resolve.go
@@ -50,7 +50,11 @@ func Resolve(ctx context.Context, reader client.Reader, namespace string, model 
 	if (model.Provider != "" && model.Provider != s.Provider) || (model.BaseURL != "" && model.BaseURL != s.Endpoint) || (model.Protocol != "" && model.Protocol != s.Protocol) || (model.CredentialProfile != "" && model.CredentialProfile != s.CredentialProfile) {
 		return model, fmt.Errorf("inline model settings differ from the selected connection")
 	}
+	if model.AllowInsecure && !s.AllowInsecure {
+		return model, fmt.Errorf("inline insecure setting is not authorized by the connection")
+	}
 	model.Provider, model.BaseURL, model.Protocol, model.CredentialProfile = s.Provider, s.Endpoint, s.Protocol, s.CredentialProfile
+	model.AllowInsecure = s.AllowInsecure
 	model.ConnectionRevision = revision
 	return model, nil
 }

--- a/web/cypress/e2e/agent-execution-flow.cy.ts
+++ b/web/cypress/e2e/agent-execution-flow.cy.ts
@@ -44,8 +44,8 @@ describe("Agent creation execution-plane flow", () => {
       cy.contains("label", "https-fetch@").find('input[type="checkbox"]').uncheck();
     });
     cy.wizardNext(); // provider (same list as the run flow)
-    cy.wizardNext(); // auth
-    cy.get('[role="dialog"]').find("input[placeholder='team-provider-key']").type("cypress-native-profile");
+    cy.wizardNext(); // auth (credential profile defaults to the provider)
+    cy.get('[role="dialog"]').should("contain", "keeps credentials on the host");
     cy.wizardNext(); // model
     cy.get("#native-model").should("have.value", "gpt-4o");
     cy.wizardNext(); // confirm

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-1sz71B1j.js"></script>
+    <script type="module" crossorigin src="/assets/index-HRMTfLYw.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D0L01iAY.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-DeZxHY5M.js"></script>
+    <script type="module" crossorigin src="/assets/index-1sz71B1j.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D0L01iAY.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-HRMTfLYw.js"></script>
+    <script type="module" crossorigin src="/assets/index-eN2QWgye.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D0L01iAY.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -705,9 +705,16 @@ export function OnboardingWizard({
   // execution plane can actually reach.
   const providerChoices = useMemo(() => {
     if (celln) {
-      // Same providers as the run/agent flow. Native Celln needs an HTTPS
-      // endpoint, which is validated when the connection is saved.
-      return PROVIDERS;
+      // The native Celln host transport only reaches public HTTPS endpoints.
+      // HTTP-only local providers and Bedrock are not offered because they can
+      // never satisfy the host egress contract.
+      return PROVIDERS.filter(
+        (p) =>
+          p.value === "openai" ||
+          p.value === "anthropic" ||
+          p.value === "azure-openai" ||
+          p.value === "custom",
+      );
     }
     if (mode === "agent" && creationKind === "agent" && form.runtimeRef) {
       // Persistent Kubernetes harnesses speak OpenAI-compatible chat.
@@ -1151,7 +1158,11 @@ export function OnboardingWizard({
                         executionLifecycle: value === "celln" ? "enduring" : "one-shot",
                         modelConnectionRef: value === form.executionBackend ? form.modelConnectionRef : undefined,
                         credentialProfile: "",
-                        provider: form.provider || "openai",
+                        provider:
+                          value === "celln" &&
+                          !["openai", "anthropic", "azure-openai", "custom"].includes(form.provider)
+                            ? "openai"
+                            : form.provider || "openai",
                         model: form.model || "gpt-4o",
                         apiKey: value === "celln" ? "" : form.apiKey,
                         secretName: value === "celln" ? "" : form.secretName,
@@ -1259,7 +1270,7 @@ export function OnboardingWizard({
                   <SelectValue placeholder="Select a provider…" />
                 </SelectTrigger>
                 <SelectContent>
-                  {readyModels.length > 0 && (
+                  {!celln && readyModels.length > 0 && (
                     <>
                       {readyModels.map((m) => (
                         <SelectItem
@@ -1288,6 +1299,12 @@ export function OnboardingWizard({
                 </SelectContent>
               </Select>
             </div>
+            {celln && (
+              <p className="text-xs text-muted-foreground">
+                Native Celln connects to public HTTPS endpoints only. Local
+                models are available on the Kubernetes execution plane.
+              </p>
+            )}
             {/* Inference mode toggle for local providers */}
             {isLocalProvider && (
               <div className="space-y-2">

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -224,6 +224,8 @@ export interface WizardResult {
   modelConnectionRef?: string;
   /** Opaque host credential mapping for a native Celln model connection. */
   credentialProfile?: string;
+  /** Explicit opt-in for an HTTP or self-signed private native model endpoint. */
+  allowInsecure?: boolean;
   executionBackend?: "job" | "celln";
   /** Default Celln lifecycle when executionBackend is celln. */
   executionLifecycle?: "one-shot" | "enduring";
@@ -600,6 +602,7 @@ function modelConnectionSpec(
     endpoint,
     models: [result.model],
     ...auth,
+    ...(celln && result.allowInsecure ? { allowInsecure: true } : {}),
   };
 }
 
@@ -705,9 +708,12 @@ export function OnboardingWizard({
   // execution plane can actually reach.
   const providerChoices = useMemo(() => {
     if (celln) {
-      // The native Celln host transport only reaches public HTTPS endpoints.
-      // HTTP-only local providers and Bedrock are not offered because they can
-      // never satisfy the host egress contract.
+      // The native Celln host transport only reaches public HTTPS endpoints by
+      // default. The explicit insecure opt-in also allows HTTP/self-signed
+      // local providers; Bedrock has no compatible protocol either way.
+      if (form.allowInsecure) {
+        return PROVIDERS.filter((p) => p.value !== "bedrock");
+      }
       return PROVIDERS.filter(
         (p) =>
           p.value === "openai" ||
@@ -723,7 +729,7 @@ export function OnboardingWizard({
       );
     }
     return PROVIDERS;
-  }, [celln, mode, creationKind, form.runtimeRef]);
+  }, [celln, mode, creationKind, form.runtimeRef, form.allowInsecure]);
   const staleTools = (form.borrowedTools || []).some((ref) => !(catalogue.data || []).some((tool) => tool.metadata.name === ref.name && tool.spec.revision === ref.revision && tool.spec.invocationABI === "celln.json-stdio/v1" && tool.spec.lane === "tool"));
   const [inferenceMode, setInferenceMode] = useState<"workload" | "node">(
     "workload",
@@ -869,7 +875,7 @@ export function OnboardingWizard({
       compatibleRuntime;
     if (persistentHarness || celln) {
       const spec = modelConnectionSpec(result, celln);
-      if (celln && !spec.endpoint.startsWith("https://")) {
+      if (celln && !result.allowInsecure && !spec.endpoint.startsWith("https://")) {
         setConnectionError(
           "Native Celln needs an HTTPS model endpoint. Configure an HTTPS gateway or choose OpenAI, Anthropic, Azure, or a custom HTTPS endpoint.",
         );
@@ -1300,10 +1306,21 @@ export function OnboardingWizard({
               </Select>
             </div>
             {celln && (
-              <p className="text-xs text-muted-foreground">
-                Native Celln connects to public HTTPS endpoints only. Local
-                models are available on the Kubernetes execution plane.
-              </p>
+              <label className="flex items-start gap-2 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={!!form.allowInsecure}
+                  onChange={(e) =>
+                    setForm({ ...form, allowInsecure: e.target.checked })
+                  }
+                />
+                <span>
+                  Allow an insecure model endpoint (HTTP or self-signed HTTPS)
+                  on a private address. This is an explicit operator opt-in;
+                  without it native Celln reaches public HTTPS endpoints only.
+                </span>
+              </label>
             )}
             {/* Inference mode toggle for local providers */}
             {isLocalProvider && (

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -588,7 +588,9 @@ function modelConnectionSpec(
       ? "anthropic-messages"
       : "openai-chat";
   const auth = celln
-    ? { credentialProfile: result.credentialProfile }
+    ? // The host operator maps the provider to a credential profile by default;
+      // the field is only overridden under Advanced.
+      { credentialProfile: result.credentialProfile || result.provider }
     : result.apiKey || !result.secretName
       ? {}
       : { secretRef: result.secretName };
@@ -723,6 +725,7 @@ export function OnboardingWizard({
   const [showYaml, setShowYaml] = useState(false);
   const [savingConnection, setSavingConnection] = useState(false);
   const [connectionError, setConnectionError] = useState("");
+  const [advancedAuth, setAdvancedAuth] = useState(false);
   const { data: capabilities } = useCapabilities();
   const { data: clusterModels } = useModels();
   const [usingLocalModel, setUsingLocalModel] = useState(false);
@@ -804,7 +807,7 @@ export function OnboardingWizard({
       case "tools":
         return !catalogue.isLoading && !catalogue.isError && !staleTools && (form.borrowedTools || []).length <= 16;
       case "apikey":
-        if (celln) return !!form.credentialProfile;
+        if (celln) return true;
         if (form.modelConnectionRef) return true;
         if (
           form.provider === "ollama" ||
@@ -1455,18 +1458,38 @@ export function OnboardingWizard({
             <div className="space-y-4">
               {celln ? (
                 <div className="space-y-2">
-                  <Label>Host credential profile</Label>
-                  <Input
-                    value={form.credentialProfile || ""}
-                    onChange={(e) =>
-                      setForm({ ...form, credentialProfile: e.target.value })
-                    }
-                    placeholder="team-provider-key"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    The host operator maps this profile to credentials. No key
-                    is stored in the cluster.
+                  <p className="text-sm text-muted-foreground">
+                    Native Celln keeps credentials on the host. The host
+                    operator maps this connection to a credential profile; no
+                    key is stored in the cluster.
                   </p>
+                  <button
+                    type="button"
+                    className="text-xs text-blue-400 hover:text-blue-300"
+                    onClick={() => setAdvancedAuth(!advancedAuth)}
+                  >
+                    {advancedAuth ? "Hide advanced" : "Advanced"}
+                  </button>
+                  {advancedAuth && (
+                    <div className="space-y-2">
+                      <Label>Host credential profile</Label>
+                      <Input
+                        value={form.credentialProfile || ""}
+                        onChange={(e) =>
+                          setForm({
+                            ...form,
+                            credentialProfile: e.target.value,
+                          })
+                        }
+                        placeholder={form.provider}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Defaults to the provider name. Set this only if your
+                        host operator configured a different credential
+                        mapping.
+                      </p>
+                    </div>
+                  )}
                 </div>
               ) : (
                 <>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -985,7 +985,7 @@ export interface CapabilitiesResponse {
 
 export interface ModelConnection {
   metadata: ObjectMeta;
-  spec: { provider: string; protocol: "openai-chat" | "anthropic-messages"; endpoint: string; credentialProfile?: string; secretRef?: string; models: string[]; disabled?: boolean };
+  spec: { provider: string; protocol: "openai-chat" | "anthropic-messages"; endpoint: string; credentialProfile?: string; secretRef?: string; models: string[]; disabled?: boolean; allowInsecure?: boolean };
 }
 
 export interface AgentExecutionDefaults {


### PR DESCRIPTION
## Why

`sympozium install` previously only set `celln.enabled=true`, which rendered a broken/partial Celln setup and required manual wiring of the router, dispatcher, tokens and storage. The host installer's dispatcher is loopback-only, so the router couldn't reach it without a reverse proxy.

## What

- **Default Celln stack**: `install` now deploys an in-cluster (pod-based) dispatcher + unprivileged router, with generated router/backend/capability bearer tokens and an ownership PVC (`celln.bootstrap`).
- **New chart `celln.dispatcher`** — a privileged pod (`/dev/kvm`, hostPath state, ClusterIP Service) so the router can actually reach it. `--celln-host-installer` opts into the bare-metal DaemonSet.
- **Router image** accepts a tag or digest (recommended); `--celln-router-image`, `--celln-installer-image`, `--celln-backend` override defaults.
- **`--celln-native`** runs the native starter catalogue + grant layers after install (operator `--celln-native-*` inputs + approval required).
- **`--no-celln`** opts out; `--enable-hermetic-workloads` is a deprecated no-op.

## Validation

- `go build ./cmd/sympozium`, `go test ./cmd/sympozium` (added `install_celln_test.go`).
- `helm template` renders matching cross-namespace tokens, the ownership PVC, dispatcher (tag/digest paths) and router.

## Note

The installer image `ghcr.io/sympozium-ai/celln-installer` is not published (only `celln:v0.5.8`); the in-cluster dispatcher path uses the full celln image and works without it. Bare-metal host install still needs that image published.