### PR TITLE
fix(celln): host installer and in-cluster dispatcher are mutually exclusive

### DIFF
--- a/cmd/sympozium/install_celln_test.go
+++ b/cmd/sympozium/install_celln_test.go
@@ -61,8 +61,8 @@ func TestCellnInstallSetValues(t *testing.T) {
 		t.Fatalf("installer.enabled = %v, want true (hostInstaller=true)", installer["enabled"])
 	}
 	dispatcher, _ := celln["dispatcher"].(map[string]interface{})
-	if dispatcher["enabled"] != true {
-		t.Fatalf("dispatcher.enabled = %v, want true", dispatcher["enabled"])
+	if dispatcher["enabled"] != false {
+		t.Fatalf("dispatcher.enabled = %v, want false (hostInstaller=true replaces the in-cluster dispatcher)", dispatcher["enabled"])
 	}
 	router, _ := celln["router"].(map[string]interface{})
 	if router["external"] != false {
@@ -104,5 +104,18 @@ func TestCellnInstallSetValuesDefaultBackends(t *testing.T) {
 		if installer["enabled"] == true {
 			t.Fatalf("installer.enabled should be false when hostInstaller=false")
 		}
+	}
+}
+
+func TestCellnInstallSetValuesHostInstallerRequiresBackend(t *testing.T) {
+	if _, err := cellnInstallSetValues(
+		context.Background(),
+		"ghcr.io/sympozium-ai/celln:v0.5.8",
+		"",
+		nil,
+		1,
+		true,
+	); err == nil {
+		t.Fatal("hostInstaller without --celln-backend must fail; the host dispatcher is loopback-only")
 	}
 }

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -1269,9 +1269,10 @@ Celln is deployed by default: an in-cluster (pod-based) dispatcher, an
 unprivileged router, and generated router/backend/capability credentials plus
 the ownership PVC. The router reaches the dispatcher over the celln-dispatcher
 Service; override with --celln-backend for an external dispatcher. Pass
---celln-host-installer to also run the privileged host-installer DaemonSet
-(bare-metal dispatcher), which mounts the host root filesystem and is a
-materially different trust boundary. Pass --no-celln to skip Celln entirely.
+--celln-host-installer to run the privileged host-installer DaemonSet (bare-metal
+systemd dispatcher) instead of the in-cluster pod dispatcher; it mounts the host
+root filesystem, is a materially different trust boundary, and requires
+--celln-backend. Pass --no-celln to skip Celln entirely.
 See docs/concepts/celln-backend.md before relying on it.
 
 Use --image-tag to override the container image tag, for example when you have
@@ -1310,7 +1311,7 @@ layers (enduring native parents); it requires the operator-reviewed
 	cmd.Flags().StringArrayVar(&setValues, "set", nil, "Set Helm values (key=value, can be repeated)")
 	cmd.Flags().BoolVar(&enableHermeticWorkloads, "enable-hermetic-workloads", false, "Deprecated: Celln is enabled by default; use --no-celln to skip it")
 	cmd.Flags().BoolVar(&noCelln, "no-celln", false, "Do not deploy the Celln backend (dispatcher, router, credentials, ownership PVC)")
-	cmd.Flags().BoolVar(&cellnHostInstaller, "celln-host-installer", false, "Also deploy the privileged host-installer DaemonSet (bare-metal dispatcher); requires --celln-backend pointing at the dispatcher/proxy")
+	cmd.Flags().BoolVar(&cellnHostInstaller, "celln-host-installer", false, "Deploy the privileged host-installer DaemonSet (bare-metal systemd dispatcher) instead of the in-cluster pod dispatcher; requires --celln-backend")
 	cmd.Flags().StringArrayVar(&cellnBackends, "celln-backend", nil, "Celln router dispatcher origin(s) http://host:port (repeatable); defaults to the in-cluster celln-dispatcher Service")
 	cmd.Flags().StringVar(&cellnRouterImage, "celln-router-image", "", "Celln router image repo:tag or repo@sha256:... (default ghcr.io/sympozium-ai/celln:v0.5.8)")
 	cmd.Flags().StringVar(&cellnInstallerImage, "celln-installer-image", "", "Celln host-installer image repo:tag (default ghcr.io/sympozium-ai/sympozium/celln-installer, tagged with this release)")
@@ -1340,13 +1341,23 @@ func cellnInstallSetValues(ctx context.Context, routerImage, installerImage stri
 	installerRepo, installerTag, _ := splitImageRef(installerImage, "ghcr.io/sympozium-ai/sympozium/celln-installer", installerTag)
 
 	// Default execution path is the in-cluster (pod-based) dispatcher, reached
-	// by the router over the celln-dispatcher Service. `--celln-backend`
-	// overrides the backend origins (e.g. an external/host-installed dispatcher).
+	// by the router over the celln-dispatcher Service. `--celln-host-installer`
+	// swaps in the host systemd dispatcher instead: both are alternative
+	// deployments of the same binary and contend for the same state root, so
+	// exactly one is enabled. `--celln-backend` overrides the router's backend
+	// origins (e.g. the host dispatcher or its TLS proxy).
+	dispatcherEnabled := "true"
+	if hostInstaller {
+		dispatcherEnabled = "false"
+		if len(backends) == 0 {
+			return nil, fmt.Errorf("--celln-host-installer requires --celln-backend pointing at the host dispatcher or its proxy")
+		}
+	}
 	vals := []string{
 		"celln.enabled=true",
 		"celln.allowInsecureHttp=true",
 		"celln.bootstrap.enabled=true",
-		"celln.dispatcher.enabled=true",
+		"celln.dispatcher.enabled=" + dispatcherEnabled,
 		"celln.tokenSecret=celln-router-client",
 		"celln.capabilityTokenSecret=celln-discovery",
 		"celln.router.external=false",

--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -10,16 +10,17 @@
 
 Sympozium optionally integrates with [Celln](https://github.com/sympozium-ai/celln) to run a single bounded, high-risk, or sensitive computation in a hardware-isolated microVM instead of a Kubernetes Job. It is selected per run with `spec.backend: "celln"` on an `AgentRun`.
 
-Celln is disabled by default. Enabling it requires explicit router credentials,
-backend endpoints, an image digest and shared ownership storage; see
-[router deployment](../guides/celln-router-deployment.md). Host installation is
-a separate `celln.installer.enabled=true` opt-in. That legacy DaemonSet runs
-privileged, with `hostPID` and a writable host root, only on nodes labelled
-`celln.dev/kvm=true`. Routers are unprivileged Deployment replicas, not per-node
-DaemonSets. Disable Celln with `helm upgrade --set celln.enabled=false`; this
-does not undo changes already made to hosts. This page also covers
-the one requirement that's easy to miss: Celln needs its own AI provider access
-on the host, separate from whatever provider your `Agent`/`AgentRun` is configured with.
+Celln is deployed by default by `sympozium install`: an in-cluster (pod-based)
+dispatcher, an unprivileged router, and generated router/backend/capability
+credentials plus the ownership PVC. The dispatcher runs as a privileged pod on
+nodes labelled `celln.dev/kvm=true`. A bare-metal alternative — a host systemd
+dispatcher installed by the `celln-installer` DaemonSet — is available via
+`sympozium install --celln-host-installer --celln-backend …`. The router is an
+unprivileged Deployment, not a per-node DaemonSet. Disable Celln with
+`sympozium install --no-celln` (or `helm upgrade --set celln.enabled=false`).
+This page also covers the one requirement that's easy to miss: Celln needs its
+own AI provider access, separate from whatever provider your
+`Agent`/`AgentRun` is configured with.
 
 The web UI's Runs page shows a live banner if any listed run uses `backend: celln` while the router is unreachable, and the New Run dialog checks live reachability when you select the Celln backend — both backed by `GET /api/v1/capabilities`.
 
@@ -66,16 +67,16 @@ AgentRun (backend: celln)
   ├─ Controller POSTs a celln.dev/v1alpha1 ExecutionRequest to CELLN_ROUTER_URL
   │   (celln-router.celln-system.svc.cluster.local:8787)
   │
-  ├─ Router (one pod per KVM node) forwards to the host-level
-  │   celln dispatcher — a systemd service on that node, installed
-  │   by the celln-installer DaemonSet
+  ├─ Router (an unprivileged Deployment) forwards to the dispatcher — by
+  │   default the in-cluster pod-based dispatcher (celln-dispatcher Service),
+  │   or a bare-metal host dispatcher installed by the celln-installer DaemonSet
   │
   └─ Dispatcher verifies the pinned program (or forges one for task-only
      requests), seals a KVM cell from a warm mote, runs it, and returns
      a receipt plus bounded display output. status.cellnActionId tracks the poll.
 ```
 
-The installer and router only schedule onto nodes labeled `celln.dev/kvm: "true"` — Celln needs `/dev/kvm` and is not a container-level isolation mechanism, so it can't run on arbitrary nodes the way the `job` backend can.
+Both the in-cluster dispatcher and the host-installer only schedule onto nodes labeled `celln.dev/kvm: "true"` — Celln needs `/dev/kvm` and is not a container-level isolation mechanism, so it can't run on arbitrary nodes the way the `job` backend can.
 
 ## Trust model: task text never grants tool authority
 
@@ -143,26 +144,28 @@ insecure HTTP. See [epic #426](https://github.com/sympozium-ai/sympozium/issues/
 for remaining deployment, replica ownership and two-node acceptance work.
 
 ```bash
-sympozium install --enable-hermetic-workloads
-# or: make install ENABLE_HERMETIC_WORKLOADS=true
-# or: helm upgrade --install sympozium charts/sympozium/ --set celln.enabled=true ...
+sympozium install                       # Celln (in-cluster dispatcher) on by default
+sympozium install --no-celln            # skip Celln entirely
+sympozium install --celln-host-installer --celln-backend http://…:8787  # bare-metal host dispatcher
+# or via Helm:
+helm upgrade --install sympozium charts/sympozium/ --set celln.enabled=false
 ```
 
 ```yaml
-# values.yaml — the safe default
+# values.yaml — Celln is on by default (the raw-Helm default is still opt-in)
 celln:
-  enabled: false
+  enabled: true
 ```
 
-When `false`, no `celln-system` namespace, installer, or router is deployed, and the controller/apiserver aren't given a router URL or credential mount.
+When `false`, no `celln-system` namespace, dispatcher, or router is deployed, and the controller/apiserver aren't given a router URL or credential mount.
 
 **Disabling it does not remove `"celln"` as a valid `backend` value on the CRD.** A run submitted while disabled is still schema-valid but refuses when the controller lacks the required transport configuration. There is no fallback to a Job. Communicate configuration changes to authors of Celln-backed runs.
 
 ## Enabling Celln: the AI provider requirement
 
-This is the part that's easy to miss: **Celln's AI provider is configured independently of your `Agent`/`AgentRun`'s `model:` field.** A celln-backed run's task string goes to whatever provider is configured on the KVM *host* — the run's own `model.provider`/`model.name` are not passed through and are ignored for this backend.
+This is the part that's easy to miss: **Celln's AI provider is configured independently of your `Agent`/`AgentRun`'s `model:` field.** A celln-backed run's task string goes to whatever provider is configured for the *dispatcher* — the run's own `model.provider`/`model.name` are not passed through and are ignored for this backend.
 
-The host-level dispatcher (not the Sympozium controller) needs one of:
+The dispatcher (the in-cluster pod by default, or the bare-metal host service) needs one of:
 
 - **An API key**, set via Helm — mounted into the `celln-installer` DaemonSet as a Secret, and written to `/etc/celln/agent-key` on the host for the dispatcher to read:
   ```yaml
@@ -206,7 +209,7 @@ dispatcher, not inside the installer container.
 |----------|----------|
 | `celln.enabled=false` | No `celln-system` namespace or resources. Runs with `backend: celln` fail at dispatch with a router-unreachable error, not at admission. |
 | `celln.enabled=true`, missing required router configuration | Helm render fails; no partially configured router is installed. |
-| `celln.enabled=true`, no eligible dispatcher reachable | Router replicas can run without KVM themselves, but cannot execute a request. The optional installer only schedules on labelled nodes. |
+| `celln.enabled=true`, no eligible dispatcher reachable | Router replicas can run without KVM themselves, but cannot execute a request. The in-cluster dispatcher and the optional host-installer only schedule on labelled nodes. |
 | `celln.enabled=true`, KVM node(s) present, no AI provider reachable on the host | Router and dispatcher report healthy. The run reaches `Running`, then fails once the dispatcher's own provider check fails — see above. |
 | Everything configured | Run dispatches, executes in a real sealed cell, and returns a bounded result. |
 

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -35,11 +35,14 @@ See [`charts/sympozium/values.yaml`](https://github.com/sympozium-ai/sympozium/b
 
 ### Celln (hermetic execution)
 
-Enabled by default (`celln.enabled: true`) so a standard installation includes
-the Celln router and controller configuration. The privileged installer and
-router schedule only on nodes explicitly labelled `celln.dev/kvm=true`; label
-KVM-capable hosts deliberately before they receive host setup. Disable all
-Celln resources with `--set celln.enabled=false`. See [Celln Backend](../concepts/celln-backend.md).
+Enabled by default (`celln.enabled: true`) so a standard installation deploys
+the in-cluster (pod-based) dispatcher, the router and controller/API wiring.
+The dispatcher and router schedule only on nodes explicitly labelled
+`celln.dev/kvm=true`; label KVM-capable hosts deliberately before they receive
+dispatcher pods. A bare-metal host dispatcher (systemd, via the `celln-installer`
+DaemonSet) is available with `celln.installer.enabled=true` but is loopback-only
+and mutually exclusive with the in-cluster dispatcher. Disable all Celln
+resources with `--set celln.enabled=false`. See [Celln Backend](../concepts/celln-backend.md).
 
 ### AgentHarness examples
 


### PR DESCRIPTION
## Problem

`sympozium install --celln-host-installer` deployed **both** the in-cluster (pod) dispatcher and the host systemd dispatcher. They are alternative deployments of the same binary and both lock `/var/lib/celln`, so the host dispatcher crash-looped:

```
celln: error: dispatcher state root is already owned or cannot be locked
```

Verified live on the `framework` cluster: after a fresh install with `--celln-host-installer`, the installer correctly installed celln on the host, but the resulting host dispatcher could not start because the in-cluster pod dispatcher (also deployed) held the lock.

## Fix

- `--celln-host-installer` now disables the in-cluster dispatcher (`celln.dispatcher.enabled=false`) and requires `--celln-backend` (the host dispatcher is loopback-only, so the router can't reach it without a proxy).
- Updated the CLI help text.
- Added/adjusted tests (`TestCellnInstallSetValues`, `TestCellnInstallSetValuesHostInstallerRequiresBackend`).

## Docs

- `docs/concepts/celln-backend.md` and `docs/reference/helm.md` now describe the in-cluster dispatcher as the default path and the host installer as the bare-metal alternative.