### PR TITLE
fix(eventbus): survive NATS being unavailable at startup and consumer reaping

### DIFF
--- a/internal/eventbus/nats.go
+++ b/internal/eventbus/nats.go
@@ -3,6 +3,7 @@ package eventbus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -15,31 +16,74 @@ const (
 	streamName    = "sympozium"
 	consumerGroup = "sympozium-workers"
 
-	// reconnectBackoff is how long a Subscribe loop waits before recreating its
-	// consumer after a fetch error (e.g. the consumer or stream was lost because
-	// NATS was restarted/recreated).
+	// reconnectBackoff is how long a Subscribe loop waits before (re)creating its
+	// consumer — after a fetch error (the consumer or stream was lost because
+	// NATS was restarted/recreated) or while NATS is still unreachable on a lazy
+	// bus.
 	reconnectBackoff = 2 * time.Second
+
+	// consumerInactiveThreshold is how long the server keeps a subscription's
+	// ephemeral consumer alive with no client activity. The server default is a
+	// few seconds, so any fetch gap longer than that — a rolling NATS restart, a
+	// network blip, a handler that blocks on a full channel — reaps the consumer,
+	// and the DeliverNew recreate in Subscribe then silently drops every event
+	// published in between. A long threshold keeps the consumer and its cursor,
+	// so the backlog is delivered when fetching resumes. Consumers orphaned by a
+	// recreate are still reclaimed by the server once the threshold elapses.
+	consumerInactiveThreshold = time.Hour
+)
+
+// Provisioning knobs. Variables rather than constants so tests can shrink
+// them; the defaults are the production values.
+var (
+	// streamBootstrapAttempts and streamBootstrapBackoff bound how long a
+	// constructor waits for the stream to become creatable before it either
+	// fails (bounded mode) or hands back a bus that provisions lazily.
+	streamBootstrapAttempts = 10
+	streamBootstrapBackoff  = 2 * time.Second
+
+	// jetStreamOpTimeout bounds each stream/consumer management call.
+	jetStreamOpTimeout = 5 * time.Second
 )
 
 // NATSEventBus implements EventBus using NATS JetStream.
 type NATSEventBus struct {
 	conn *nats.Conn
 	js   jetstream.JetStream
+
+	// lazy marks a bus built by NewNATSEventBus: NATS being unreachable at
+	// startup or at Subscribe time is treated as transient and self-heals,
+	// rather than failing the caller.
+	lazy bool
 }
 
-// NewNATSEventBus creates a new NATS JetStream event bus.
+// NewNATSEventBus creates a NATS JetStream event bus for a long-lived process
+// such as the controller. It does not fail because NATS is merely unreachable:
+// the connection reconnects indefinitely, the stream is provisioned on first
+// use if it cannot be created at startup, and Subscribe hands back a live
+// channel whose consumer is created once NATS answers. A process whose NATS
+// peer is recreated alongside it (node drain, rolling upgrade) therefore comes
+// up with routing intact instead of running with the bus permanently
+// disabled. Configuration errors — a malformed URL, bad options — are still
+// returned.
 func NewNATSEventBus(url string) (*NATSEventBus, error) {
-	return NewNATSEventBusWithContext(context.Background(), url)
+	return newNATSEventBus(context.Background(), url, true)
 }
 
