### PR TITLE
fix(celln): use Recreate strategy for the in-cluster dispatcher

### DIFF
--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -261,6 +261,12 @@ metadata:
     app.kubernetes.io/part-of: sympozium
 spec:
   replicas: {{ $dispatcher.replicas | default 1 }}
+  # The dispatcher takes an exclusive flock on its hostPath state root
+  # (/var/lib/celln). RollingUpdate would overlap the outgoing and incoming
+  # pods and they would contend for the lock, so the old pod must be fully
+  # terminated before a replacement starts.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: celln-dispatcher

--- a/internal/controller/celln_deployment_test.go
+++ b/internal/controller/celln_deployment_test.go
@@ -133,6 +133,49 @@ func TestCellnDeployment(t *testing.T) {
 	}
 }
 
+// TestCellnDispatcherRecreateStrategy guards the in-cluster dispatcher against
+// RollingUpdate: the dispatcher takes an exclusive flock on its hostPath state
+// root, so a rolling update would overlap two pods contending for the lock.
+func TestCellnDispatcherRecreateStrategy(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm required for chart rendering")
+	}
+	out, err := exec.Command("helm", "template", "m0", "../../charts/sympozium",
+		"--set", cellnDeploymentTestSettings,
+		"--set", "celln.dispatcher.enabled=true").CombinedOutput()
+	if err != nil {
+		t.Fatalf("render: %v\n%s", err, out)
+	}
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(out), 4096)
+	var dispatcher appsv1.Deployment
+	for {
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var meta struct {
+			Kind     string
+			Metadata struct{ Name string }
+		}
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			t.Fatal(err)
+		}
+		if meta.Metadata.Name == "celln-dispatcher" && meta.Kind == "Deployment" {
+			if err := json.Unmarshal(raw, &dispatcher); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if dispatcher.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
+		t.Fatalf("dispatcher strategy = %q, want Recreate", dispatcher.Spec.Strategy.Type)
+	}
+}
+
 func TestCellnDeploymentRefusesIncompleteConfiguration(t *testing.T) {
 	if _, err := exec.LookPath("helm"); err != nil {
 		t.Skip("helm required for chart rendering")


### PR DESCRIPTION
## Problem

The `celln-dispatcher` Deployment defaulted to `RollingUpdate`. The dispatcher takes an exclusive `flock` on its hostPath state root (`/var/lib/celln`), so during any rollout the outgoing and incoming pods overlap and the new pod crashes with:

```
dispatcher state root is already owned or cannot be locked
```

This wedged the `v0.10.60` upgrade on the `framework` cluster — observed live: the old dispatcher pod held the lock while the rolling-update replacement pod crash-looped.

## Fix

Set `spec.strategy.type: Recreate` on the in-cluster dispatcher Deployment so the old pod is fully terminated before a replacement starts, plus a chart-render regression test (`TestCellnDispatcherRecreateStrategy`).