-// NewNATSEventBusWithContext bounds initial stream provisioning. Cancellation
-// closes the connection, including its background reconnect loop. A successfully
-// returned bus retains the existing lifetime/reconnect policy after ctx expires.
+// NewNATSEventBusWithContext bounds initial stream provisioning and fails fast
+// when NATS is not usable within ctx. Cancellation closes the connection,
+// including its background reconnect loop. A successfully returned bus retains
+// the existing lifetime/reconnect policy after ctx expires, and its Subscribe
+// keeps fail-fast semantics, which suits per-request subscribers.
 func NewNATSEventBusWithContext(ctx context.Context, url string) (*NATSEventBus, error) {
+	return newNATSEventBus(ctx, url, false)
+}
+
+func newNATSEventBus(ctx context.Context, url string, lazy bool) (*NATSEventBus, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	n := &NATSEventBus{}
+	n := &NATSEventBus{lazy: lazy}
 	initialized := make(chan struct{})
 
 	// MaxReconnects(-1) keeps the client reconnecting indefinitely. A bounded
@@ -93,14 +137,14 @@ func NewNATSEventBusWithContext(ctx context.Context, url string) (*NATSEventBus,
 
 	// Retry stream creation — NATS may not be fully ready yet.
 	var lastErr error
-	for attempt := 0; attempt < 10; attempt++ {
+	for attempt := 0; attempt < streamBootstrapAttempts; attempt++ {
 		if _, lastErr = n.ensureStream(ctx); lastErr == nil {
 			break
 		}
-		if attempt == 9 {
+		if attempt == streamBootstrapAttempts-1 {
 			break
 		}
-		timer := time.NewTimer(2 * time.Second)
+		timer := time.NewTimer(streamBootstrapBackoff)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
@@ -110,8 +154,15 @@ func NewNATSEventBusWithContext(ctx context.Context, url string) (*NATSEventBus,
 		}
 	}
 	if lastErr != nil {
-		nc.Close()
-		return nil, fmt.Errorf("creating JetStream stream after retries: %w", lastErr)
+		if !lazy {
+			nc.Close()
+			return nil, fmt.Errorf("creating JetStream stream after retries: %w", lastErr)
+		}
+		// Lazy bus: keep the connection (it is reconnecting in the background)
+		// and let Publish/Subscribe provision the stream once NATS answers.
+		// Failing here would leave the caller without an event bus for the
+		// life of the process over what is usually a startup-ordering race.
+		log.Printf("eventbus: JetStream stream not provisioned at startup (%v); it will be created on first use once NATS is reachable", lastErr)
 	}
 
 	return n, nil
@@ -119,6 +170,11 @@ func NewNATSEventBusWithContext(ctx context.Context, url string) (*NATSEventBus,
 
 // Publish sends an event to the NATS JetStream stream.
 // Trace context from ctx is automatically injected into NATS message headers.
+//
+// If the stream is missing server-side — NATS was recreated with ephemeral
+// storage, the reconnect handler has not finished re-ensuring it, or this bus
+// was built lazily before NATS was reachable — Publish recreates the stream
+// and retries once instead of failing.
 func (n *NATSEventBus) Publish(ctx context.Context, topic string, event *Event) error {
 	data, err := json.Marshal(event)
 	if err != nil {
@@ -133,12 +189,35 @@ func (n *NATSEventBus) Publish(ctx context.Context, topic string, event *Event) 
 	}
 	InjectTraceContext(ctx, msg.Header)
 
-	_, err = n.js.PublishMsg(ctx, msg)
-	if err != nil {
-		return fmt.Errorf("publishing to %s: %w", subject, err)
+	if _, err := n.js.PublishMsg(ctx, msg); err != nil {
+		if !isStreamGoneErr(err) {
+			return fmt.Errorf("publishing to %s: %w", subject, err)
+		}
+		log.Printf("eventbus: publish to %s found no stream (%v); recreating and retrying", subject, err)
+		if _, serr := n.ensureStream(ctx); serr != nil {
+			return fmt.Errorf("publishing to %s: stream missing (%v) and recreate failed: %w", subject, err, serr)
+		}
+		if _, rerr := n.js.PublishMsg(ctx, msg); rerr != nil {
+			return fmt.Errorf("publishing to %s after recreating stream: %w", subject, rerr)
+		}
 	}
 
 	return nil
+}
+
+// isStreamGoneErr reports whether err means the server has no stream for us
+// to publish to or consume from, so the caller should recreate it and retry.
+// ErrNoResponders is included because a JetStream that has restarted without
+// our stream answers requests with no responders rather than a typed
+// not-found error. A missing consumer is deliberately not classified here:
+// the stream is fine in that case and only the consumer needs recreating.
+func isStreamGoneErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, jetstream.ErrStreamNotFound) ||
+		errors.Is(err, jetstream.ErrNoStreamResponse) ||
+		errors.Is(err, nats.ErrNoResponders)
 }
 
 // Subscribe returns a channel that receives events for the given topic.
@@ -147,12 +226,25 @@ func (n *NATSEventBus) Publish(ctx context.Context, topic string, event *Event) 
 // because the consumer or stream no longer exists, the loop recreates them
 // (re-creating the stream first if needed) and resumes, so the subscription
 // recovers without requiring the process to restart.
+//
+// On a bus built with NewNATSEventBus, NATS being unreachable at Subscribe
+// time is handled the same way: the channel is returned live and the consumer
+// is created once NATS answers. A bus built with NewNATSEventBusWithContext
+// returns the error instead, so per-request subscribers fail fast.
 func (n *NATSEventBus) Subscribe(ctx context.Context, topic string) (<-chan *Event, error) {
 	subject := topicToSubject(topic)
 
 	consumer, err := n.createConsumer(ctx, subject)
 	if err != nil {
-		return nil, fmt.Errorf("creating consumer for %s: %w", subject, err)
+		if !n.lazy {
+			return nil, fmt.Errorf("creating consumer for %s: %w", subject, err)
+		}
+		// A long-lived subscriber (the routers) returning this error from Start
+		// takes the whole controller-runtime manager down over a transient
+		// outage the fetch loop below would have ridden out. Hand back a live
+		// channel and let the loop create the consumer instead.
+		log.Printf("eventbus: consumer for %s not created yet (%v); will keep trying", subject, err)
+		consumer = nil
 	}
 
 	ch := make(chan *Event, 64)
@@ -162,6 +254,23 @@ func (n *NATSEventBus) Subscribe(ctx context.Context, topic string) (<-chan *Eve
 		for {
 			if ctx.Err() != nil {
 				return
+			}
+
+			// Lazy start: NATS was unreachable at Subscribe time. Keep trying
+			// to create the consumer, backing off between attempts.
+			if consumer == nil {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(reconnectBackoff):
+				}
+				created, cerr := n.createConsumer(ctx, subject)
+				if cerr != nil {
+					continue
+				}
+				log.Printf("eventbus: created consumer for %s", subject)
+				consumer = created
+				continue
 			}
 
 			msgs, err := consumer.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
@@ -229,7 +338,7 @@ func (n *NATSEventBus) Close() error {
 // it. It is safe to call repeatedly — after a NATS recreate the stream no longer
 // exists, and calling this recreates it.
 func (n *NATSEventBus) ensureStream(ctx context.Context) (jetstream.Stream, error) {
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	cctx, cancel := context.WithTimeout(ctx, jetStreamOpTimeout)
 	defer cancel()
 	return n.js.CreateOrUpdateStream(cctx, streamConfig())
 }
@@ -242,13 +351,21 @@ func (n *NATSEventBus) createConsumer(ctx context.Context, subject string) (jets
 		return nil, err
 	}
 
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	cctx, cancel := context.WithTimeout(ctx, jetStreamOpTimeout)
 	defer cancel()
-	return stream.CreateOrUpdateConsumer(cctx, jetstream.ConsumerConfig{
-		FilterSubject: subject,
-		AckPolicy:     jetstream.AckExplicitPolicy,
-		DeliverPolicy: jetstream.DeliverNewPolicy,
-	})
+	return stream.CreateOrUpdateConsumer(cctx, consumerConfig(subject))
+}
+
+// consumerConfig returns the ephemeral pull-consumer configuration Subscribe
+// uses for a subject. See consumerInactiveThreshold for why the threshold is
+// set explicitly.
+func consumerConfig(subject string) jetstream.ConsumerConfig {
+	return jetstream.ConsumerConfig{
+		FilterSubject:     subject,
+		AckPolicy:         jetstream.AckExplicitPolicy,
+		DeliverPolicy:     jetstream.DeliverNewPolicy,
+		InactiveThreshold: consumerInactiveThreshold,
+	}
 }
 
 // streamConfig returns the JetStream stream configuration for Sympozium events.

--- a/internal/eventbus/nats_resilience_test.go
+++ b/internal/eventbus/nats_resilience_test.go
@@ -1,0 +1,128 @@
+package eventbus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestIsStreamGoneErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"stream not found", jetstream.ErrStreamNotFound, true},
+		{"no stream response", jetstream.ErrNoStreamResponse, true},
+		{"no responders", nats.ErrNoResponders, true},
+		{"wrapped stream not found", fmt.Errorf("publish: %w", jetstream.ErrStreamNotFound), true},
+		{"consumer not found is a consumer problem, not a stream problem", jetstream.ErrConsumerNotFound, false},
+		{"context deadline", context.DeadlineExceeded, false},
+		{"unrelated", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStreamGoneErr(tc.err); got != tc.want {
+				t.Fatalf("isStreamGoneErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConsumerConfigSurvivesFetchGaps(t *testing.T) {
+	cfg := consumerConfig("sympozium.agent.run.completed")
+	// The server-side default is a few seconds; a consumer reaped during a
+	// NATS restart loses every event published until Subscribe recreates it.
+	if cfg.InactiveThreshold < 10*time.Minute {
+		t.Fatalf("InactiveThreshold = %s, want at least 10m so a restart does not reap the consumer", cfg.InactiveThreshold)
+	}
+	if cfg.FilterSubject != "sympozium.agent.run.completed" {
+		t.Fatalf("FilterSubject = %q", cfg.FilterSubject)
+	}
+	if cfg.AckPolicy != jetstream.AckExplicitPolicy {
+		t.Fatalf("AckPolicy = %v, want explicit", cfg.AckPolicy)
+	}
+	if cfg.DeliverPolicy != jetstream.DeliverNewPolicy {
+		t.Fatalf("DeliverPolicy = %v, want new", cfg.DeliverPolicy)
+	}
+}
+
+// shrinkProvisioningKnobs makes the unavailable-NATS paths fail fast so the
+// tests below finish in well under a second per attempt. Restored on cleanup.
+func shrinkProvisioningKnobs(t *testing.T) {
+	t.Helper()
+	attempts, backoff, opTimeout := streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout
+	streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout = 1, 0, 100*time.Millisecond
+	t.Cleanup(func() {
+		streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout = attempts, backoff, opTimeout
+	})
+}
+
+// unusedLoopbackAddress reserves a loopback port and releases it, so a dial
+// there is refused immediately — the shape of "NATS is not up yet".
+func unusedLoopbackAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := listener.Addr().String()
+	listener.Close()
+	return address
+}
+
+func TestLazyStartupReturnsUsableBusWhenNATSUnavailable(t *testing.T) {
+	shrinkProvisioningKnobs(t)
+	t.Setenv("NATS_USERNAME", "")
+	t.Setenv("NATS_PASSWORD", "")
+	address := unusedLoopbackAddress(t)
+
+	start := time.Now()
+	bus, err := NewNATSEventBus("nats://" + address)
+	if err != nil || bus == nil {
+		t.Fatalf("NewNATSEventBus must hand back a lazily provisioned bus when NATS is down: bus=%v err=%v", bus, err)
+	}
+	defer bus.Close()
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("lazy startup took %s; bootstrap did not respect the shrunken knobs", elapsed)
+	}
+
+	// Subscribe must not fail either: a router's Start returning an error here
+	// would take the whole manager down over a startup-ordering race. It gets
+	// a live channel that closes once the subscription context ends.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	events, err := bus.Subscribe(ctx, TopicAgentRunCompleted)
+	if err != nil || events == nil {
+		t.Fatalf("lazy Subscribe: events=%v err=%v", events, err)
+	}
+	select {
+	case _, ok := <-events:
+		if ok {
+			t.Fatal("received an event from an unreachable NATS")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("subscription channel did not close after its context ended")
+	}
+}
+
+func TestBoundedStartupStillFailsWhenNATSUnavailable(t *testing.T) {
+	shrinkProvisioningKnobs(t)
+	t.Setenv("NATS_USERNAME", "")
+	t.Setenv("NATS_PASSWORD", "")
+	address := unusedLoopbackAddress(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	bus, err := NewNATSEventBusWithContext(ctx, "nats://"+address)
+	if bus != nil || err == nil {
+		t.Fatalf("bounded startup must keep failing fast: bus=%v err=%v", bus, err)
+	}
+}

--- a/internal/eventbus/nats_resilience_test.go
+++ b/internal/eventbus/nats_resilience_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"os/exec"
+	"strconv"
 	"testing"
 	"time"
 
@@ -54,15 +57,22 @@ func TestConsumerConfigSurvivesFetchGaps(t *testing.T) {
 	}
 }
 
+// setProvisioningKnobs overrides the bootstrap knobs for one test and restores
+// them on cleanup.
+func setProvisioningKnobs(t *testing.T, attempts int, backoff, opTimeout time.Duration) {
+	t.Helper()
+	prevAttempts, prevBackoff, prevOpTimeout := streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout
+	streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout = attempts, backoff, opTimeout
+	t.Cleanup(func() {
+		streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout = prevAttempts, prevBackoff, prevOpTimeout
+	})
+}
+
 // shrinkProvisioningKnobs makes the unavailable-NATS paths fail fast so the
-// tests below finish in well under a second per attempt. Restored on cleanup.
+// no-server tests finish in well under a second per attempt.
 func shrinkProvisioningKnobs(t *testing.T) {
 	t.Helper()
-	attempts, backoff, opTimeout := streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout
-	streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout = 1, 0, 100*time.Millisecond
-	t.Cleanup(func() {
-		streamBootstrapAttempts, streamBootstrapBackoff, jetStreamOpTimeout = attempts, backoff, opTimeout
-	})
+	setProvisioningKnobs(t, 1, 0, 100*time.Millisecond)
 }
 
 // unusedLoopbackAddress reserves a loopback port and releases it, so a dial
@@ -125,4 +135,150 @@ func TestBoundedStartupStillFailsWhenNATSUnavailable(t *testing.T) {
 	if bus != nil || err == nil {
 		t.Fatalf("bounded startup must keep failing fast: bus=%v err=%v", bus, err)
 	}
+}
+
+// Opt-in real-server regression for the lazy paths, in the same shape as
+// TestNATSRealServerReconnectAfterStartupContextExpires: this test owns a
+// loopback nats-server process and temporary storage; no external endpoint or
+// credentials are accepted.
+//
+// Scenario: the controller starts before NATS exists (node drain, rolling
+// upgrade). The bus and a router subscription are created against a refused
+// port, NATS comes up afterwards, and events must flow without any restart.
+// Then the stream is deleted server-side while the connection stays up, and a
+// publish must recreate it rather than fail.
+func TestNATSRealServerLazyStartupRecoversWhenServerAppearsLater(t *testing.T) {
+	binary := os.Getenv("SYMPOZIUM_NATS_SERVER")
+	if binary == "" {
+		t.Skip("set SYMPOZIUM_NATS_SERVER to a local nats-server binary")
+	}
+	// One quick bootstrap attempt so the pre-server construction returns fast,
+	// but a realistic per-call timeout once the server is up.
+	setProvisioningKnobs(t, 1, 0, 2*time.Second)
+	t.Setenv("NATS_USERNAME", "")
+	t.Setenv("NATS_PASSWORD", "")
+
+	address := unusedLoopbackAddress(t)
+	_, portText, err := net.SplitHostPort(address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, _ := strconv.Atoi(portText)
+	storage := t.TempDir()
+	var server *exec.Cmd
+	stop := func() {
+		if server != nil {
+			_ = server.Process.Kill()
+			_ = server.Wait()
+			server = nil
+		}
+	}
+	defer stop()
+	start := func() {
+		server = exec.Command(binary, "-a", "127.0.0.1", "-p", strconv.Itoa(port), "-js", "-sd", storage)
+		server.Stdout = os.Stderr
+		server.Stderr = os.Stderr
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+			if err == nil {
+				conn.Close()
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		t.Fatal("owned NATS process did not listen")
+	}
+
+	// 1. Nothing is listening yet. Construction and subscription must both
+	//    succeed lazily.
+	bus, err := NewNATSEventBus("nats://" + address)
+	if err != nil {
+		t.Fatalf("lazy construction against a refused port: %v", err)
+	}
+	defer bus.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	events, err := bus.Subscribe(ctx, TopicAgentRunCompleted)
+	if err != nil {
+		t.Fatalf("lazy Subscribe against a refused port: %v", err)
+	}
+
+	// 2. A publish while NATS is still down must report an error — the lazy
+	//    bus defers provisioning, it never pretends a publish succeeded.
+	downCtx, cancelDown := context.WithTimeout(ctx, 500*time.Millisecond)
+	if err := bus.Publish(downCtx, TopicAgentRunCompleted, &Event{Topic: TopicAgentRunCompleted, Timestamp: time.Now()}); err == nil {
+		t.Fatal("publish with NATS down must fail, not silently succeed")
+	}
+	cancelDown()
+
+	// 3. NATS comes up. The connection reconnects on its own and the lazy
+	//    subscription creates its consumer; the consumer is DeliverNew, so keep
+	//    publishing fresh proofs until one comes back.
+	start()
+	deadline := time.Now().Add(10 * time.Second)
+	for !bus.conn.IsConnected() && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !bus.conn.IsConnected() {
+		t.Fatal("connection did not establish after the server appeared")
+	}
+	awaitRoundTrip := func(prefix string) {
+		t.Helper()
+		ticker := time.NewTicker(300 * time.Millisecond)
+		defer ticker.Stop()
+		giveUp := time.After(20 * time.Second)
+		for i := 0; ; i++ {
+			id := fmt.Sprintf("%s-%d", prefix, i)
+			publishCtx, cancelPublish := context.WithTimeout(ctx, 3*time.Second)
+			err := bus.Publish(publishCtx, TopicAgentRunCompleted, &Event{
+				Topic: TopicAgentRunCompleted, Timestamp: time.Now(), Metadata: map[string]string{"proof": id},
+			})
+			cancelPublish()
+			if err != nil {
+				t.Logf("publish %s: %v (retrying)", id, err)
+			}
+			select {
+			case got, ok := <-events:
+				if !ok {
+					t.Fatal("subscription channel closed")
+				}
+				t.Logf("received %s", got.Metadata["proof"])
+				return
+			case <-ticker.C:
+			case <-giveUp:
+				t.Fatalf("no %s event arrived on the lazily created subscription", prefix)
+			}
+		}
+	}
+	awaitRoundTrip("after-start")
+
+	// 4. Delete the stream out from under a live connection. The very next
+	//    publish must recreate it and succeed instead of returning an error.
+	js, err := jetstream.New(bus.conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := js.DeleteStream(ctx, streamName); err != nil {
+		t.Fatalf("deleting stream: %v", err)
+	}
+	publishCtx, cancelPublish := context.WithTimeout(ctx, 5*time.Second)
+	err = bus.Publish(publishCtx, TopicAgentRunCompleted, &Event{
+		Topic: TopicAgentRunCompleted, Timestamp: time.Now(), Metadata: map[string]string{"proof": "after-stream-delete"},
+	})
+	cancelPublish()
+	if err != nil {
+		t.Fatalf("publish after stream deletion must recreate the stream, got: %v", err)
+	}
+	if _, err := js.Stream(ctx, streamName); err != nil {
+		t.Fatalf("stream was not recreated by Publish: %v", err)
+	}
+
+	// 5. The subscriber lost its consumer with the stream; #254's recreate
+	//    path brings it back, and events flow again.
+	awaitRoundTrip("after-stream-delete")
 }


### PR DESCRIPTION
Builds on #254, which made subscriptions self-heal after a NATS restart. Three gaps remained:

- **Consumers were reaped during any fetch gap.** Ephemeral subscribe consumers used the server default `InactiveThreshold` (5s). A NATS rolling restart, a network blip, or a handler blocked on a full channel reaped the consumer, and the `DeliverNew` recreate then silently dropped every event published in between. Set it to 1h so the consumer and its cursor survive the gap. Trade-off: consumers orphaned by a recreate now linger up to 1h before the server reclaims them (one per recreate, so bounded).
- **Publish failed when the stream was missing** — NATS recreated with ephemeral storage, or the reconnect handler not yet done re-ensuring it. Now recreates the stream via `ensureStream` and retries once.
- **NATS unreachable at boot disabled routing for the life of the process.** `NewNATSEventBus` failed after ~20s, the controller logged "channel routing disabled" and carried on without a bus; and a router whose initial `Subscribe` failed returned that error from `Start`, taking the whole manager down. This is the node-drain / rolling-upgrade case where the NATS pod and the controller are recreated together. The controller's bus now provisions lazily: startup returns a usable bus, and `Subscribe` returns a live channel that creates its consumer once NATS answers.

**Behavior change:** `NewNATSEventBus` no longer returns an error for an unreachable NATS (configuration errors are still returned). `NewNATSEventBusWithContext` — used by the API server, whose webproxy subscribes per request — keeps its fail-fast contract unchanged.

**Testing:** `nats_resilience_test.go` in the existing no-server style: `TestIsStreamGoneErr`, `TestConsumerConfigSurvivesFetchGaps`, `TestLazyStartupReturnsUsableBusWhenNATSUnavailable` (bus + live channel from a refused loopback port), `TestBoundedStartupStillFailsWhenNATSUnavailable`. `go test -race ./internal/eventbus/` passes.