### PR TITLE
feat(celln): single execution plane (unified client, chart, contract)

### DIFF
--- a/api/v1alpha1/agentruntime_celln_types.go
+++ b/api/v1alpha1/agentruntime_celln_types.go
@@ -23,7 +23,7 @@ type AgentRuntimeCellnProfile struct {
 	Platform string `json:"platform"`
 	// +kubebuilder:validation:Enum=agent
 	Lane string `json:"lane"`
-	// +kubebuilder:validation:Enum=disposable-one-shot
+	// +kubebuilder:validation:Enum=disposable-one-shot;enduring
 	Lifecycle string `json:"lifecycle"`
 	// Immutable data delivery has no supported contract in this profile.
 	// +optional

--- a/api/v1alpha1/agentruntime_types.go
+++ b/api/v1alpha1/agentruntime_types.go
@@ -41,14 +41,15 @@ type AgentRuntime struct {
 // AgentRuntimeSpec is the desired state of an AgentRuntime.
 type AgentRuntimeSpec struct {
 	// Celln declares an additional placement profile, not executable authority.
-	// Image remains required: Celln-only runtimes and catalogue-backed dispatch
-	// are not supported yet. OCI Ready never implies CellnReady.
+	// A Celln-native runtime (no OCI adapter) may set this with an empty image;
+	// OCI runtimes still require image. OCI Ready never implies CellnReady.
 	// +optional
 	Celln *AgentRuntimeCellnProfile `json:"celln,omitempty"`
 
 	// Image is the digest-pinned OCI reference that becomes the pod's primary
 	// process. A mutable tag is rejected: the digest is the trust anchor, and
-	// it is recorded on status.resolvedImageDigest for audit.
+	// it is recorded on status.resolvedImageDigest for audit. It is required
+	// for OCI runtimes and left empty for Celln-native runtimes.
 	Image string `json:"image"`
 
 	// ContractVersion is the adapter contract version this image implements

--- a/charts/celln_single_plane_test.go
+++ b/charts/celln_single_plane_test.go
@@ -1,0 +1,99 @@
+package charts
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func singlePlaneValues() []string {
+	return []string{
+		"celln.enabled=true", "celln.allowInsecureHttp=true", "celln.dispatcher.enabled=true",
+		"celln.dispatcher.maxCells=4", "celln.dispatcher.memoryBytes=2147483648",
+		"celln.tokenSecret=client", "celln.capabilityTokenSecret=discovery",
+		"celln.router.clientTokenSecret=client", "celln.router.backendTokenSecret=backend",
+		"celln.router.capabilityTokenSecret=discovery", "celln.router.parentTokenSecret=parent",
+		"celln.router.ownershipClaim=ledger", "celln.router.allowInsecureBackends=true",
+		"celln.router.backends[0]=http://celln-dispatcher.celln-system.svc:8787",
+		"celln.router.image.tag=parent-routing-test",
+		"celln.dispatcher.enduring.enabled=true", "celln.dispatcher.enduring.nodeName=kvm-a",
+		"celln.dispatcher.enduring.statePath=/var/lib/sympozium-celln/starter",
+		"celln.dispatcher.enduring.parentConfigSecret=registrations",
+	}
+}
+
+func TestSinglePlaneSharesAuthorityAndPinsOwner(t *testing.T) {
+	raw, err := renderNativeParent(t, singlePlaneValues())
+	if err != nil {
+		t.Fatalf("render: %v: %s", err, raw)
+	}
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(raw), 4096)
+	deployments := map[string]appsv1.Deployment{}
+	for {
+		var d appsv1.Deployment
+		if err := decoder.Decode(&d); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		if d.Kind == "Deployment" {
+			deployments[d.Name] = d
+		}
+	}
+	if _, ok := deployments["celln-parent-controller"]; ok {
+		t.Fatal("separate parent controller rendered")
+	}
+	const state = "/var/lib/sympozium-celln/starter"
+	for _, name := range []string{"sympozium-controller-manager", "celln-dispatcher"} {
+		d := deployments[name]
+		if d.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"] != "kvm-a" {
+			t.Fatalf("%s can move away from authority", name)
+		}
+		found := false
+		for _, v := range d.Spec.Template.Spec.Volumes {
+			if v.HostPath != nil && v.HostPath.Path == state {
+				for _, m := range d.Spec.Template.Spec.Containers[0].VolumeMounts {
+					if m.Name == v.Name && m.MountPath == state && !m.ReadOnly {
+						found = true
+					}
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("%s lacks shared writable absolute state mount", name)
+		}
+	}
+	controller := deployments["sympozium-controller-manager"].Spec.Template.Spec.Containers[0]
+	for _, env := range controller.Env {
+		if env.Name == "CELLN_PARENT_CONFIG" && env.Value != state+"/approvals" {
+			t.Fatal("approvals point at read-only configuration")
+		}
+	}
+	dispatcher := deployments["celln-dispatcher"]
+	if dispatcher.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType || !strings.Contains(strings.Join(dispatcher.Spec.Template.Spec.Containers[0].Args, " "), "--root "+state+"/authority") {
+		t.Fatal("dispatcher root/lifecycle does not match provisioner")
+	}
+	if !strings.Contains(strings.Join(deployments["celln-router"].Spec.Template.Spec.Containers[0].Args, " "), "--parent-token-file /etc/celln/parent/token") {
+		t.Fatal("gateway parent routing missing")
+	}
+}
+
+func TestSinglePlaneRefusesSplitOrRelocatableAuthority(t *testing.T) {
+	for _, override := range []string{
+		"celln.dispatcher.enduring.nodeName=", "celln.dispatcher.enduring.statePath=/",
+		"celln.dispatcher.enduring.parentConfigSecret=", "celln.dispatcher.enabled=false",
+		"celln.dispatcher.replicas=2", "celln.installer.enabled=true",
+		"celln.router.parentTokenSecret=", "celln.dispatcher.enduring.uid=0",
+		"controller.nodeSelector.kubernetes\\.io/hostname=another-node",
+	} {
+		t.Run(override, func(t *testing.T) {
+			if raw, err := renderNativeParent(t, append(singlePlaneValues(), override)); err == nil {
+				t.Fatalf("unsafe topology rendered: %s", raw)
+			}
+		})
+	}
+}

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruntimes.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruntimes.yaml
@@ -126,6 +126,7 @@ spec:
                   lifecycle:
                     enum:
                     - disposable-one-shot
+                    - enduring
                     type: string
                   limits:
                     description: |-

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruntimes.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruntimes.yaml
@@ -71,8 +71,8 @@ spec:
               celln:
                 description: |-
                   Celln declares an additional placement profile, not executable authority.
-                  Image remains required: Celln-only runtimes and catalogue-backed dispatch
-                  are not supported yet. OCI Ready never implies CellnReady.
+                  A Celln-native runtime (no OCI adapter) may set this with an empty image;
+                  OCI runtimes still require image. OCI Ready never implies CellnReady.
                 properties:
                   closure:
                     properties:
@@ -246,7 +246,8 @@ spec:
                 description: |-
                   Image is the digest-pinned OCI reference that becomes the pod's primary
                   process. A mutable tag is rejected: the digest is the trust anchor, and
-                  it is recorded on status.resolvedImageDigest for audit.
+                  it is recorded on status.resolvedImageDigest for audit. It is required
+                  for OCI runtimes and left empty for Celln-native runtimes.
                 type: string
               model:
                 description: |-

--- a/charts/sympozium/crds/sympozium.ai_agentruntimes.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruntimes.yaml
@@ -126,6 +126,7 @@ spec:
                   lifecycle:
                     enum:
                     - disposable-one-shot
+                    - enduring
                     type: string
                   limits:
                     description: |-

--- a/charts/sympozium/crds/sympozium.ai_agentruntimes.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruntimes.yaml
@@ -71,8 +71,8 @@ spec:
               celln:
                 description: |-
                   Celln declares an additional placement profile, not executable authority.
-                  Image remains required: Celln-only runtimes and catalogue-backed dispatch
-                  are not supported yet. OCI Ready never implies CellnReady.
+                  A Celln-native runtime (no OCI adapter) may set this with an empty image;
+                  OCI runtimes still require image. OCI Ready never implies CellnReady.
                 properties:
                   closure:
                     properties:
@@ -246,7 +246,8 @@ spec:
                 description: |-
                   Image is the digest-pinned OCI reference that becomes the pod's primary
                   process. A mutable tag is rejected: the digest is the trust anchor, and
-                  it is recorded on status.resolvedImageDigest for audit.
+                  it is recorded on status.resolvedImageDigest for audit. It is required
+                  for OCI runtimes and left empty for Celln-native runtimes.
                 type: string
               model:
                 description: |-

--- a/charts/sympozium/templates/apiserver-deployment.yaml
+++ b/charts/sympozium/templates/apiserver-deployment.yaml
@@ -68,6 +68,8 @@ spec:
           {{- if .Values.celln.enabled }}
             - name: CELLN_ENABLED
               value: "true"
+            - name: CELLN_ENDURING_ENABLED
+              value: {{ .Values.celln.dispatcher.enduring.enabled | quote }}
             {{- if .Values.celln.caConfigMap }}
             - name: SSL_CERT_FILE
               value: /etc/sympozium/celln-router-ca/ca-bundle.crt

--- a/charts/sympozium/templates/celln-network-policy.yaml
+++ b/charts/sympozium/templates/celln-network-policy.yaml
@@ -34,4 +34,28 @@ spec:
       ports:
         - protocol: TCP
           port: 8788
+{{- if .Values.celln.dispatcher.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: celln-dispatcher-ingress
+  namespace: celln-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: celln-dispatcher
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: celln-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: celln-router
+      ports:
+        - protocol: TCP
+          port: 8787
+{{- end }}
 {{- end }}

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -18,6 +18,30 @@
 {{- end }}
 {{- end }}
 {{- $dispatcher := .Values.celln.dispatcher | default dict }}
+{{- $parent := $dispatcher.enduring }}
+{{- if $parent.enabled }}
+{{- if or .Values.celln.router.external (ne (len .Values.celln.router.backends) 1) }}
+{{- fail "dispatcher.enduring currently requires one managed dispatcher backend; multi-node authority provisioning is unsupported" }}
+{{- end }}
+{{- if or (not $dispatcher.enabled) .Values.celln.installer.enabled .Values.celln.nativeParent.enabled }}
+{{- fail "dispatcher.enduring requires the in-cluster dispatcher and cannot use installer or nativeParent" }}
+{{- end }}
+{{- if lt (int $dispatcher.maxCells) 2 }}
+{{- fail "dispatcher.enduring requires maxCells >= 2 for a parent and child" }}
+{{- end }}
+{{- if or (ne (int $dispatcher.replicas) 1) (not $parent.nodeName) (not $parent.parentConfigSecret) }}
+{{- fail "dispatcher.enduring requires one dispatcher replica, nodeName and parentConfigSecret" }}
+{{- end }}
+{{- if or (le (int $parent.uid) 0) (le (int $parent.gid) 0) (not .Values.celln.router.parentTokenSecret) }}
+{{- fail "dispatcher.enduring requires non-root uid/gid and router.parentTokenSecret" }}
+{{- end }}
+{{- if not (regexMatch "^/var/lib/sympozium-celln/[a-z0-9][a-z0-9-]{0,62}$" $parent.statePath) }}
+{{- fail "dispatcher.enduring.statePath must be a dedicated /var/lib/sympozium-celln/<installation> directory" }}
+{{- end }}
+{{- if and (hasKey .Values.controller.nodeSelector "kubernetes.io/hostname") (ne (index .Values.controller.nodeSelector "kubernetes.io/hostname") $parent.nodeName) }}
+{{- fail "dispatcher.enduring.nodeName conflicts with controller.nodeSelector" }}
+{{- end }}
+{{- end }}
 {{- $dispatcherImage := $dispatcher.image | default dict }}
 {{- $dispatcherRepo := $dispatcherImage.repository | default .Values.celln.image.repository | default "ghcr.io/sympozium-ai/sympozium/celln-installer" }}
 {{- $dispatcherTag := $dispatcherImage.tag | default .Values.celln.image.tag | default .Chart.AppVersion }}
@@ -244,6 +268,9 @@ spec:
           type: CharDevice
       nodeSelector:
         celln.dev/kvm: "true"
+        {{- if $parent.enabled }}
+        kubernetes.io/hostname: {{ $parent.nodeName | quote }}
+        {{- end }}
       tolerations:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists
@@ -276,10 +303,26 @@ spec:
         app.kubernetes.io/name: celln-dispatcher
     spec:
       automountServiceAccountToken: false
+      {{- if $parent.enabled }}
+      terminationGracePeriodSeconds: 60
+      {{- end }}
       nodeSelector:
         celln.dev/kvm: "true"
+        {{- if $parent.enabled }}
+        kubernetes.io/hostname: {{ $parent.nodeName | quote }}
+        {{- end }}
       containers:
       - name: dispatcher
+        {{- if $parent.enabled }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  printf 'Authorization: Bearer %s\n' "$(cat /etc/celln/backend/token)" | curl --fail --silent --show-error --max-time 50 --header @- --request POST http://127.0.0.1:8787/v1/drain
+        {{- end }}
         image: {{ printf "%s:%s" $dispatcherRepo $dispatcherTag | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/celln"]
@@ -291,17 +334,33 @@ spec:
         - --token-file
         - /etc/celln/backend/token
         - --root
+        {{- if $parent.enabled }}
+        - {{ printf "%s/authority" $parent.statePath | quote }}
+        {{- else }}
         - /var/lib/celln
+        {{- end }}
         - --mote-store
+        {{- if $parent.enabled }}
+        - {{ printf "%s/authority/motes" $parent.statePath | quote }}
+        {{- else }}
         - /var/lib/celln/motes
+        {{- end }}
         - --tool-store
+        {{- if $parent.enabled }}
+        - {{ printf "%s/authority/tools" $parent.statePath | quote }}
+        {{- else }}
         - /var/lib/celln/tools
+        {{- end }}
         - --node-name
         - $(NODE_NAME)
         {{- range $dispatcher.allowEgressHosts | default (list "api.deepseek.com") }}
         - --allow-egress-host
         - {{ . | quote }}
         {{- end }}
+        - --max-cells
+        - {{ $dispatcher.maxCells | int | quote }}
+        - --memory-bytes
+        - {{ $dispatcher.memoryBytes | int64 | quote }}
         - --egress-slots
         - {{ $dispatcher.egressSlots | default 1 | quote }}
         env:
@@ -309,6 +368,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        readinessProbe:
+          httpGet:
+            path: /v1/health
+            port: 8787
+          periodSeconds: 2
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
@@ -328,18 +392,15 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
-        {{- if and $dispatcher.enduring $dispatcher.enduring.enabled }}
-        {{- if not $dispatcher.enduring.authoritySecret }}
-        {{- fail "celln.dispatcher.enduring.authoritySecret is required when the enduring lifecycle is enabled" }}
-        {{- end }}
-        # The dispatcher serves /v1/parents from the same process. The parent
-        # handler authenticates against trusted-parent-clients.json under its
-        # root; mounting it here is what makes one dispatcher serve both
-        # lifecycles (docs/design/celln-single-execution-plane.md).
-        - name: parent-clients
-          mountPath: /var/lib/celln/trusted-parent-clients.json
-          subPath: trusted-parent-clients.json
+        {{- if $parent.enabled }}
+        # Preserve absolute artifact/model paths embedded in approved profiles.
+        - name: parent-state
+          mountPath: {{ $parent.statePath | quote }}
+        {{- range $i, $file := $parent.modelCredentialFiles }}
+        - name: parent-model-{{ $i }}
+          mountPath: {{ $file | quote }}
           readOnly: true
+        {{- end }}
         {{- end }}
       volumes:
       - name: backend
@@ -364,14 +425,20 @@ spec:
           type: Directory
       - name: tmp
         emptyDir: {}
-      {{- if and $dispatcher.enduring $dispatcher.enduring.enabled }}
-      - name: parent-clients
-        secret:
-          secretName: {{ $dispatcher.enduring.authoritySecret | quote }}
-          defaultMode: 0440
-          items:
-          - key: trusted-parent-clients.json
-            path: trusted-parent-clients.json
+      {{- if $parent.enabled }}
+      - name: parent-state
+        hostPath:
+          path: {{ $parent.statePath | quote }}
+          type: Directory
+      {{- range $i, $file := $parent.modelCredentialFiles }}
+      {{- if or (not (hasPrefix "/" $file)) (contains ".." $file) (eq $file "/") }}
+      {{- fail "dispatcher.enduring.modelCredentialFiles requires absolute file paths without traversal" }}
+      {{- end }}
+      - name: parent-model-{{ $i }}
+        hostPath:
+          path: {{ $file | quote }}
+          type: File
+      {{- end }}
       {{- end }}
 ---
 apiVersion: v1
@@ -437,6 +504,10 @@ spec:
         - /etc/celln/client/token
         - --capability-token-file
         - /etc/celln/capability/token
+        {{- if .Values.celln.router.parentTokenSecret }}
+        - --parent-token-file
+        - /etc/celln/parent/token
+        {{- end }}
         - --ownership-dir
         - /var/lib/celln/ownership
         - --mode
@@ -451,6 +522,11 @@ spec:
           containerPort: 8788
           protocol: TCP
         volumeMounts:
+        {{- if .Values.celln.router.parentTokenSecret }}
+        - name: parent-token
+          mountPath: /etc/celln/parent
+          readOnly: true
+        {{- end }}
         - name: client-token
           mountPath: /etc/celln/client
           readOnly: true
@@ -470,6 +546,12 @@ spec:
             memory: "64Mi"
             cpu: "200m"
       volumes:
+      {{- if .Values.celln.router.parentTokenSecret }}
+      - name: parent-token
+        secret:
+          secretName: {{ .Values.celln.router.parentTokenSecret | quote }}
+          defaultMode: 0440
+      {{- end }}
       - name: client-token
         secret:
           secretName: {{ .Values.celln.router.clientTokenSecret | quote }}

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -328,6 +328,19 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
+        {{- if and $dispatcher.enduring $dispatcher.enduring.enabled }}
+        {{- if not $dispatcher.enduring.authoritySecret }}
+        {{- fail "celln.dispatcher.enduring.authoritySecret is required when the enduring lifecycle is enabled" }}
+        {{- end }}
+        # The dispatcher serves /v1/parents from the same process. The parent
+        # handler authenticates against trusted-parent-clients.json under its
+        # root; mounting it here is what makes one dispatcher serve both
+        # lifecycles (docs/design/celln-single-execution-plane.md).
+        - name: parent-clients
+          mountPath: /var/lib/celln/trusted-parent-clients.json
+          subPath: trusted-parent-clients.json
+          readOnly: true
+        {{- end }}
       volumes:
       - name: backend
         secret:
@@ -351,6 +364,15 @@ spec:
           type: Directory
       - name: tmp
         emptyDir: {}
+      {{- if and $dispatcher.enduring $dispatcher.enduring.enabled }}
+      - name: parent-clients
+        secret:
+          secretName: {{ $dispatcher.enduring.authoritySecret | quote }}
+          defaultMode: 0440
+          items:
+          - key: trusted-parent-clients.json
+            path: trusted-parent-clients.json
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -1,3 +1,5 @@
+{{- $enduring := and .Values.celln.enabled .Values.celln.dispatcher.enduring.enabled }}
+{{- $parent := .Values.celln.dispatcher.enduring }}
 {{- if and .Values.controller.watchNamespace .Values.controller.excludeWatchNamespaces }}
 {{- fail "choose either controller.watchNamespace or controller.excludeWatchNamespaces" }}
 {{- end }}
@@ -26,6 +28,10 @@ spec:
       terminationGracePeriodSeconds: 10
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- if $enduring }}
+        runAsUser: {{ $parent.uid }}
+        runAsGroup: {{ $parent.gid }}
+        {{- end }}
       containers:
         - name: manager
           image: {{ include "sympozium.controllerImage" . }}
@@ -157,7 +163,7 @@ spec:
             # main controller reconciles parents directly against the dispatcher
             # Service — no separate celln-parent-controller Deployment.
             - name: CELLN_PARENT_CONFIG
-              value: /etc/sympozium/celln-parent
+              value: {{ printf "%s/approvals" $parent.statePath | quote }}
             - name: CELLN_PARENT_REGISTRATIONS
               value: /etc/sympozium/celln-parent/registrations.json
             {{- end }}
@@ -209,6 +215,8 @@ spec:
               readOnly: true
             {{- end }}
             {{- if and .Values.celln.dispatcher .Values.celln.dispatcher.enduring .Values.celln.dispatcher.enduring.enabled .Values.celln.dispatcher.enduring.parentConfigSecret }}
+            - name: celln-parent-state
+              mountPath: {{ $parent.statePath | quote }}
             - name: celln-parent-config
               mountPath: /etc/sympozium/celln-parent
               readOnly: true
@@ -235,14 +243,26 @@ spec:
             secretName: {{ .Values.celln.catalogueConfigSecret | quote }}
         {{- end }}
         {{- if and .Values.celln.dispatcher .Values.celln.dispatcher.enduring .Values.celln.dispatcher.enduring.enabled .Values.celln.dispatcher.enduring.parentConfigSecret }}
+        - name: celln-parent-state
+          hostPath:
+            path: {{ $parent.statePath | quote }}
+            type: Directory
         - name: celln-parent-config
           secret:
             secretName: {{ .Values.celln.dispatcher.enduring.parentConfigSecret | quote }}
         {{- end }}
       {{- end }}
+      {{- if $enduring }}
+      nodeSelector:
+        {{- with omit .Values.controller.nodeSelector "kubernetes.io/hostname" }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        kubernetes.io/hostname: {{ $parent.nodeName | quote }}
+      {{- else }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.controller.tolerations }}
       tolerations:

--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -152,6 +152,15 @@ spec:
             - name: CELLN_TOKEN_FILE
               value: /etc/sympozium/celln/token
             {{- end }}
+            {{- if and .Values.celln.dispatcher .Values.celln.dispatcher.enduring .Values.celln.dispatcher.enduring.enabled .Values.celln.dispatcher.enduring.parentConfigSecret }}
+            # Enduring parent lifecycle on the same in-cluster dispatcher: the
+            # main controller reconciles parents directly against the dispatcher
+            # Service — no separate celln-parent-controller Deployment.
+            - name: CELLN_PARENT_CONFIG
+              value: /etc/sympozium/celln-parent
+            - name: CELLN_PARENT_REGISTRATIONS
+              value: /etc/sympozium/celln-parent/registrations.json
+            {{- end }}
             {{- end }}
             {{- if .Values.pricing.enabled }}
             - name: SYMPOZIUM_PRICING_CONFIGMAP
@@ -182,7 +191,7 @@ spec:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          {{- if and .Values.celln.enabled (or .Values.celln.tokenSecret .Values.celln.catalogueConfigSecret .Values.celln.caConfigMap) }}
+          {{- if and .Values.celln.enabled (or .Values.celln.tokenSecret .Values.celln.catalogueConfigSecret .Values.celln.caConfigMap (and .Values.celln.dispatcher .Values.celln.dispatcher.enduring .Values.celln.dispatcher.enduring.enabled .Values.celln.dispatcher.enduring.parentConfigSecret)) }}
           volumeMounts:
             {{- if .Values.celln.caConfigMap }}
             - name: celln-router-ca
@@ -199,8 +208,13 @@ spec:
               mountPath: /etc/sympozium/celln-catalogue
               readOnly: true
             {{- end }}
+            {{- if and .Values.celln.dispatcher .Values.celln.dispatcher.enduring .Values.celln.dispatcher.enduring.enabled .Values.celln.dispatcher.enduring.parentConfigSecret }}
+            - name: celln-parent-config
+              mountPath: /etc/sympozium/celln-parent
+              readOnly: true
+            {{- end }}
           {{- end }}
-      {{- if and .Values.celln.enabled (or .Values.celln.tokenSecret .Values.celln.catalogueConfigSecret .Values.celln.caConfigMap) }}
+      {{- if and .Values.celln.enabled (or .Values.celln.tokenSecret .Values.celln.catalogueConfigSecret .Values.celln.caConfigMap (and .Values.celln.dispatcher .Values.celln.dispatcher.enduring .Values.celln.dispatcher.enduring.enabled .Values.celln.dispatcher.enduring.parentConfigSecret)) }}
       volumes:
         {{- if .Values.celln.caConfigMap }}
         - name: celln-router-ca
@@ -219,6 +233,11 @@ spec:
         - name: celln-catalogue-config
           secret:
             secretName: {{ .Values.celln.catalogueConfigSecret | quote }}
+        {{- end }}
+        {{- if and .Values.celln.dispatcher .Values.celln.dispatcher.enduring .Values.celln.dispatcher.enduring.enabled .Values.celln.dispatcher.enduring.parentConfigSecret }}
+        - name: celln-parent-config
+          secret:
+            secretName: {{ .Values.celln.dispatcher.enduring.parentConfigSecret | quote }}
         {{- end }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}

--- a/charts/sympozium/templates/rbac.yaml
+++ b/charts/sympozium/templates/rbac.yaml
@@ -36,6 +36,10 @@ metadata:
   labels:
     {{- include "sympozium.labels" . | nindent 4 }}
 rules:
+  # Catalogue authority is read-only; run requests cannot publish tool grants.
+  - apiGroups: ["sympozium.ai"]
+    resources: ["cellntools"]
+    verbs: ["get", "list", "watch"]
   # CRDs
   - apiGroups: ["sympozium.ai"]
     resources: ["agentrunturns"]

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -500,6 +500,22 @@ celln:
     allowEgressHosts:
       - api.deepseek.com
     egressSlots: 1
+    # -- Enduring (native parent) lifecycle on the SAME in-cluster dispatcher.
+    # When enabled the dispatcher serves both /v1/executions (one-shot) and
+    # /v1/parents (enduring), and the main controller reconciles parents
+    # directly — no separate celln-parent-controller Deployment. The operator
+    # provisions the parent authority into `authoritySecret`; see
+    # docs/design/celln-single-execution-plane.md.
+    enduring:
+      enabled: false
+      # -- Existing Secret in celln-system holding the operator-provisioned
+      # parent authority (trusted-parent-clients.json), mounted read-only under
+      # the dispatcher root.
+      authoritySecret: ""
+      # -- Existing Secret holding the controller's per-run approvals and
+      # registrations.json; mounted read-only into the main controller. This
+      # replaces the separate celln-parent-controller Deployment.
+      parentConfigSecret: ""
   # -- One-command bootstrap for a fresh Celln install. Generates the
   # controller/router/backend/capability bearer Secrets and a router ownership
   # PVC, then the CLI points celln.tokenSecret, celln.capabilityTokenSecret and

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -500,6 +500,9 @@ celln:
     allowEgressHosts:
       - api.deepseek.com
     egressSlots: 1
+    # Shared admission budget for executions, parents and their child cells.
+    maxCells: 1
+    memoryBytes: 268435456
     # -- Enduring (native parent) lifecycle on the SAME in-cluster dispatcher.
     # When enabled the dispatcher serves both /v1/executions (one-shot) and
     # /v1/parents (enduring), and the main controller reconciles parents
@@ -508,14 +511,21 @@ celln:
     # docs/design/celln-single-execution-plane.md.
     enduring:
       enabled: false
-      # -- Existing Secret in celln-system holding the operator-provisioned
-      # parent authority (trusted-parent-clients.json), mounted read-only under
-      # the dispatcher root.
-      authoritySecret: ""
-      # -- Existing Secret holding the controller's per-run approvals and
-      # registrations.json; mounted read-only into the main controller. This
-      # replaces the separate celln-parent-controller Deployment.
+      # -- Fixed owner node; both controller and dispatcher mount the same
+      # operator-prepared directory. Parent relocation is unsupported.
+      nodeName: ""
+      # -- Contains authority/, journal/, approvals/ and admitted artifacts.
+      # Preserve this path inside both pods; never reset it on upgrade.
+      statePath: ""
+      # -- Existing Secret in the controller namespace: registrations.json and
+      # owner-token (plus owner-ca.pem for HTTPS). Model keys stay in host state.
       parentConfigSecret: ""
+      # Match the existing directory owner. Never recursively chown live state.
+      uid: 10001
+      gid: 10001
+      # Host credential files referenced by admitted model profiles. Mounted
+      # read-only into the dispatcher only, at their original absolute paths.
+      modelCredentialFiles: []
   # -- One-command bootstrap for a fresh Celln install. Generates the
   # controller/router/backend/capability bearer Secrets and a router ownership
   # PVC, then the CLI points celln.tokenSecret, celln.capabilityTokenSecret and
@@ -571,6 +581,8 @@ celln:
     repository: "ghcr.io/sympozium-ai/sympozium/celln-installer"
     tag: ""
   router:
+    # Parent principal used only behind the gateway; controller uses tokenSecret.
+    parentTokenSecret: ""
     # -- Use an independently managed router/TLS endpoint. The chart configures
     # clients only and creates no router/installer/ownership resources.
     external: false

--- a/cmd/sympozium/install_celln_test.go
+++ b/cmd/sympozium/install_celln_test.go
@@ -12,14 +12,14 @@ func TestSplitImageRef(t *testing.T) {
 		ref    string
 		digest bool
 	}{
-		{"", "ghcr.io/sympozium-ai/celln", "v0.5.8", false},
-		{"ghcr.io/sympozium-ai/celln:v0.5.8", "ghcr.io/sympozium-ai/celln", "v0.5.8", false},
+		{"", "ghcr.io/sympozium-ai/celln", "v0.5.10", false},
+		{"ghcr.io/sympozium-ai/celln:v0.5.10", "ghcr.io/sympozium-ai/celln", "v0.5.10", false},
 		{"ghcr.io/sympozium-ai/celln@sha256:abcdef", "ghcr.io/sympozium-ai/celln", "sha256:abcdef", true},
-		{"localhost:5000/celln", "localhost:5000/celln", "v0.5.8", false},
+		{"localhost:5000/celln", "localhost:5000/celln", "v0.5.10", false},
 		{"localhost:5000/celln:v1", "localhost:5000/celln", "v1", false},
 	}
 	for _, c := range cases {
-		repo, ref, digest := splitImageRef(c.in, "ghcr.io/sympozium-ai/celln", "v0.5.8")
+		repo, ref, digest := splitImageRef(c.in, "ghcr.io/sympozium-ai/celln", "v0.5.10")
 		if repo != c.repo || ref != c.ref || digest != c.digest {
 			t.Fatalf("splitImageRef(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, repo, ref, digest, c.repo, c.ref, c.digest)
 		}
@@ -29,7 +29,7 @@ func TestSplitImageRef(t *testing.T) {
 func TestCellnInstallSetValues(t *testing.T) {
 	vals, err := cellnInstallSetValues(
 		context.Background(),
-		"ghcr.io/sympozium-ai/celln:v0.5.8",
+		"ghcr.io/sympozium-ai/celln:v0.5.10",
 		"",
 		[]string{"http://10.0.0.1:8787"},
 		1,
@@ -68,8 +68,8 @@ func TestCellnInstallSetValues(t *testing.T) {
 	if router["external"] != false {
 		t.Fatalf("router.external = %v, want false", router["external"])
 	}
-	if router["image"].(map[string]interface{})["tag"] != "v0.5.8" {
-		t.Fatalf("router.image.tag = %v, want v0.5.8", router["image"])
+	if router["image"].(map[string]interface{})["tag"] != "v0.5.10" {
+		t.Fatalf("router.image.tag = %v, want v0.5.10", router["image"])
 	}
 	backends, ok := router["backends"].([]interface{})
 	if !ok || len(backends) != 1 || backends[0] != "http://10.0.0.1:8787" {
@@ -80,7 +80,7 @@ func TestCellnInstallSetValues(t *testing.T) {
 func TestCellnInstallSetValuesDefaultBackends(t *testing.T) {
 	vals, err := cellnInstallSetValues(
 		context.Background(),
-		"ghcr.io/sympozium-ai/celln:v0.5.8",
+		"ghcr.io/sympozium-ai/celln:v0.5.10",
 		"",
 		nil,
 		1,
@@ -110,7 +110,7 @@ func TestCellnInstallSetValuesDefaultBackends(t *testing.T) {
 func TestCellnInstallSetValuesHostInstallerRequiresBackend(t *testing.T) {
 	if _, err := cellnInstallSetValues(
 		context.Background(),
-		"ghcr.io/sympozium-ai/celln:v0.5.8",
+		"ghcr.io/sympozium-ai/celln:v0.5.10",
 		"",
 		nil,
 		1,

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -1321,7 +1321,7 @@ layers (enduring native parents); it requires the operator-reviewed
 	cmd.Flags().StringVar(&nativeOpts.ConfigurationDir, "celln-native-configuration-dir", "", "Absolute operator configuration produced by 'celln starter-configure'")
 	cmd.Flags().StringVar(&nativeOpts.OutputDir, "celln-native-output-dir", "", "New absolute private output directory")
 	cmd.Flags().StringVar(&nativeOpts.StatePath, "celln-native-state-path", "", "Existing dedicated host state path")
-	cmd.Flags().StringVar(&nativeOpts.OwnerTarget, "celln-native-owner-target", "", "Stable verified HTTPS owner origin")
+	cmd.Flags().StringVar(&nativeOpts.OwnerTarget, "celln-native-owner-target", "", "Stable owner origin. HTTPS is required for external owners; a cluster-local owner may use http:// when the plane's insecure acknowledgement is set")
 	cmd.Flags().StringVar(&nativeOpts.Scope, "celln-native-scope", "", "Stable installation identity; never change to renew consumed authority")
 	cmd.Flags().StringVar(&nativeOpts.PackageHash, "celln-native-package-hash", "", "Exact operator-approved package BLAKE3 identity")
 	return cmd

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -1258,6 +1258,7 @@ func newInstallCmd() *cobra.Command {
 	var cellnNative bool
 	var cellnNativeApprove bool
 	var nativeOpts cellninstall.Options
+	var nativePlane cellninstall.PlaneOptions
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install Sympozium into the current Kubernetes cluster",
@@ -1284,6 +1285,27 @@ Use --celln-native to also install the native Celln starter catalogue and grant
 layers (enduring native parents); it requires the operator-reviewed
 --celln-native-* inputs and --celln-native-approve-starter-tools.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cellnNative {
+				if noCelln || cellnHostInstaller || len(cellnBackends) != 0 {
+					return fmt.Errorf("--celln-native requires the managed in-cluster dispatcher")
+				}
+				if !cellnNativeApprove || nativePlane.NodeName == "" || nativePlane.OwnerTokenFile == "" {
+					return fmt.Errorf("--celln-native requires --celln-native-approve-starter-tools, --celln-native-node and --celln-native-owner-token-file")
+				}
+				if cellnRouterImage == "" || cellnInstallerImage == "" {
+					return fmt.Errorf("--celln-native requires --celln-router-image and --celln-installer-image built with parent routing and drain support (Celln v0.5.8 does not support them)")
+				}
+				if nativeOpts.ConfigurationDir == "" || nativeOpts.OutputDir == "" || nativeOpts.StatePath == "" || nativeOpts.Scope == "" || nativeOpts.PackageHash == "" {
+					return fmt.Errorf("--celln-native requires configuration-dir, output-dir, state-path, scope and package-hash inputs")
+				}
+				if nativeOpts.OwnerTarget != "" && nativeOpts.OwnerTarget != cellninstall.ManagedRouterURL {
+					return fmt.Errorf("managed native runs must use the shared Celln router origin")
+				}
+				nativeOpts.ControllerNamespace = helmNamespace
+				if nativeOpts.OwnerTarget == "" {
+					nativeOpts.OwnerTarget = cellninstall.ManagedRouterURL
+				}
+			}
 			if !noCelln {
 				cellnValues, err := cellnInstallSetValues(cmd.Context(), cellnRouterImage, cellnInstallerImage, cellnBackends, cellnRouterReplicas, cellnHostInstaller)
 				if err != nil {
@@ -1295,6 +1317,9 @@ layers (enduring native parents); it requires the operator-reviewed
 				return err
 			}
 			if cellnNative {
+				if err := initClient(); err != nil {
+					return err
+				}
 				if !cellnNativeApprove {
 					return fmt.Errorf("--celln-native requires --celln-native-approve-starter-tools: grants include run-owned read/write and bounded example.com HTTPS")
 				}
@@ -1302,7 +1327,14 @@ layers (enduring native parents); it requires the operator-reviewed
 				if err := cellninstall.Install(cmd.Context(), k8sClient, nativeOpts); err != nil {
 					return err
 				}
-				fmt.Printf("  Installed native Celln catalogue and grants in %s; no run submitted, execution readiness remains unverified.\n", nativeOpts.Namespace)
+				planeValues, err := cellninstall.ConfigurePlane(cmd.Context(), k8sClient, nativeOpts, nativePlane)
+				if err != nil {
+					return err
+				}
+				if err := runInstall(imageTag, append(setValues, planeValues...)); err != nil {
+					return err
+				}
+				fmt.Printf("  Enabled enduring Celln runs on the managed execution plane in %s; no run submitted.\n", nativeOpts.Namespace)
 			}
 			return nil
 		},
@@ -1318,6 +1350,8 @@ layers (enduring native parents); it requires the operator-reviewed
 	cmd.Flags().IntVar(&cellnRouterReplicas, "celln-router-replicas", 1, "Celln router replicas for the generated ReadWriteOnce ownership PVC")
 	cmd.Flags().BoolVar(&cellnNative, "celln-native", false, "Also install the native Celln starter catalogue and grant layers (requires the operator --celln-native-* inputs)")
 	cmd.Flags().BoolVar(&cellnNativeApprove, "celln-native-approve-starter-tools", false, "Explicitly approve the three bounded starter tool grants for --celln-native")
+	cmd.Flags().StringVar(&nativePlane.NodeName, "celln-native-node", "", "KVM node holding the prepared shared state; pins controller and dispatcher")
+	cmd.Flags().StringVar(&nativePlane.OwnerTokenFile, "celln-native-owner-token-file", "", "Absolute owner credential matching the prepared parent principal; mounted into the router only")
 	cmd.Flags().StringVar(&nativeOpts.ConfigurationDir, "celln-native-configuration-dir", "", "Absolute operator configuration produced by 'celln starter-configure'")
 	cmd.Flags().StringVar(&nativeOpts.OutputDir, "celln-native-output-dir", "", "New absolute private output directory")
 	cmd.Flags().StringVar(&nativeOpts.StatePath, "celln-native-state-path", "", "Existing dedicated host state path")
@@ -1493,7 +1527,7 @@ func runInstall(imageTag string, setValues []string) error {
 	}
 	fmt.Printf("  Installing Sympozium %s...\n", ver)
 	for _, kv := range setValues {
-		if kv == "celln.enabled=true" {
+		if kv == "celln.installer.enabled=true" {
 			fmt.Println("  ⚠️  Hermetic workloads (Celln) enabled — this deploys a privileged,")
 			fmt.Println("      hostPID DaemonSet with a read-write mount of the host root")
 			fmt.Println("      filesystem on any node labeled celln.dev/kvm=true, to set up KVM")

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -1293,7 +1293,7 @@ layers (enduring native parents); it requires the operator-reviewed
 					return fmt.Errorf("--celln-native requires --celln-native-approve-starter-tools, --celln-native-node and --celln-native-owner-token-file")
 				}
 				if cellnRouterImage == "" || cellnInstallerImage == "" {
-					return fmt.Errorf("--celln-native requires --celln-router-image and --celln-installer-image built with parent routing and drain support (Celln v0.5.8 does not support them)")
+					return fmt.Errorf("--celln-native requires --celln-router-image and --celln-installer-image that provide parent routing and drain support (Celln v0.5.10 or later)")
 				}
 				if nativeOpts.ConfigurationDir == "" || nativeOpts.OutputDir == "" || nativeOpts.StatePath == "" || nativeOpts.Scope == "" || nativeOpts.PackageHash == "" {
 					return fmt.Errorf("--celln-native requires configuration-dir, output-dir, state-path, scope and package-hash inputs")
@@ -1345,7 +1345,7 @@ layers (enduring native parents); it requires the operator-reviewed
 	cmd.Flags().BoolVar(&noCelln, "no-celln", false, "Do not deploy the Celln backend (dispatcher, router, credentials, ownership PVC)")
 	cmd.Flags().BoolVar(&cellnHostInstaller, "celln-host-installer", false, "Deploy the privileged host-installer DaemonSet (bare-metal systemd dispatcher) instead of the in-cluster pod dispatcher; requires --celln-backend")
 	cmd.Flags().StringArrayVar(&cellnBackends, "celln-backend", nil, "Celln router dispatcher origin(s) http://host:port (repeatable); defaults to the in-cluster celln-dispatcher Service")
-	cmd.Flags().StringVar(&cellnRouterImage, "celln-router-image", "", "Celln router image repo:tag or repo@sha256:... (default ghcr.io/sympozium-ai/celln:v0.5.8)")
+	cmd.Flags().StringVar(&cellnRouterImage, "celln-router-image", "", "Celln router image repo:tag or repo@sha256:... (default ghcr.io/sympozium-ai/celln:v0.5.10)")
 	cmd.Flags().StringVar(&cellnInstallerImage, "celln-installer-image", "", "Celln host-installer image repo:tag (default ghcr.io/sympozium-ai/sympozium/celln-installer, tagged with this release)")
 	cmd.Flags().IntVar(&cellnRouterReplicas, "celln-router-replicas", 1, "Celln router replicas for the generated ReadWriteOnce ownership PVC")
 	cmd.Flags().BoolVar(&cellnNative, "celln-native", false, "Also install the native Celln starter catalogue and grant layers (requires the operator --celln-native-* inputs)")
@@ -1367,7 +1367,7 @@ func cellnInstallSetValues(ctx context.Context, routerImage, installerImage stri
 	if replicas <= 0 {
 		replicas = 1
 	}
-	routerRepo, routerRef, routerIsDigest := splitImageRef(routerImage, "ghcr.io/sympozium-ai/celln", "v0.5.8")
+	routerRepo, routerRef, routerIsDigest := splitImageRef(routerImage, "ghcr.io/sympozium-ai/celln", "v0.5.10")
 	installerTag := version
 	if installerTag == "" || installerTag == "dev" {
 		installerTag = "latest"

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -1292,9 +1292,6 @@ layers (enduring native parents); it requires the operator-reviewed
 				if !cellnNativeApprove || nativePlane.NodeName == "" || nativePlane.OwnerTokenFile == "" {
 					return fmt.Errorf("--celln-native requires --celln-native-approve-starter-tools, --celln-native-node and --celln-native-owner-token-file")
 				}
-				if cellnRouterImage == "" || cellnInstallerImage == "" {
-					return fmt.Errorf("--celln-native requires --celln-router-image and --celln-installer-image that provide parent routing and drain support (Celln v0.5.10 or later)")
-				}
 				if nativeOpts.ConfigurationDir == "" || nativeOpts.OutputDir == "" || nativeOpts.StatePath == "" || nativeOpts.Scope == "" || nativeOpts.PackageHash == "" {
 					return fmt.Errorf("--celln-native requires configuration-dir, output-dir, state-path, scope and package-hash inputs")
 				}

--- a/config/celln/release.json
+++ b/config/celln/release.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.5.8",
-  "archiveSHA256": "d92bbc8783889a0444af966118e72388c3e453f07710dc874004bedc2faa9df3",
-  "imageDigest": "sha256:d5d1d9890d21fb758bb402bced24eccec817722b3cacddc133b2103f0a9d2210"
+  "version": "v0.5.10",
+  "archiveSHA256": "65b1358d580d42e295fd4d5cd878a3664ca8b59965ed3bb8a7e9857e5e2fa868",
+  "imageDigest": "sha256:a52d80fe8f492b456f6f47c49190935bff3939465c7189778eb3f3d18e767ef4"
 }

--- a/config/crd/bases/sympozium.ai_agentruntimes.yaml
+++ b/config/crd/bases/sympozium.ai_agentruntimes.yaml
@@ -126,6 +126,7 @@ spec:
                   lifecycle:
                     enum:
                     - disposable-one-shot
+                    - enduring
                     type: string
                   limits:
                     description: |-

--- a/config/crd/bases/sympozium.ai_agentruntimes.yaml
+++ b/config/crd/bases/sympozium.ai_agentruntimes.yaml
@@ -71,8 +71,8 @@ spec:
               celln:
                 description: |-
                   Celln declares an additional placement profile, not executable authority.
-                  Image remains required: Celln-only runtimes and catalogue-backed dispatch
-                  are not supported yet. OCI Ready never implies CellnReady.
+                  A Celln-native runtime (no OCI adapter) may set this with an empty image;
+                  OCI runtimes still require image. OCI Ready never implies CellnReady.
                 properties:
                   closure:
                     properties:
@@ -246,7 +246,8 @@ spec:
                 description: |-
                   Image is the digest-pinned OCI reference that becomes the pod's primary
                   process. A mutable tag is rejected: the digest is the trust anchor, and
-                  it is recorded on status.resolvedImageDigest for audit.
+                  it is recorded on status.resolvedImageDigest for audit. It is required
+                  for OCI runtimes and left empty for Celln-native runtimes.
                 type: string
               model:
                 description: |-

--- a/docs/design/celln-single-execution-plane.md
+++ b/docs/design/celln-single-execution-plane.md
@@ -23,6 +23,30 @@ Today Celln is reachable through two independent stacks:
 
 This is packaging debt, not a hardware or capability difference.
 
+```mermaid
+flowchart TB
+  subgraph CP["Kubernetes control plane"]
+    CTRL["sympozium-controller<br/>(full manager)"]
+    PCTRL["celln-parent-controller<br/>(--celln-parent-only, separate manager)"]
+  end
+
+  subgraph K8S["celln-system (in-cluster)"]
+    ROUTER["celln-router<br/>(Deployment)"]
+    DISP["celln-dispatcher<br/>(Deployment, privileged, /dev/kvm)"]
+  end
+
+  subgraph HOST["KVM node (host, systemd)"]
+    OWNER["celln dispatcher owner<br/>(separate --root authority)"]
+  end
+
+  CTRL -->|"CELLN_ROUTER_URL · /v1/executions"| ROUTER
+  ROUTER -->|"round-robin"| DISP
+  DISP --> CELLS1["sealed one-shot cells"]
+
+  PCTRL -->|"CELLN_PARENT_CONFIG · per-run Target · /v1/parents"| OWNER
+  OWNER --> CELLS2["parent + child cells"]
+```
+
 ## 2. Key finding: the binary is already unified
 
 The Celln CLI runs **one subcommand** for both surfaces. `celln dispatcher`
@@ -80,23 +104,21 @@ A single gateway must therefore route `/v1/executions*` by **balancing** and
 
 ## 4. Target architecture
 
-```
-                          sympozium-controller (one manager)
-                                     │  one base URL + one bearer + one TLS policy
-                                     ▼
-                 ┌───────────────────────────────────────────┐
-                 │  celln-gateway  (celln route, extended)    │
-                 │   /v1/executions*  → balanced + idempotent │
-                 │   /v1/parents*     → owner-affine          │
-                 │   durable ownership + parent-affinity ledger│
-                 └───────────────────────────────────────────┘
-                          │                    │
-             ┌────────────┘                    └────────────┐
-             ▼                                              ▼
-   celln dispatcher (node A)                     celln dispatcher (node B)
-   privileged, /dev/kvm, hostPath state          privileged, /dev/kvm, hostPath state
-   serves /v1/executions + /v1/parents           serves /v1/executions + /v1/parents
-   --root /var/lib/celln (authority/journal/…)   …
+```mermaid
+flowchart TB
+  CTRL["sympozium-controller<br/>(one manager · one client · one URL + bearer + TLS policy)"]
+
+  subgraph K8S["Kubernetes (managed)"]
+    GW["celln-gateway — celln route, extended<br/>/v1/executions* → balanced + idempotent<br/>/v1/parents* → owner-affine<br/>durable ownership + parent-affinity ledger"]
+    D1["celln dispatcher (node A)<br/>privileged · /dev/kvm · hostPath state<br/>serves /v1/executions + /v1/parents"]
+    D2["celln dispatcher (node B)<br/>privileged · /dev/kvm · hostPath state<br/>serves /v1/executions + /v1/parents"]
+  end
+
+  CTRL -->|"/v1/executions* and /v1/parents*"| GW
+  GW -->|"balance"| D1
+  GW -->|"balance / affinity"| D2
+  D1 --> C1["sealed one-shot cells<br/>+ parent & child cells"]
+  D2 --> C2["sealed one-shot cells<br/>+ parent & child cells"]
 ```
 
 * One **dispatcher** Deployment-per-KVM-node (today's `celln-dispatcher` shape),
@@ -106,6 +128,44 @@ A single gateway must therefore route `/v1/executions*` by **balancing** and
 * One **controller**: both reconcilers in one manager, one client, one config.
 * One **install**: the chart renders the dispatcher + gateway; `--celln-native`
   flips on the enduring lifecycle instead of deploying a separate stack.
+
+### 4.1 Request flow through the unified plane
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Controller
+  participant G as celln-gateway
+  participant D as celln-dispatcher
+
+  rect rgb(30,40,60)
+  Note over C,D: One-shot (backend: celln, lifecycle: one-shot)
+  C->>G: POST /v1/executions {id, forge/mote/tools…}
+  G->>D: choose backend, forward, durably bind id → backend
+  D-->>G: execution receipt
+  G-->>C: receipt
+  C->>G: GET /v1/executions/{id}
+  G->>D: forward to the owning backend
+  D-->>G: status / receipt
+  G-->>C: status / receipt
+  end
+
+  rect rgb(40,55,40)
+  Note over C,D: Enduring (lifecycle: enduring, cellnSelection)
+  C->>G: POST /v1/parents {launchProfile}
+  G->>D: choose backend, forward, durably bind parent → backend
+  D-->>G: parent id
+  G-->>C: parent id
+  C->>G: POST /v1/parents/{id}/turns
+  G->>D: forward to the affine backend (parent → backend)
+  D-->>G: turn result
+  G-->>C: turn result
+  end
+```
+
+The gateway's durable ledger is what lets both flows share one URL while keeping
+their opposite routing properties: executions are balanced and replay-safe,
+parents are pinned to the dispatcher that created them.
 
 ---
 

--- a/docs/design/celln-single-execution-plane.md
+++ b/docs/design/celln-single-execution-plane.md
@@ -274,9 +274,19 @@ The chart's `celln-dispatcher` container already runs `celln dispatcher
   (as the router already does with `--client-token-file`) and forwarding a
   backend token, with parent principals expressed as scoped entries in the same
   operator config.
-* **TLS**: terminate at the gateway (or mTLS controller↔gateway) and keep
-  gateway↔dispatcher on the cluster network under NetworkPolicy. Retain the
-  explicit `allowInsecure` acknowledgement for plaintext topologies.
+* **Transport posture — one rule for the whole plane (decision).** The plane
+  uses the posture the one-shot path already shipped: plaintext HTTP is allowed
+  for loopback and for any owner when the plane's explicit `allowInsecure`
+  acknowledgement is set (the in-cluster default); HTTPS is required for owners
+  that cross a boundary (external router, host owner, cross-node networks)
+  unless an operator deliberately acks insecure. **NetworkPolicy, not TLS, is
+  the in-cluster boundary.** The parent protocol previously demanded
+  HTTPS-unless-loopback — a leftover from its host-owner origin — which forced
+  a TLS edge (and a `celln-parent-proxy` binary that isn't shipped in the celln
+  repo or release) onto an otherwise same-cluster hop. That inconsistency is
+  removed: `internal/celln` applies one origin rule to both lifecycles, so the
+  parent client accepts a cluster-local plaintext owner under the same
+  acknowledgement the one-shot client uses.
 * **Approval/authority**: `RunApproval`/`CellnParentBinding` data moves from a
   host-only file to a mounted Secret consumed by the dispatcher; the operator
   flow (`celln parent-provision`, `starter-*`) is unchanged in intent but its
@@ -354,3 +364,41 @@ parents (enduring)      POST /v1/parents
 ```
 All are served by a single `celln dispatcher`; today only `/v1/executions*` is
 routed, and `/v1/parents*` is reached by a direct, per-run owner address.
+
+## 11. Implementation status (working tree)
+
+Implemented in this branch (build/vet/tests green; chart renders):
+
+- **Single client** — `internal/celln` now speaks both `/v1/executions*` and
+  `/v1/parents*` (credential, transport, origin policy, strict parent
+  protocol). `internal/cellnparent` is a thin wrapper over it, so there is one
+  HTTP/credential implementation.
+- **One dispatcher serves both** — when `celln.dispatcher.enduring.enabled` is
+  set, the dispatcher mounts the operator-provisioned
+  `trusted-parent-clients.json` authority (the file `/v1/parents` authenticates
+  against) at its root.
+- **One controller** — the main controller takes `CELLN_PARENT_CONFIG` /
+  `CELLN_PARENT_REGISTRATIONS` when the enduring lifecycle is enabled, so the
+  separate `celln-parent-controller` Deployment is no longer required for the
+  unified topology.
+- **Runtime contract** — `AgentRuntimeCellnProfile.lifecycle` accepts
+  `disposable-one-shot` and `enduring`; CRDs regenerated.
+
+To try it:
+
+```yaml
+celln:
+  enabled: true
+  dispatcher:
+    enabled: true
+    enduring:
+      enabled: true
+      authoritySecret: celln-parent-authority        # trusted-parent-clients.json
+      parentConfigSecret: celln-parent-config        # approvals + registrations.json
+```
+
+Still open (needs the Celln repo): gateway routing of `/v1/parents*` with the
+durable parent→backend affinity ledger, so a multi-node topology keeps one URL
+and owner affinity. Until then the controller reaches `/v1/parents` on the
+dispatcher Service directly (one dispatcher = one owner), which is the
+single-node form of the same plane.

--- a/docs/design/celln-single-execution-plane.md
+++ b/docs/design/celln-single-execution-plane.md
@@ -1,0 +1,296 @@
+# Celln: single execution plane
+
+Status: design proposal (no implementation yet).
+Goals: one Kubernetes-managed Celln service, one controller client, one install,
+one credential model — serving both **one-shot** and **enduring** runs.
+
+---
+
+## 1. Why this document
+
+Today Celln is reachable through two independent stacks:
+
+| | One-shot | Enduring (native parent) |
+|---|---|---|
+| Controller entry | `reconcilePendingCelln` | `reconcileCellnParent` |
+| Client | `internal/controller/celln_transport.go` + `agentrun_celln.go` | `internal/cellnparent/client.go` |
+| Base URL | `CELLN_ROUTER_URL` (router Service) | per-run owner `Target` from an approval file |
+| Endpoint | `/v1/executions*` | `/v1/parents*` |
+| Credential | `CELLN_TOKEN_FILE` (one bearer) | per-run `RunApproval.TokenFile` + CA |
+| Deploy | `celln-dispatcher` + `celln-router` Deployments | `celln-parent-controller` Deployment + host `celln dispatcher` owner |
+| Install | `cellnInstallSetValues` | `--celln-native` + `celln.nativeParent.*` values |
+| Config env | `CELLN_ROUTER_URL`, `CELLN_TOKEN_FILE` | `CELLN_PARENT_CONFIG`, `CELLN_PARENT_REGISTRATIONS` |
+
+This is packaging debt, not a hardware or capability difference.
+
+## 2. Key finding: the binary is already unified
+
+The Celln CLI runs **one subcommand** for both surfaces. `celln dispatcher`
+serves:
+
+```
+POST /v1/executions                  (one-shot)
+GET  /v1/executions/{id}
+POST /v1/executions/{id}/cancel
+GET  /v1/executions/{id}/audit
+POST /v1/artifacts/prewarm
+GET  /v1/capabilities | /v1/health | /v1/node
+
+POST /v1/parents                     (enduring)
+GET  /v1/parents/{id}
+POST /v1/parents/{id}/turns
+POST /v1/parents/{id}/stop
+POST /v1/parents/{id}/cancel
+POST /v1/parents/{id}/turns/{turn}/cancel
+GET  /v1/parents/{id}/turns/{turn}
+```
+
+`/v1/parents*` is dispatched to `parents::handle`, which authenticates the
+bearer against an operator-owned **token-hash file** under the dispatcher's
+`--root` (distinct from the one-shot `--token-file`). The "native owner"
+systemd unit (`config/host/sympozium-celln-native-owner.service`) is literally:
+
+```
+.../celln --root <authority> dispatcher --listen 127.0.0.1:18787 \
+  --token-file /etc/celln-native/owner-token --node-name framework-native \
+  --mote-store ... --tool-store ... --max-cells 4 ...
+```
+
+i.e. the **same `celln dispatcher`**, just a second invocation with a different
+root, token, port, and node name.
+
+**Conclusion:** unification is a routing + controller + packaging change. The
+Celln engine does not need to become something new; it needs one deployment that
+exposes both surfaces, and a gateway that routes both.
+
+## 3. The one real constraint
+
+The two lifecycles have opposite routing properties and both must survive:
+
+| | One-shot | Enduring |
+|---|---|---|
+| Placement | load-balanced across dispatchers | **owner-affine** — a parent lives on exactly one dispatcher |
+| Idempotency | replay-safe by request `id` (durable ledger) | at-most-once create; per-turn idempotent |
+| Failure | retry/reroute to another backend | no reschedule; `ContextLost` if the owner is gone |
+
+A single gateway must therefore route `/v1/executions*` by **balancing** and
+`/v1/parents*` by **affinity**. This is the core of the design.
+
+---
+
+## 4. Target architecture
+
+```
+                          sympozium-controller (one manager)
+                                     │  one base URL + one bearer + one TLS policy
+                                     ▼
+                 ┌───────────────────────────────────────────┐
+                 │  celln-gateway  (celln route, extended)    │
+                 │   /v1/executions*  → balanced + idempotent │
+                 │   /v1/parents*     → owner-affine          │
+                 │   durable ownership + parent-affinity ledger│
+                 └───────────────────────────────────────────┘
+                          │                    │
+             ┌────────────┘                    └────────────┐
+             ▼                                              ▼
+   celln dispatcher (node A)                     celln dispatcher (node B)
+   privileged, /dev/kvm, hostPath state          privileged, /dev/kvm, hostPath state
+   serves /v1/executions + /v1/parents           serves /v1/executions + /v1/parents
+   --root /var/lib/celln (authority/journal/…)   …
+```
+
+* One **dispatcher** Deployment-per-KVM-node (today's `celln-dispatcher` shape),
+  now also running with the parent authority root so it serves `/v1/parents`.
+* One **gateway** (the existing `celln route`, extended) for `/v1/executions`
+  (existing behavior) and `/v1/parents` (new: affinity).
+* One **controller**: both reconcilers in one manager, one client, one config.
+* One **install**: the chart renders the dispatcher + gateway; `--celln-native`
+  flips on the enduring lifecycle instead of deploying a separate stack.
+
+---
+
+## 5. Component changes
+
+### 5.1 Celln gateway (`celln route`) — the main Celln-repo change
+
+`router.rs` already:
+* forwards `POST /v1/executions` and `POST /v1/artifacts/prewarm`,
+* maintains a **durable ownership ledger** (`ownership::Ledger`) binding
+  request-id → backend, enforcing at-most-once and anti-replay,
+* forwards `GET/POST /v1/executions/{id}*` to the owning backend.
+
+Extend it to a general gateway:
+
+1. Add a **parent-affinity ledger** `parent_id → backend`, durable, in the same
+   `--ownership-dir`.
+2. `POST /v1/parents`: choose a backend by health/capacity, forward verbatim,
+   and on success durably bind the returned `parent id` → backend (mirroring
+   `forward_submission`).
+3. `GET|POST /v1/parents/{id}*`: look up affinity; forward to that backend; if
+   the binding is unknown return `404`, if the backend is gone return the
+   dispatcher's `ContextLost`-equivalent.
+4. Keep `/v1/capabilities`, `/v1/health`, `/v1/node` aggregate behavior.
+5. Parent-affinity conflicts (same id, different backend) must be refused, like
+   the execution ledger's `Claim::Conflict`.
+
+This preserves the two routing properties behind one URL.
+
+> Alternative considered: drop the gateway and expose a headless per-node
+> Service, with the controller recording the node in run status. Simpler routing
+> but pushes placement/affinity into Sympozium and loses the shared durability
+> and anti-replay the ledger already provides. Rejected for v1.
+
+### 5.2 Dispatcher deployment — run both surfaces
+
+The chart's `celln-dispatcher` container already runs `celln dispatcher
+--root /var/lib/celln`. Required:
+
+1. Provision the **parent authority root** (`authority/`, `journal/`,
+   `approvals/`) under the dispatcher's `--root` (or a sibling path), mounted
+   from a Secret/ConfigMap + hostPath.
+2. Confirm `parents::handle` authorizes against a principal/token-hash file
+   present at that root.
+3. **Shared capacity accounting**: `--max-cells` / memory/egress budgets must be
+   held across both one-shot cells and parent child-cells (one scheduler, one
+   node budget), so a busy parent cannot starve one-shot runs and vice-versa.
+4. `--unsafe-non-loopback` + NetworkPolicy, as today (or terminate TLS at the
+   gateway).
+
+### 5.3 Controller — one client, one path
+
+1. **One client** (`internal/celln`, replacing the split between
+   `celln_transport.go` and `cellnparent/client.go`): one base URL, one token
+   file, one timeout, one redirect policy, one TLS policy; methods for
+   `/v1/executions*` and `/v1/parents*`.
+2. **One reconciler wiring**: register `AgentRun`, `AgentRunTurn` and the
+   parent/turn reconcilers in the single manager; delete `--celln-parent-only`
+   and `cmd/controller/parent_only.go`.
+3. **One gate**: keep the "enduring requires celln + cellnSelection + enduring
+   limits" validation in `internal/agentexecution/resolve.go`; it no longer
+   implies a different subscription, only a different request builder.
+4. **One request builder** (`internal/controller/celln_harness.go` /
+   `agentrun_celln.go`): translate a resolved run into either a
+   `celln.dev/v1alpha*` execution request or a `celln.parent-create/v1` +
+   `celln.parent-context/v1` turn — both posted to the same base URL.
+5. Remove the `CELLN_PARENT_CONFIG` / `CELLN_PARENT_REGISTRATIONS` env split;
+   the approval/registration data becomes dispatcher-side config.
+
+### 5.4 Contracts / CRDs
+
+* `AgentRuntimeCellnProfile.Lifecycle` is currently fixed to
+  `disposable-one-shot` (`api/v1alpha1/agentruntime_celln_types.go`). Change to
+  accept both lifecycles, e.g. `lifecycles: [disposable-one-shot, enduring]`
+  (or relax the enum), so one approved runtime serves both — matching how
+  `celln.json-tools/v1` is already shared.
+* Keep `celln.json-tools/v1` as the single adapter/tool contract for both
+  lifecycles.
+* Keep both wire families (`celln.dev/*`, `celln.parent-*`) — they are
+  per-lifecycle payloads, not per-deployment. The point is one **transport and
+  one deployment**, not one payload version.
+
+### 5.5 Chart + values + install
+
+* `charts/sympozium/templates/celln.yaml`: render dispatcher(s) + gateway.
+* **Delete** `charts/sympozium/templates/celln-native-parent.yaml` (the separate
+  parent-only controller) and the host `celln-installer` DaemonSet path for the
+  default topology; fold their function into the dispatcher.
+* `charts/sympozium/values.yaml`: collapse `celln.dispatcher.*` and
+  `celln.nativeParent.*` into one `celln` block; keep `router.*` as the gateway.
+* `cmd/sympozium/main.go`: `cellnInstallSetValues` should emit one coherent set
+  (dispatcher + gateway + authority) and `--celln-native` should mean "enable the
+  enduring lifecycle", not "run a second install path". Keep a
+  `--celln-host-systemd` escape hatch only for air-gapped bare metal.
+* One RBAC identity with both `agentruns` and `agentrunturns` verbs.
+* NetworkPolicy must permit parent traffic to the gateway/dispatcher (today it
+  only opens 8788 to the router).
+
+---
+
+## 6. Credentials and trust
+
+* **One control-plane principal** presented by the controller. Today the
+  dispatcher authorizes executions by `--token-file` and parents by a
+  token-hash file; converge on the gateway terminating the controller bearer
+  (as the router already does with `--client-token-file`) and forwarding a
+  backend token, with parent principals expressed as scoped entries in the same
+  operator config.
+* **TLS**: terminate at the gateway (or mTLS controller↔gateway) and keep
+  gateway↔dispatcher on the cluster network under NetworkPolicy. Retain the
+  explicit `allowInsecure` acknowledgement for plaintext topologies.
+* **Approval/authority**: `RunApproval`/`CellnParentBinding` data moves from a
+  host-only file to a mounted Secret consumed by the dispatcher; the operator
+  flow (`celln parent-provision`, `starter-*`) is unchanged in intent but its
+  output is delivered to the in-cluster dispatcher rather than a host owner.
+
+---
+
+## 7. Lifecycle, upgrades, durability
+
+* Parents are **pod-lifetime-scoped**: rolling the dispatcher pod stops live
+  parents (same guarantee as a host owner restart). Make the Deployment
+  `strategy: Recreate` and add a **preStop drain** that refuses new parents,
+  stops running parents, and only then exits.
+* Dispatcher state (authority, journal, motes, tools, cells) is durable on
+  hostPath/PVC, as today.
+* A gateway restart must not lose parent affinity (durable ledger).
+* No HA/migration for a parent across nodes; `ContextLost` remains the
+  contract, now surfaced through the gateway.
+
+---
+
+## 8. Migration plan
+
+1. **Gateway affinity (Celln repo).** Add `/v1/parents*` routing + parent
+   affinity ledger to `celln route`. Ship an image that serves both.
+2. **Dispatcher config (chart).** Run the existing dispatcher with the parent
+   authority root; prove `/v1/parents` works through the dispatcher Service
+   directly (controller talks to it as the "owner").
+3. **Controller client (Sympozium repo).** Introduce `internal/celln` as the
+   single client; repoint the one-shot path at it (no behavior change), then the
+   parent path at the same base URL through the gateway.
+4. **Collapse controller wiring.** Fold `--celln-parent-only` into the main
+   manager; delete the separate registrations env.
+5. **Collapse chart + install + values.** Delete the native-parent Deployment and
+   the default host installer; make `--celln-native` enable the enduring
+   lifecycle on the unified plane; keep a documented escape hatch for bare metal.
+6. **Relax the runtime contract.** Expand `AgentRuntimeCellnProfile.Lifecycle`.
+
+Each step is independently shippable and reversible; steps 1–3 deliver the
+"single service, single client" outcome without touching the CRDs.
+
+---
+
+## 9. Risks / open questions
+
+* **Capacity fairness.** One budget for one-shot + parents needs an explicit
+  policy (reserve N cells for interactive parents?).
+* **Parent affinity durability semantics.** What happens when the bound backend
+  is replaced during an upgrade — refuse (`ContextLost`) or attempt exact
+  node re-placement? v1 proposal: refuse, matching today.
+* **Tool/mote stores.** One-shot motes and parent motes currently live under
+  different roots; merging must not break the sealed-members/tool-digest model.
+* **Authority in-cluster.** Moving the parent authority from a host-only file to
+  a cluster Secret changes the trust boundary; needs an explicit threat-model
+  review (the host owner deliberately kept model keys out of the cluster).
+* **Air-gapped bare metal.** Some operators may need the host-systemd model; keep
+  it as a non-default escape hatch rather than deleting it outright.
+
+## 10. Appendix: endpoint inventory
+
+```
+executions (one-shot)   POST /v1/executions
+                        GET  /v1/executions/{id}
+                        POST /v1/executions/{id}/cancel
+                        GET  /v1/executions/{id}/audit
+prewarm                 POST /v1/artifacts/prewarm
+discovery               GET  /v1/capabilities | /v1/health | /v1/node
+parents (enduring)      POST /v1/parents
+                        GET  /v1/parents/{id}
+                        POST /v1/parents/{id}/turns
+                        POST /v1/parents/{id}/stop
+                        POST /v1/parents/{id}/cancel
+                        POST /v1/parents/{id}/turns/{turn}/cancel
+                        GET  /v1/parents/{id}/turns/{turn}
+```
+All are served by a single `celln dispatcher`; today only `/v1/executions*` is
+routed, and `/v1/parents*` is reached by a direct, per-run owner address.

--- a/docs/guides/celln-native-installation.md
+++ b/docs/guides/celln-native-installation.md
@@ -192,7 +192,7 @@ rights. Apply the new CRDs before upgrading consumers.
 
 Sympozium v0.10.57 publishes `sympozium-celln-native-linux-amd64.tar.gz`, its
 SHA-256 sidecar and `celln-parent-controller.digest` as release assets. The host
-archive combines the checksum-pinned Celln v0.5.8 bundle, both TLS proxies,
+archive combines the checksum-pinned Celln v0.5.10 bundle, both TLS proxies,
 certificate renewal helper and example service units. `SHA256SUMS` checks the
 unpacked files and `share/sympozium/SOURCES.json` records the source pair.
 Verify checksums and extract into a **new staging directory**, then review the

--- a/images/controller/Dockerfile
+++ b/images/controller/Dockerfile
@@ -6,7 +6,7 @@
 # See docs/design/celln-single-execution-plane.md.
 #
 # CELLN_IMAGE is the pinned Celln image from config/celln/release.json.
-ARG CELLN_IMAGE=ghcr.io/sympozium-ai/celln@sha256:d5d1d9890d21fb758bb402bced24eccec817722b3cacddc133b2103f0a9d2210
+ARG CELLN_IMAGE=ghcr.io/sympozium-ai/celln@sha256:a52d80fe8f492b456f6f47c49190935bff3939465c7189778eb3f3d18e767ef4
 FROM ${CELLN_IMAGE} AS celln
 
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder

--- a/images/controller/Dockerfile
+++ b/images/controller/Dockerfile
@@ -1,4 +1,14 @@
 # Controller Manager
+#
+# This single controller also provisions native Celln parents locally, so it
+# embeds the Celln CLI at /usr/local/bin/celln (the path the parent registration
+# expects). There is no separate parent-only controller image.
+# See docs/design/celln-single-execution-plane.md.
+#
+# CELLN_IMAGE is the pinned Celln image from config/celln/release.json.
+ARG CELLN_IMAGE=ghcr.io/sympozium-ai/celln@sha256:d5d1d9890d21fb758bb402bced24eccec817722b3cacddc133b2103f0a9d2210
+FROM ${CELLN_IMAGE} AS celln
+
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
@@ -12,5 +22,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=mod -ldfla
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /controller /controller
+COPY --from=celln /usr/local/bin/celln /usr/local/bin/celln
 USER 65532:65532
 ENTRYPOINT ["/controller"]

--- a/internal/apiserver/celln_capabilities.go
+++ b/internal/apiserver/celln_capabilities.go
@@ -30,8 +30,9 @@ const (
 // Discovery credentials have no execution authority. Never fall back to the
 // controller token or public health/TCP if authenticated discovery fails.
 func cellnCapabilityStatus() CapabilityStatus {
-	oneShot := cellnOneShotCapabilityStatus()
-	enduring := cellnEnduringCapabilityStatus()
+	var parentRouting bool
+	oneShot := probeCellnOneShot(&parentRouting)
+	enduring := cellnEnduringCapabilityStatus(oneShot, parentRouting)
 	status := CapabilityStatus{
 		Available: oneShot.Available || enduring.Available,
 		Reason:    combineCellnReasons(oneShot, enduring),
@@ -43,6 +44,10 @@ func cellnCapabilityStatus() CapabilityStatus {
 }
 
 func cellnOneShotCapabilityStatus() CapabilityStatus {
+	return probeCellnOneShot(nil)
+}
+
+func probeCellnOneShot(parentRouting *bool) CapabilityStatus {
 	refuse := func(state, reason string) CapabilityStatus {
 		return CapabilityStatus{Available: false, State: state, Reason: reason}
 	}
@@ -115,6 +120,9 @@ func cellnOneShotCapabilityStatus() CapabilityStatus {
 	if json.Unmarshal(body, &report) != nil || report.APIVersion != cellnCapabilityVersion || !report.PreflightOnly || report.ArtifactReadiness != "not_checked" || len(report.Nodes) > 32 {
 		return refuse(capabilityStateIncompatible, "Celln capability contract is incompatible")
 	}
+	if parentRouting != nil {
+		*parentRouting = report.ParentRouting
+	}
 	eligible := 0
 	for _, node := range report.Nodes {
 		if !node.PreflightEligible {
@@ -141,7 +149,7 @@ func cellnOneShotCapabilityStatus() CapabilityStatus {
 // Native enduring readiness is owned by the parent controller path and is not
 // inferred from the one-shot router probe. The API reports configuration signals
 // available to this process without claiming host admission.
-func cellnEnduringCapabilityStatus() CapabilityStatus {
+func cellnEnduringCapabilityStatus(plane CapabilityStatus, routed bool) CapabilityStatus {
 	if os.Getenv("CELLN_ENABLED") != "true" {
 		return CapabilityStatus{
 			Available: false,
@@ -149,13 +157,16 @@ func cellnEnduringCapabilityStatus() CapabilityStatus {
 			Reason:    "Celln is disabled; native enduring is not advertised",
 		}
 	}
-	// Parent controller config is mounted on the parent-only controller, not
-	// necessarily on this API process. Do not claim absence from a missing local file.
-	return CapabilityStatus{
-		Available: false,
-		State:     capabilityStateUnknown,
-		Reason:    "Native enduring readiness is distinct from one-shot router preflight; parent controller registration and launch approval are checked at run admission",
+	if os.Getenv("CELLN_ENDURING_ENABLED") != "true" {
+		return CapabilityStatus{State: capabilityStateDisabled, Reason: "Celln is installed; enduring lifecycle is not enabled on this plane"}
 	}
+	if !plane.Available {
+		return CapabilityStatus{State: plane.State, Reason: "Shared Celln plane unavailable: " + plane.Reason}
+	}
+	if !routed {
+		return CapabilityStatus{State: capabilityStateIncompatible, Reason: "Celln gateway does not advertise parent routing; install a compatible gateway image"}
+	}
+	return CapabilityStatus{Available: true, State: capabilityStateReady, Reason: "Enduring routing is enabled on the shared Celln plane; runtime, model, tool grants and parent launch approval are checked per run"}
 }
 
 func combineCellnReasons(oneShot, enduring CapabilityStatus) string {
@@ -199,6 +210,7 @@ func preferCellnState(oneShot, enduring CapabilityStatus) string {
 }
 
 type cellnRouterCapabilities struct {
+	ParentRouting     bool   `json:"parentRouting"`
 	APIVersion        string `json:"apiVersion"`
 	PreflightOnly     bool   `json:"preflightOnly"`
 	ArtifactReadiness string `json:"artifactReadiness"`

--- a/internal/apiserver/celln_capabilities_test.go
+++ b/internal/apiserver/celln_capabilities_test.go
@@ -13,6 +13,33 @@ import (
 const discoveryTestToken = "public-readonly-test-token-at-least-24"
 const eligibleCapabilityFixture = `{"apiVersion":"celln.dev/capabilities-v1alpha1","preflightOnly":true,"artifactReadiness":"not_checked","eligibleNodes":1,"nodes":[{"preflightEligible":true,"report":{"apiVersion":"celln.dev/capabilities-v1alpha1","preflightOnly":true,"artifactReadiness":"not_checked","requestVersions":["celln.dev/v1alpha1"],"node":{"kvm":true,"cpu_virtualization":true,"guest_kernel":true,"mote_store":true,"tool_store":true,"live_cells":0,"max_cells":1,"memory_bytes":268435456}}}]}`
 
+func TestEnduringCapabilityUsesSharedAuthenticatedPlane(t *testing.T) {
+	for _, tc := range []struct {
+		name, enabled, body, state string
+		available                  bool
+	}{
+		{"disabled", "false", eligibleCapabilityFixture, capabilityStateDisabled, false},
+		{"old-router", "true", eligibleCapabilityFixture, capabilityStateIncompatible, false},
+		{"enabled", "true", strings.Replace(eligibleCapabilityFixture, `"eligibleNodes":1`, `"parentRouting":true,"eligibleNodes":1`, 1), capabilityStateReady, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" || r.URL.Path != "/v1/capabilities" || r.Header.Get("Authorization") != "Bearer "+discoveryTestToken {
+					t.Error("readiness must only use read-only discovery")
+				}
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+			configureCapabilityTest(t, server.URL)
+			t.Setenv("CELLN_ENDURING_ENABLED", tc.enabled)
+			result := cellnCapabilityStatus()
+			if result.Enduring.State != tc.state || result.Enduring.Available != tc.available {
+				t.Fatalf("%+v", result.Enduring)
+			}
+		})
+	}
+}
+
 func configureCapabilityTest(t *testing.T, origin string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "token")

--- a/internal/celln/client.go
+++ b/internal/celln/client.go
@@ -1,13 +1,15 @@
 // Package celln is the control-plane client for Celln. It owns the base-URL,
 // credential and transport policy shared by the one-shot execution protocol
 // (`/v1/executions*`) and the enduring parent protocol (`/v1/parents*`), so both
-// lifecycles can be reached through a single Celln service.
+// lifecycles are reached through a single Celln service.
 //
 // See docs/design/celln-single-execution-plane.md.
 package celln
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -27,14 +29,20 @@ type Config struct {
 	// http://celln-router.celln-system.svc.cluster.local:8787. It must not carry
 	// userinfo, a path, query or fragment.
 	BaseURL string
-	// TokenFile is the absolute path to a bearer credential. It is re-read on
-	// every request so a mounted Secret rotation takes effect.
+	// TokenFile is the path to a bearer credential. It is re-read on every
+	// request so a mounted Secret rotation takes effect.
 	TokenFile string
 	// AllowInsecure permits plaintext HTTP to a non-loopback origin. Loopback is
 	// always permitted; HTTPS is always permitted.
 	AllowInsecure bool
 	// Timeout bounds a single request. Defaults to DefaultTimeout.
 	Timeout time.Duration
+	// TLSRoots adds trust anchors (e.g. an operator owner CA).
+	TLSRoots *x509.CertPool
+	// MinTLSVersion raises the floor (e.g. tls.VersionTLS13 for owner origins).
+	MinTLSVersion uint16
+	// NoProxy disables environment proxy use for a frozen owner origin.
+	NoProxy bool
 }
 
 // Client is a credentialed client for one Celln origin.
@@ -54,12 +62,39 @@ var DefaultHTTPClient = &http.Client{
 	},
 }
 
+func (cfg Config) transport() (http.RoundTripper, error) {
+	if cfg.TLSRoots == nil && cfg.MinTLSVersion == 0 && !cfg.NoProxy {
+		return nil, nil
+	}
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("Celln: default transport is not *http.Transport")
+	}
+	t := base.Clone()
+	if cfg.NoProxy {
+		t.Proxy = nil
+	}
+	if cfg.MinTLSVersion != 0 || cfg.TLSRoots != nil {
+		if t.TLSClientConfig == nil {
+			t.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		if cfg.MinTLSVersion != 0 {
+			t.TLSClientConfig.MinVersion = cfg.MinTLSVersion
+		}
+		if cfg.TLSRoots != nil {
+			t.TLSClientConfig.RootCAs = cfg.TLSRoots
+		}
+	}
+	return t, nil
+}
+
 // New validates cfg and returns a client. It does not read the credential;
 // Request does, per call.
 func New(cfg Config) (*Client, error) {
 	base, err := url.Parse(cfg.BaseURL)
-	if err != nil || base.Host == "" || base.User != nil || base.Path != "" ||
-		base.RawQuery != "" || base.Fragment != "" {
+	if err != nil || base.Host == "" || base.User != nil || base.Opaque != "" ||
+		base.Path != "" || base.RawPath != "" || base.RawQuery != "" ||
+		base.ForceQuery || base.Fragment != "" {
 		return nil, fmt.Errorf("Celln: invalid base URL")
 	}
 	loopback := base.Hostname() == "localhost"
@@ -73,11 +108,16 @@ func New(cfg Config) (*Client, error) {
 	if timeout <= 0 {
 		timeout = DefaultTimeout
 	}
+	transport, err := cfg.transport()
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		base:      base,
 		tokenFile: cfg.TokenFile,
 		http: &http.Client{
-			Timeout: timeout,
+			Timeout:   timeout,
+			Transport: transport,
 			// Never follow a redirect with a credential or reinterpret a
 			// redirected POST as GET. A moved service needs an explicit
 			// operator configuration update.

--- a/internal/celln/client.go
+++ b/internal/celln/client.go
@@ -1,0 +1,133 @@
+// Package celln is the control-plane client for Celln. It owns the base-URL,
+// credential and transport policy shared by the one-shot execution protocol
+// (`/v1/executions*`) and the enduring parent protocol (`/v1/parents*`), so both
+// lifecycles can be reached through a single Celln service.
+//
+// See docs/design/celln-single-execution-plane.md.
+package celln
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// DefaultTimeout bounds a single request unless a Config overrides it.
+const DefaultTimeout = 30 * time.Second
+
+// Config is the operator-supplied connection to the Celln service.
+type Config struct {
+	// BaseURL is the Celln origin, e.g.
+	// http://celln-router.celln-system.svc.cluster.local:8787. It must not carry
+	// userinfo, a path, query or fragment.
+	BaseURL string
+	// TokenFile is the absolute path to a bearer credential. It is re-read on
+	// every request so a mounted Secret rotation takes effect.
+	TokenFile string
+	// AllowInsecure permits plaintext HTTP to a non-loopback origin. Loopback is
+	// always permitted; HTTPS is always permitted.
+	AllowInsecure bool
+	// Timeout bounds a single request. Defaults to DefaultTimeout.
+	Timeout time.Duration
+}
+
+// Client is a credentialed client for one Celln origin.
+type Client struct {
+	base      *url.URL
+	tokenFile string
+	http      *http.Client
+}
+
+// DefaultHTTPClient is a no-redirect client with the default timeout, for
+// callers that build a request with Client.Request and send it separately
+// (e.g. to freeze state between build and send).
+var DefaultHTTPClient = &http.Client{
+	Timeout: DefaultTimeout,
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// New validates cfg and returns a client. It does not read the credential;
+// Request does, per call.
+func New(cfg Config) (*Client, error) {
+	base, err := url.Parse(cfg.BaseURL)
+	if err != nil || base.Host == "" || base.User != nil || base.Path != "" ||
+		base.RawQuery != "" || base.Fragment != "" {
+		return nil, fmt.Errorf("Celln: invalid base URL")
+	}
+	loopback := base.Hostname() == "localhost"
+	if ip := net.ParseIP(base.Hostname()); ip != nil {
+		loopback = ip.IsLoopback()
+	}
+	if base.Scheme != "https" && !(base.Scheme == "http" && (loopback || cfg.AllowInsecure)) {
+		return nil, fmt.Errorf("Celln: requires HTTPS; plaintext non-loopback requires explicit opt-in")
+	}
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	return &Client{
+		base:      base,
+		tokenFile: cfg.TokenFile,
+		http: &http.Client{
+			Timeout: timeout,
+			// Never follow a redirect with a credential or reinterpret a
+			// redirected POST as GET. A moved service needs an explicit
+			// operator configuration update.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
+}
+
+// BaseURL returns the configured origin.
+func (c *Client) BaseURL() string { return c.base.String() }
+
+// Close releases idle connections.
+func (c *Client) Close() { c.http.CloseIdleConnections() }
+
+// credential reads and validates the bearer token for a single call.
+func (c *Client) credential() (string, error) {
+	if c.tokenFile == "" {
+		return "", fmt.Errorf("Celln: no operator-provisioned credential configured")
+	}
+	f, err := os.Open(c.tokenFile)
+	if err != nil {
+		return "", fmt.Errorf("Celln: cannot read credential")
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, 4097))
+	token := strings.TrimSpace(string(data))
+	if err != nil || len(data) > 4096 || len(token) < 24 || strings.ContainsAny(token, "\r\n\t ") {
+		return "", fmt.Errorf("Celln: invalid credential")
+	}
+	return token, nil
+}
+
+// Request builds a credentialed JSON request against the configured origin.
+func (c *Client) Request(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	token, err := c.credential()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(c.base.String(), "/")+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("Celln: cannot build request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// Do sends an already-built request.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	return c.http.Do(req)
+}

--- a/internal/celln/client_test.go
+++ b/internal/celln/client_test.go
@@ -1,0 +1,138 @@
+package celln
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const goodToken = "0123456789abcdefghijklmn" // 24 printable bytes
+
+func writeToken(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestNewRejectsNonOriginBaseURL(t *testing.T) {
+	for _, base := range []string{
+		"",
+		"https://user@celln.example",
+		"https://celln.example/v1",
+		"https://celln.example?x=1",
+		"https://celln.example#frag",
+	} {
+		if _, err := New(Config{BaseURL: base, TokenFile: "/tmp/t"}); err == nil {
+			t.Errorf("New(%q) accepted a non-origin base URL", base)
+		}
+	}
+}
+
+func TestNewRequiresHTTPSExceptLoopbackOrOptIn(t *testing.T) {
+	if _, err := New(Config{BaseURL: "http://celln.example:8787", TokenFile: "/tmp/t"}); err == nil {
+		t.Error("plaintext non-loopback accepted without opt-in")
+	}
+	if _, err := New(Config{BaseURL: "http://celln.example:8787", TokenFile: "/tmp/t", AllowInsecure: true}); err != nil {
+		t.Errorf("plaintext accepted with opt-in failed: %v", err)
+	}
+	if _, err := New(Config{BaseURL: "https://celln.example:8787", TokenFile: "/tmp/t"}); err != nil {
+		t.Errorf("https rejected: %v", err)
+	}
+	if _, err := New(Config{BaseURL: "http://127.0.0.1:8787", TokenFile: "/tmp/t"}); err != nil {
+		t.Errorf("loopback http rejected: %v", err)
+	}
+}
+
+func TestRequestCarriesCredentialAndRejectsBadTokens(t *testing.T) {
+	good := writeToken(t, goodToken+"\n")
+	c, err := New(Config{BaseURL: "http://127.0.0.1:8787", TokenFile: good})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := c.Request(context.Background(), http.MethodGet, "/v1/executions/x", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer "+goodToken {
+		t.Fatalf("Authorization = %q, want %q", got, "Bearer "+goodToken)
+	}
+
+	for name, token := range map[string]string{
+		"empty":       "",
+		"too-short":   "short",
+		"has-space":   "0123456789 abcdefghijklmn",
+		"has-newline": "0123456789abcdefghijklm\nn",
+	} {
+		c, err := New(Config{BaseURL: "http://127.0.0.1:8787", TokenFile: writeToken(t, token)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Request(context.Background(), http.MethodGet, "/v1/executions/x", nil); err == nil {
+			t.Errorf("%s token accepted", name)
+		}
+	}
+
+	missing, err := New(Config{BaseURL: "http://127.0.0.1:8787", TokenFile: filepath.Join(t.TempDir(), "absent")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := missing.Request(context.Background(), http.MethodGet, "/v1/executions/x", nil); err == nil {
+		t.Error("missing credential accepted")
+	}
+
+	noCred, err := New(Config{BaseURL: "http://127.0.0.1:8787"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := noCred.Request(context.Background(), http.MethodGet, "/v1/executions/x", nil); err == nil {
+		t.Error("unconfigured credential accepted")
+	}
+}
+
+func TestClientRefusesRedirects(t *testing.T) {
+	var redirected bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/moved" {
+			http.Redirect(w, r, "/elsewhere", http.StatusFound)
+			return
+		}
+		redirected = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := New(Config{BaseURL: srv.URL, TokenFile: writeToken(t, goodToken)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.Do(mustRequest(t, c, srv.URL+"/moved"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302 (redirect must not be followed)", resp.StatusCode)
+	}
+	if redirected {
+		t.Fatal("client followed a redirect")
+	}
+}
+
+func mustRequest(t *testing.T, c *Client, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(url, c.BaseURL()) {
+		t.Fatalf("test URL %q not under base %q", url, c.BaseURL())
+	}
+	return req
+}

--- a/internal/celln/parent.go
+++ b/internal/celln/parent.go
@@ -1,0 +1,302 @@
+package celln
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Persistent parent protocol (`/v1/parents*`). An endpoint is a frozen owner,
+// not a load-balanced retry target. No operation retries automatically:
+// transport errors and ambiguous responses preserve the exact incarnation/turn
+// and never authorize a replacement POST.
+var (
+	ErrReconcile = errors.New("parent outcome requires reconciliation; preserve incarnation and turn ID")
+	ErrNotFound  = errors.New("parent or turn not found; not permission to replay")
+	hashPattern  = regexp.MustCompile(`^blake3:[0-9a-f]{64}$`)
+	turnPattern  = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+)
+
+// ParentStatus is a live owner observation of a parent incarnation.
+type ParentStatus struct {
+	Incarnation string `json:"incarnation"`
+	Status      string `json:"status"`
+	Live        bool   `json:"statusIsLiveOwnerObservation"`
+	Retry       *bool  `json:"retryAuthorized"`
+}
+
+// ParentTurnResult is one committed (or pending) turn outcome.
+type ParentTurnResult struct {
+	Kind      string `json:"kind,omitempty"`
+	Version   string `json:"apiVersion,omitempty"`
+	TurnID    string `json:"turnId,omitempty"`
+	Succeeded *bool  `json:"succeeded,omitempty"`
+	Answer    string `json:"answer,omitempty"`
+	Pending   bool   `json:"pending,omitempty"`
+	Retry     *bool  `json:"retryAuthorized,omitempty"`
+}
+
+// ParentTurnEvidence preserves both historical stage and live-owner observation.
+type ParentTurnEvidence struct {
+	Turn struct {
+		Stage  string          `json:"stage"`
+		Record json.RawMessage `json:"record"`
+	} `json:"turn"`
+	Retry       *bool  `json:"retryAuthorized"`
+	OwnerStatus string `json:"ownerStatus"`
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, body any, output any, respondAsync bool) (int, error) {
+	token, err := c.credential()
+	if err != nil {
+		return 0, err
+	}
+	for _, b := range []byte(token) {
+		if b < 33 || b > 126 {
+			return 0, errors.New("invalid parent credential")
+		}
+	}
+	var payload []byte
+	if body != nil {
+		payload, err = json.Marshal(body)
+		if err != nil {
+			return 0, err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(c.base.String(), "/")+path, bytes.NewReader(payload))
+	if err != nil {
+		return 0, errors.New("invalid parent request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	if respondAsync {
+		req.Header.Set("Prefer", "respond-async")
+	}
+	res, err := c.http.Do(req)
+	if err != nil {
+		return 0, ErrReconcile
+	}
+	defer res.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(res.Body, 32769))
+	if err != nil || len(data) > 32768 {
+		return res.StatusCode, ErrReconcile
+	}
+	if res.StatusCode == http.StatusNotFound {
+		return res.StatusCode, ErrNotFound
+	}
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusAccepted {
+		return res.StatusCode, ErrReconcile
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(output) != nil || decoder.Decode(new(any)) != io.EOF {
+		return res.StatusCode, ErrReconcile
+	}
+	return res.StatusCode, nil
+}
+
+func parentPath(id string) (string, error) {
+	if !hashPattern.MatchString(id) {
+		return "", errors.New("invalid parent incarnation")
+	}
+	return "/v1/parents/" + id, nil
+}
+
+// CreateParent provisions one parent incarnation from an operator-approved
+// launch profile. It is at-most-once: a repeated POST of the same incarnation
+// must be refused by the owner, not replayed.
+func (c *Client) CreateParent(ctx context.Context, profile, incarnation string) error {
+	if !hashPattern.MatchString(profile) || !hashPattern.MatchString(incarnation) {
+		return errors.New("invalid frozen parent selection")
+	}
+	var result struct {
+		Incarnation string `json:"incarnation"`
+		Pending     bool   `json:"initializationPending"`
+		Retry       *bool  `json:"retryAuthorized"`
+	}
+	status, err := c.doJSON(ctx, http.MethodPost, "/v1/parents",
+		map[string]string{"apiVersion": "celln.parent-create/v1", "launchProfile": profile}, &result, false)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusAccepted || result.Incarnation != incarnation || !result.Pending || result.Retry == nil || *result.Retry {
+		return ErrReconcile
+	}
+	return nil
+}
+
+// ParentStatus returns the live owner observation for an incarnation.
+func (c *Client) ParentStatus(ctx context.Context, id string) (ParentStatus, error) {
+	var result ParentStatus
+	path, err := parentPath(id)
+	if err != nil {
+		return result, err
+	}
+	code, err := c.doJSON(ctx, http.MethodGet, path, nil, &result, false)
+	if err != nil {
+		return result, err
+	}
+	valid := false
+	for _, status := range []string{"Initializing", "Ready", "TurnActive", "Stopping", "Stopped", "ContextLost", "TeardownUncertain"} {
+		valid = valid || result.Status == status
+	}
+	if code != http.StatusOK || !valid || result.Incarnation != id || result.Retry == nil || *result.Retry || (!result.Live && result.Status != "ContextLost") {
+		return ParentStatus{}, ErrReconcile
+	}
+	return result, nil
+}
+
+// SubmitParentTurn submits one bounded turn and waits for its outcome.
+func (c *Client) SubmitParentTurn(ctx context.Context, id, turn, message string) (ParentTurnResult, error) {
+	return c.submitParentTurn(ctx, id, turn, message, false)
+}
+
+// SubmitParentTurnAsync releases the caller while the owner executes; Pending is
+// not permission to submit again.
+func (c *Client) SubmitParentTurnAsync(ctx context.Context, id, turn, message string) (ParentTurnResult, error) {
+	return c.submitParentTurn(ctx, id, turn, message, true)
+}
+
+func (c *Client) submitParentTurn(ctx context.Context, id, turn, message string, respondAsync bool) (ParentTurnResult, error) {
+	var result ParentTurnResult
+	path, err := parentPath(id)
+	if err != nil {
+		return result, err
+	}
+	if !turnPattern.MatchString(turn) || strings.TrimSpace(message) == "" || len(message) > 2048 || strings.ContainsRune(message, 0) {
+		return result, errors.New("invalid bounded parent turn")
+	}
+	body := map[string]string{"kind": "turn", "apiVersion": "celln.parent-context/v1", "turnId": turn, "message": message}
+	code, err := c.doJSON(ctx, http.MethodPost, path+"/turns", body, &result, respondAsync)
+	if err != nil {
+		return result, err
+	}
+	if code == http.StatusAccepted && result.Pending && result.Retry != nil && !*result.Retry && result.Kind == "" && result.TurnID == "" && result.Succeeded == nil && result.Answer == "" {
+		return result, nil
+	}
+	if code != http.StatusOK || result.Pending || result.Kind != "completed" || result.Version != "celln.parent-context/v1" || result.TurnID != turn || result.Succeeded == nil || len(result.Answer) > 2048 || strings.TrimSpace(result.Answer) == "" || strings.ContainsRune(result.Answer, 0) {
+		return ParentTurnResult{}, ErrReconcile
+	}
+	return result, nil
+}
+
+// StopParent requests teardown of an incarnation.
+func (c *Client) StopParent(ctx context.Context, id string) error {
+	path, err := parentPath(id)
+	if err != nil {
+		return err
+	}
+	var result struct {
+		Confirmed bool `json:"teardownConfirmed"`
+	}
+	code, err := c.doJSON(ctx, http.MethodPost, path+"/stop", nil, &result, false)
+	if err != nil {
+		return err
+	}
+	if code != http.StatusOK || !result.Confirmed {
+		return ErrReconcile
+	}
+	return nil
+}
+
+// CancelParent requests cancellation of an entire parent.
+func (c *Client) CancelParent(ctx context.Context, id string) error {
+	path, err := parentPath(id)
+	if err != nil {
+		return err
+	}
+	var result struct {
+		Requested bool  `json:"cancellationRequested"`
+		Confirmed *bool `json:"teardownConfirmed"`
+	}
+	code, err := c.doJSON(ctx, http.MethodPost, path+"/cancel", nil, &result, false)
+	if err != nil {
+		return err
+	}
+	if code != http.StatusAccepted || !result.Requested || result.Confirmed == nil || *result.Confirmed {
+		return ErrReconcile
+	}
+	return nil
+}
+
+// CancelParentTurn signals only this immutable turn's child. Success is not
+// proof of teardown or parent readiness; callers must reconcile the durable
+// turn result. It never falls back to CancelParent, which stops the whole parent.
+func (c *Client) CancelParentTurn(ctx context.Context, id, turn string) error {
+	path, err := parentPath(id)
+	if err != nil {
+		return err
+	}
+	if !turnPattern.MatchString(turn) {
+		return fmt.Errorf("invalid turn ID")
+	}
+	var result struct {
+		Requested bool  `json:"cancellationRequested"`
+		Confirmed *bool `json:"teardownConfirmed"`
+		Retry     *bool `json:"retryAuthorized"`
+	}
+	code, err := c.doJSON(ctx, http.MethodPost, path+"/turns/"+turn+"/cancel", nil, &result, false)
+	if err != nil {
+		return err
+	}
+	if code != http.StatusAccepted || !result.Requested || result.Confirmed == nil || *result.Confirmed || result.Retry == nil || *result.Retry {
+		return ErrReconcile
+	}
+	return nil
+}
+
+// ParentTurn returns the durable evidence for a turn, reconciling stage and
+// live owner status.
+func (c *Client) ParentTurn(ctx context.Context, id, turn string) (ParentTurnEvidence, error) {
+	var result ParentTurnEvidence
+	path, err := parentPath(id)
+	if err != nil {
+		return result, err
+	}
+	if !turnPattern.MatchString(turn) {
+		return result, fmt.Errorf("invalid turn ID")
+	}
+	code, err := c.doJSON(ctx, http.MethodGet, path+"/turns/"+turn, nil, &result, false)
+	if err != nil {
+		return result, err
+	}
+	if code != http.StatusOK || result.Retry == nil || *result.Retry {
+		return ParentTurnEvidence{}, ErrReconcile
+	}
+	switch result.OwnerStatus {
+	case "Initializing", "Ready", "TurnActive", "Stopping", "Stopped", "ContextLost", "TeardownUncertain":
+	default:
+		return ParentTurnEvidence{}, ErrReconcile
+	}
+	var record struct {
+		Version int    `json:"version"`
+		Parent  string `json:"parent"`
+		Child   string `json:"child"`
+		TurnID  string `json:"turnId"`
+		Request struct {
+			TurnID string `json:"turnId"`
+		} `json:"request"`
+	}
+	if json.Unmarshal(result.Turn.Record, &record) != nil || record.Version != 1 || record.Parent != id || !hashPattern.MatchString(record.Child) {
+		return ParentTurnEvidence{}, ErrReconcile
+	}
+	switch result.Turn.Stage {
+	case "reserved":
+		if record.Request.TurnID != turn {
+			return ParentTurnEvidence{}, ErrReconcile
+		}
+	case "child-destroyed", "parent-committed":
+		if record.TurnID != turn {
+			return ParentTurnEvidence{}, ErrReconcile
+		}
+	default:
+		return ParentTurnEvidence{}, ErrReconcile
+	}
+	return result, nil
+}

--- a/internal/celln/parent.go
+++ b/internal/celln/parent.go
@@ -52,7 +52,7 @@ type ParentTurnEvidence struct {
 	OwnerStatus string `json:"ownerStatus"`
 }
 
-func (c *Client) doJSON(ctx context.Context, method, path string, body any, output any, respondAsync bool) (int, error) {
+func (c *Client) doJSON(ctx context.Context, method, path string, body any, output any, respondAsync bool, headers ...http.Header) (int, error) {
 	token, err := c.credential()
 	if err != nil {
 		return 0, err
@@ -75,6 +75,11 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body any, outp
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
+	for _, h := range headers {
+		for key, values := range h {
+			req.Header[key] = values
+		}
+	}
 	if respondAsync {
 		req.Header.Set("Prefer", "respond-async")
 	}
@@ -121,7 +126,8 @@ func (c *Client) CreateParent(ctx context.Context, profile, incarnation string) 
 		Retry       *bool  `json:"retryAuthorized"`
 	}
 	status, err := c.doJSON(ctx, http.MethodPost, "/v1/parents",
-		map[string]string{"apiVersion": "celln.parent-create/v1", "launchProfile": profile}, &result, false)
+		map[string]string{"apiVersion": "celln.parent-create/v1", "launchProfile": profile}, &result, false,
+		http.Header{"X-Celln-Parent-Incarnation": []string{incarnation}})
 	if err != nil {
 		return err
 	}

--- a/internal/cellnauthority/plan.go
+++ b/internal/cellnauthority/plan.go
@@ -45,7 +45,7 @@ func prepare(snapshot SelectionSnapshot, imageBytes int64, allowBroker bool) (*P
 	if p == nil {
 		return nil, fmt.Errorf("Celln runtime profile required")
 	}
-	if p.ContractVersion != "celln.json-tools/v1" || p.Platform != "linux/amd64" || p.Lane != "agent" || p.Lifecycle != "disposable-one-shot" || len(p.RuntimeData) != 0 || p.JSON == nil || p.JSON.MaxTurns < 1 || p.JSON.MaxTurns > 6 || p.JSON.MaxCalls < 0 || p.JSON.MaxCalls > 16 || !hashPattern.MatchString(p.Executable.Hash) || !hashPattern.MatchString(p.Closure.Hash) || !hashPattern.MatchString(p.Mote.Hash) || !publisherPattern.MatchString(p.PublisherKey) || !pathPattern.MatchString(p.EntryPoint) || len(p.EntryPoint) > 256 || p.EntryPoint == "/pilot-fetch" || len(p.Revision) < 1 || len(p.Revision) > 64 {
+	if p.ContractVersion != "celln.json-tools/v1" || p.Platform != "linux/amd64" || p.Lane != "agent" || (p.Lifecycle != "disposable-one-shot" && p.Lifecycle != "enduring") || len(p.RuntimeData) != 0 || p.JSON == nil || p.JSON.MaxTurns < 1 || p.JSON.MaxTurns > 6 || p.JSON.MaxCalls < 0 || p.JSON.MaxCalls > 16 || !hashPattern.MatchString(p.Executable.Hash) || !hashPattern.MatchString(p.Closure.Hash) || !hashPattern.MatchString(p.Mote.Hash) || !publisherPattern.MatchString(p.PublisherKey) || !pathPattern.MatchString(p.EntryPoint) || len(p.EntryPoint) > 256 || p.EntryPoint == "/pilot-fetch" || len(p.Revision) < 1 || len(p.Revision) > 64 {
 		return nil, fmt.Errorf("invalid or unsupported JSON runtime profile")
 	}
 	l := p.Limits

--- a/internal/cellninstall/install.go
+++ b/internal/cellninstall/install.go
@@ -229,7 +229,11 @@ func Install(ctx context.Context, store client.Client, o Options) error {
 		return err
 	}
 	approvals, journal := filepath.Join(o.StatePath, "approvals"), filepath.Join(o.StatePath, "journal")
-	registration := cellnparent.RegistrationConfig{APIVersion: "sympozium.ai/celln-parent-registrations-v1", Journal: journal, Approvals: approvals, OperatorSource: ref("operator"), RuntimeSource: ref("runtime"), AgentSource: ref("agent"), LocalProvisioner: &cellnparent.LocalProvisioner{Binary: "/usr/local/bin/celln", Root: filepath.Join(o.StatePath, "authority"), Journal: journal, Approvals: approvals, Target: o.OwnerTarget, TokenFile: "/etc/sympozium/celln-parent/owner-token", CAFile: "/etc/sympozium/celln-parent/owner-ca.pem"}, HostTemplates: []cellnparent.HostProvisionTemplate{{APIVersion: "sympozium.ai/celln-parent-host-template-v1", SelectionSHA256: digest, Scope: o.Scope, Principal: configured.Principal, Model: configured.Model, HostLimits: configured.HostLimits, Native: native}}}
+	caFile := ""
+	if origin.Scheme == "https" {
+		caFile = "/etc/sympozium/celln-parent/owner-ca.pem"
+	}
+	registration := cellnparent.RegistrationConfig{APIVersion: "sympozium.ai/celln-parent-registrations-v1", Journal: journal, Approvals: approvals, OperatorSource: ref("operator"), RuntimeSource: ref("runtime"), AgentSource: ref("agent"), LocalProvisioner: &cellnparent.LocalProvisioner{Binary: "/usr/local/bin/celln", Root: filepath.Join(o.StatePath, "authority"), Journal: journal, Approvals: approvals, Target: o.OwnerTarget, TokenFile: "/etc/sympozium/celln-parent/owner-token", CAFile: caFile}, HostTemplates: []cellnparent.HostProvisionTemplate{{APIVersion: "sympozium.ai/celln-parent-host-template-v1", SelectionSHA256: digest, Scope: o.Scope, Principal: configured.Principal, Model: configured.Model, HostLimits: configured.HostLimits, Native: native}}}
 	if err := write("registrations.json", registration); err != nil {
 		return err
 	}

--- a/internal/cellninstall/install.go
+++ b/internal/cellninstall/install.go
@@ -100,7 +100,7 @@ func Partitioned(args []string, namespace string) bool {
 
 func Install(ctx context.Context, store client.Client, o Options) error {
 	origin, originErr := url.Parse(o.OwnerTarget)
-	if store == nil || len(validation.IsDNS1123Label(o.Namespace)) != 0 || o.Namespace == o.ControllerNamespace || o.Scope == "" || originErr != nil || origin.Scheme != "https" || origin.Hostname() == "" || origin.User != nil || origin.RawQuery != "" || origin.Fragment != "" || (origin.Path != "" && origin.Path != "/") || !strings.HasPrefix(o.PackageHash, "blake3:") || len(o.PackageHash) != 71 {
+	if store == nil || len(validation.IsDNS1123Label(o.Namespace)) != 0 || o.Namespace == o.ControllerNamespace || o.Scope == "" || originErr != nil || (origin.Scheme != "https" && origin.Scheme != "http") || origin.Hostname() == "" || origin.User != nil || origin.RawQuery != "" || origin.Fragment != "" || (origin.Path != "" && origin.Path != "/") || !strings.HasPrefix(o.PackageHash, "blake3:") || len(o.PackageHash) != 71 {
 		return fmt.Errorf("dedicated namespace, scope and HTTPS owner required")
 	}
 	for _, path := range []string{o.ConfigurationDir, o.OutputDir, o.StatePath} {
@@ -115,8 +115,12 @@ func Install(ctx context.Context, store client.Client, o Options) error {
 	if err := store.Get(ctx, types.NamespacedName{Namespace: o.ControllerNamespace, Name: "sympozium-controller-manager"}, &d); err != nil {
 		return err
 	}
-	if len(d.Spec.Template.Spec.Containers) != 1 || !Partitioned(d.Spec.Template.Spec.Containers[0].Args, o.Namespace) || d.Spec.Replicas == nil || *d.Spec.Replicas < 1 || d.Status.ObservedGeneration < d.Generation || d.Status.Replicas != *d.Spec.Replicas || d.Status.UpdatedReplicas != *d.Spec.Replicas || d.Status.AvailableReplicas != *d.Spec.Replicas {
-		return fmt.Errorf("general controller must finish its namespace-separated rollout before native installation")
+	// The unified plane folds the parent reconcilers into the one controller, so
+	// the legacy namespace partition (a separate parent-only controller watching
+	// a dedicated namespace) is no longer required. We still require the
+	// controller to be fully rolled out before writing native authority.
+	if len(d.Spec.Template.Spec.Containers) != 1 || d.Spec.Replicas == nil || *d.Spec.Replicas < 1 || d.Status.ObservedGeneration < d.Generation || d.Status.Replicas != *d.Spec.Replicas || d.Status.UpdatedReplicas != *d.Spec.Replicas || d.Status.AvailableReplicas != *d.Spec.Replicas {
+		return fmt.Errorf("general controller must finish its rollout before native installation")
 	}
 	var cat catalogue
 	var configured receipt

--- a/internal/cellninstall/install_test.go
+++ b/internal/cellninstall/install_test.go
@@ -42,7 +42,7 @@ func TestPartitionRequiresExplicitNonOverlappingScope(t *testing.T) {
 }
 
 func TestInstallationPublishesBoundConfigurationWithoutSubmittingRun(t *testing.T) {
-	for _, mode := range []string{"success", "overlap", "rollout", "hash", "changed-catalogue", "existing-output", "existing-resource"} {
+	for _, mode := range []string{"success", "rollout", "hash", "changed-catalogue", "existing-output", "existing-resource"} {
 		t.Run(mode, func(t *testing.T) {
 			ctx := context.Background()
 			dir := t.TempDir()
@@ -75,9 +75,6 @@ func TestInstallationPublishesBoundConfigurationWithoutSubmittingRun(t *testing.
 			_ = os.WriteFile(filepath.Join(cfg, "configured.json"), raw, 0600)
 			replicas := int32(1)
 			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "sympozium-controller-manager", Namespace: "sympozium-system", Generation: 1}, Spec: appsv1.DeploymentSpec{Replicas: &replicas, Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Args: []string{"--exclude-watch-namespaces=celln-agents"}}}}}}, Status: appsv1.DeploymentStatus{ObservedGeneration: 1, Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1}}
-			if mode == "overlap" {
-				deployment.Spec.Template.Spec.Containers[0].Args = nil
-			}
 			if mode == "rollout" {
 				deployment.Status.UpdatedReplicas = 0
 			}

--- a/internal/cellninstall/plane.go
+++ b/internal/cellninstall/plane.go
@@ -1,0 +1,121 @@
+package cellninstall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnparent"
+	"github.com/zeebo/blake3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PlaneOptions connects an already reviewed installation to the managed plane.
+// The owner credential is explicitly supplied; model credentials are never read.
+type PlaneOptions struct {
+	NodeName, OwnerTokenFile string
+}
+
+const ManagedRouterURL = "http://celln-router.celln-system.svc.cluster.local:8787"
+
+// ConfigurePlane publishes immutable installation configuration, never run
+// authority. Existing Secrets are refused rather than silently replacing a live
+// owner's identity. Call only after Install, then apply the returned Helm values.
+func ConfigurePlane(ctx context.Context, store client.Client, o Options, p PlaneOptions) ([]string, error) {
+	if len(validation.IsDNS1123Subdomain(p.NodeName)) != 0 || !filepath.IsAbs(p.OwnerTokenFile) || o.ControllerNamespace == "" || o.OwnerTarget != ManagedRouterURL {
+		return nil, fmt.Errorf("managed Celln requires node name, absolute owner token file and controller namespace")
+	}
+	var registration cellnparent.RegistrationConfig
+	if _, err := read(filepath.Join(o.OutputDir, "registrations.json"), &registration); err != nil {
+		return nil, err
+	}
+	if registration.LocalProvisioner == nil || len(registration.HostTemplates) != 1 || len(registration.Registrations) != 0 {
+		return nil, fmt.Errorf("managed Celln requires a fresh local starter registration")
+	}
+	root := filepath.Join(o.StatePath, "authority")
+	if registration.LocalProvisioner.Root != root || registration.Approvals != filepath.Join(o.StatePath, "approvals") || registration.Journal != filepath.Join(o.StatePath, "journal") {
+		return nil, fmt.Errorf("registration must use the shared installation state")
+	}
+	for _, path := range []string{root, registration.Approvals, registration.Journal, filepath.Join(root, "parent-issuance"), filepath.Join(root, "trusted-parent-permits"), filepath.Join(root, "trusted-parent-launches")} {
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() {
+			return nil, fmt.Errorf("prepared shared state directory unavailable: %s", path)
+		}
+	}
+	// Bounded read; never include token bytes in an error or generated values.
+	info, err := os.Lstat(p.OwnerTokenFile)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > 4096 {
+		return nil, fmt.Errorf("bounded regular owner credential required")
+	}
+	raw, err := os.ReadFile(p.OwnerTokenFile)
+	token := strings.TrimSpace(string(raw))
+	if err != nil || len(token) < 24 || len(raw) > 4096 || strings.ContainsAny(token, " \t\r\n") {
+		return nil, fmt.Errorf("invalid owner credential")
+	}
+	var authority struct {
+		APIVersion string `json:"apiVersion"`
+		Clients    []struct {
+			Principal string `json:"principal"`
+			TokenHash string `json:"tokenHash"`
+		} `json:"clients"`
+	}
+	if _, err := read(filepath.Join(root, "trusted-parent-clients.json"), &authority); err != nil {
+		return nil, err
+	}
+	digest := fmt.Sprintf("blake3:%x", blake3.Sum256([]byte(token)))
+	matches := 0
+	for _, entry := range authority.Clients {
+		if entry.TokenHash == digest && entry.Principal == registration.HostTemplates[0].Principal {
+			matches++
+		}
+	}
+	if authority.APIVersion != "celln.parent-clients/v1" || matches != 1 {
+		return nil, fmt.Errorf("owner token does not match the prepared parent principal")
+	}
+	// The prepared model profile lives in the SAME authority root as launches.
+	// Inspect only the path/hash, never the credential bytes referenced by it.
+	modelHash := registration.HostTemplates[0].Native.ModelProfile
+	if len(modelHash) != 71 || !strings.HasPrefix(modelHash, "blake3:") || strings.ContainsAny(modelHash, "/\\") {
+		return nil, fmt.Errorf("invalid prepared model profile hash")
+	}
+	var model struct {
+		CredentialFile string `json:"credentialFile"`
+	}
+	actual, err := read(filepath.Join(root, "trusted-parent-models", strings.TrimPrefix(modelHash, "blake3:")+".json"), &model)
+	if err != nil || actual != modelHash || !filepath.IsAbs(model.CredentialFile) || filepath.Clean(model.CredentialFile) != model.CredentialFile || strings.ContainsAny(model.CredentialFile, ",{}[]\\\n\r") {
+		return nil, fmt.Errorf("prepared model profile must exist in the shared authority root with a clean absolute credential path")
+	}
+	// Both endpoint families now use the controller's existing router identity.
+	registration.LocalProvisioner.TokenFile = "/etc/sympozium/celln/token"
+	registration.LocalProvisioner.CAFile = ""
+	registration.LocalProvisioner.Target = o.OwnerTarget
+	data, err := json.Marshal(registration)
+	if err != nil {
+		return nil, err
+	}
+	for _, secret := range []*corev1.Secret{
+		{ObjectMeta: metav1.ObjectMeta{Name: "celln-parent-config", Namespace: o.ControllerNamespace}, Data: map[string][]byte{"registrations.json": data}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "celln-router-parent", Namespace: "celln-system"}, Data: map[string][]byte{"token": []byte(token)}},
+	} {
+		if err := store.Create(ctx, secret); err != nil {
+			return nil, fmt.Errorf("publish %s: %w; partial installation retained", secret.Name, err)
+		}
+	}
+	return []string{
+		"celln.dispatcher.enduring.enabled=true",
+		"celln.dispatcher.maxCells=4",
+		fmt.Sprintf("celln.dispatcher.memoryBytes=%d", registration.HostTemplates[0].Native.ReservedMemoryBytes+268435456),
+		"celln.dispatcher.enduring.nodeName=" + p.NodeName,
+		"celln.dispatcher.enduring.statePath=" + o.StatePath,
+		"celln.dispatcher.enduring.parentConfigSecret=celln-parent-config",
+		"celln.router.parentTokenSecret=celln-router-parent",
+		"celln.nativeParent.enabled=false",
+		"celln.dispatcher.enduring.modelCredentialFiles[0]=" + model.CredentialFile,
+	}, nil
+}

--- a/internal/cellninstall/plane_test.go
+++ b/internal/cellninstall/plane_test.go
@@ -1,0 +1,103 @@
+package cellninstall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sympozium-ai/sympozium/internal/cellnparent"
+	"github.com/zeebo/blake3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestManagedPlaneCredentialAndSharedRootBinding(t *testing.T) {
+	for _, mode := range []string{"valid", "wrong-token", "wrong-principal", "wrong-root", "missing-model", "different-origin"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			o := Options{StatePath: dir, OutputDir: filepath.Join(dir, "installation"), ControllerNamespace: "sympozium-system", OwnerTarget: ManagedRouterURL}
+			p := PlaneOptions{NodeName: "kvm-a", OwnerTokenFile: filepath.Join(dir, "owner-token")}
+			for _, sub := range []string{"authority/trusted-parent-models", "authority/parent-issuance", "authority/trusted-parent-permits", "authority/trusted-parent-launches", "approvals", "journal", "installation"} {
+				if err := os.MkdirAll(filepath.Join(dir, sub), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			const token = "parent-only-high-entropy-test-credential"
+			write := func(path string, bytes []byte) {
+				t.Helper()
+				if err := os.WriteFile(path, bytes, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write(p.OwnerTokenFile, []byte(token))
+			model := []byte(`{"credentialFile":"/etc/celln/model-key-must-not-be-read"}`)
+			modelHash := fmt.Sprintf("blake3:%x", blake3.Sum256(model))
+			if mode != "missing-model" {
+				write(filepath.Join(dir, "authority/trusted-parent-models", strings.TrimPrefix(modelHash, "blake3:")+".json"), model)
+			}
+			registration := cellnparent.RegistrationConfig{
+				Approvals: filepath.Join(dir, "approvals"), Journal: filepath.Join(dir, "journal"),
+				LocalProvisioner: &cellnparent.LocalProvisioner{Root: filepath.Join(dir, "authority")},
+				HostTemplates:    []cellnparent.HostProvisionTemplate{{Principal: "operator", Native: cellnparent.NativeProvisionConfig{ModelProfile: modelHash}}},
+			}
+			if mode == "wrong-root" {
+				registration.LocalProvisioner.Root = "/another/root"
+			}
+			if mode == "different-origin" {
+				o.OwnerTarget = "http://another-owner:8787"
+			}
+			if mode == "wrong-token" {
+				write(p.OwnerTokenFile, []byte("another-parent-credential-at-least-24"))
+			}
+			if mode == "wrong-principal" {
+				registration.HostTemplates[0].Principal = "another-operator"
+			}
+			raw, _ := json.Marshal(registration)
+			write(filepath.Join(o.OutputDir, "registrations.json"), raw)
+			write(filepath.Join(dir, "authority/trusted-parent-clients.json"), []byte(fmt.Sprintf(`{"apiVersion":"celln.parent-clients/v1","clients":[{"principal":"operator","tokenHash":"blake3:%x"}]}`, blake3.Sum256([]byte(token)))))
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			store := fake.NewClientBuilder().WithScheme(scheme).Build()
+			values, err := ConfigurePlane(ctx, store, o, p)
+			if mode != "valid" {
+				if err == nil {
+					t.Fatal("invalid authority accepted")
+				}
+				var secrets corev1.SecretList
+				if err := store.List(ctx, &secrets); err != nil || len(secrets.Items) != 0 {
+					t.Fatal("failed preflight published partial authority")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			var controller, router corev1.Secret
+			if err := store.Get(ctx, types.NamespacedName{Namespace: o.ControllerNamespace, Name: "celln-parent-config"}, &controller); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.Get(ctx, types.NamespacedName{Namespace: "celln-system", Name: "celln-router-parent"}, &router); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(controller.Data["registrations.json"]), token) || strings.Contains(strings.Join(values, "\n"), token) || string(router.Data["token"]) != token {
+				t.Fatal("credential boundary violated")
+			}
+			if err := json.Unmarshal(controller.Data["registrations.json"], &registration); err != nil {
+				t.Fatal(err)
+			}
+			if registration.LocalProvisioner.TokenFile != "/etc/sympozium/celln/token" || registration.LocalProvisioner.Target != ManagedRouterURL || registration.LocalProvisioner.CAFile != "" {
+				t.Fatal("parent did not join shared connection")
+			}
+			if _, err := ConfigurePlane(ctx, store, o, p); err == nil {
+				t.Fatal("existing installation silently replaced")
+			}
+		})
+	}
+}

--- a/internal/cellnparent/admission.go
+++ b/internal/cellnparent/admission.go
@@ -5,8 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/url"
+	"os"
+
+	"github.com/sympozium-ai/sympozium/internal/celln"
 	"unicode"
 
 	api "github.com/sympozium-ai/sympozium/api/v1alpha1"
@@ -62,14 +63,14 @@ func ValidateAdmission(run *api.AgentRun, approval api.CellnParentBinding) error
 }
 
 func validateOwnerOrigin(target string) error {
-	u, err := url.Parse(target)
-	if err != nil || len(target) > 2048 || u.Hostname() == "" || u.User != nil || u.Opaque != "" || u.Path != "" || u.RawPath != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+	if len(target) > 2048 {
 		return fmt.Errorf("parent approval requires an exact owner origin")
 	}
-	ip := net.ParseIP(u.Hostname())
-	if u.Scheme != "https" && !(u.Scheme == "http" && ip != nil && ip.IsLoopback()) {
-		return fmt.Errorf("parent owner requires protected transport")
+	c, err := celln.New(celln.Config{BaseURL: target, AllowInsecure: os.Getenv("CELLN_ALLOW_INSECURE_HTTP") == "true"})
+	if err != nil {
+		return fmt.Errorf("parent owner requires protected transport: %w", err)
 	}
+	c.Close()
 	return nil
 }
 

--- a/internal/cellnparent/admission_test.go
+++ b/internal/cellnparent/admission_test.go
@@ -106,3 +106,20 @@ func TestDurableCreateClaimHasExactlyOneWinner(t *testing.T) {
 		t.Fatal("durable binding lost")
 	}
 }
+
+func TestParentAdmissionUsesPlaneTransportAcknowledgement(t *testing.T) {
+	const target = "http://celln-router.celln-system.svc.cluster.local:8787"
+	t.Setenv("CELLN_ALLOW_INSECURE_HTTP", "false")
+	if validateOwnerOrigin(target) == nil {
+		t.Fatal("unacknowledged plaintext admitted")
+	}
+	t.Setenv("CELLN_ALLOW_INSECURE_HTTP", "true")
+	if err := validateOwnerOrigin(target); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{"/v1/parents", "?", "?token=x", "#fragment"} {
+		if validateOwnerOrigin(target+suffix) == nil {
+			t.Fatal("non-origin owner admitted")
+		}
+	}
+}

--- a/internal/cellnparent/client.go
+++ b/internal/cellnparent/client.go
@@ -1,333 +1,115 @@
 // Package cellnparent implements the caller-scoped persistent parent protocol.
-// An endpoint is a frozen operator-selected owner, not a load-balanced retry target.
+// An endpoint is a frozen operator-selected owner, not a load-balanced retry
+// target.
+//
+// The transport and credential handling live in internal/celln (the single
+// Celln client). This package keeps the parent-protocol surface stable for its
+// callers and pins the owner-specific policy: TLS 1.3 minimum, no proxy, an
+// absolute credential path.
 package cellnparent
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/celln"
 )
 
+// The sentinels and validation patterns are shared with internal/celln.
 var (
-	ErrReconcile = errors.New("parent outcome requires reconciliation; preserve incarnation and turn ID")
-	ErrNotFound  = errors.New("parent or turn not found; not permission to replay")
+	ErrReconcile = celln.ErrReconcile
+	ErrNotFound  = celln.ErrNotFound
 	hashPattern  = regexp.MustCompile(`^blake3:[0-9a-f]{64}$`)
-	turnPattern  = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 )
+
+// Type aliases keep the parent protocol types in one place (internal/celln).
+type (
+	Status       = celln.ParentStatus
+	TurnResult   = celln.ParentTurnResult
+	TurnEvidence = celln.ParentTurnEvidence
+)
+
+// OwnerTimeout bounds one owner request.
+const OwnerTimeout = 40 * time.Second
 
 type Options struct {
 	URL, TokenFile string
 	Roots          *x509.CertPool
+	// AllowInsecure permits plaintext HTTP to a non-loopback owner (the same
+	// explicit acknowledgement the one-shot path uses). Cluster-local owners
+	// are plaintext by default; external owners still require HTTPS.
+	AllowInsecure bool
 }
 
 type Client struct {
-	origin, tokenFile string
-	http              *http.Client
+	inner *celln.Client
 }
 
 func New(o Options) (*Client, error) {
-	u, err := url.Parse(o.URL)
-	if err != nil || u.Hostname() == "" || u.User != nil || u.Opaque != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || u.Path != "" || !filepath.IsAbs(o.TokenFile) {
+	if !filepath.IsAbs(o.TokenFile) {
 		return nil, errors.New("parent client requires an operator origin and absolute credential path")
 	}
-	ip := net.ParseIP(u.Hostname())
-	if u.Scheme != "https" && !(u.Scheme == "http" && ip != nil && ip.IsLoopback()) {
-		return nil, errors.New("parent origin requires HTTPS except literal loopback test endpoints")
+	inner, err := celln.New(celln.Config{
+		BaseURL:       o.URL,
+		TokenFile:     o.TokenFile,
+		TLSRoots:      o.Roots,
+		MinTLSVersion: tls.VersionTLS13,
+		NoProxy:       true,
+		Timeout:       OwnerTimeout,
+		AllowInsecure: o.AllowInsecure,
+	})
+	if err != nil {
+		return nil, errors.New("parent client requires an operator origin and absolute credential path")
 	}
-	transport := &http.Transport{Proxy: nil, TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS13, RootCAs: o.Roots},
-		DialContext: (&net.Dialer{Timeout: 10 * time.Second}).DialContext, TLSHandshakeTimeout: 10 * time.Second,
-		ResponseHeaderTimeout: 35 * time.Second, IdleConnTimeout: 30 * time.Second, MaxConnsPerHost: 4, DisableCompression: true}
-	return &Client{origin: u.String(), tokenFile: o.TokenFile, http: &http.Client{Transport: transport, Timeout: 40 * time.Second,
-		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}}, nil
+	return &Client{inner: inner}, nil
 }
 
-func (c *Client) Close() { c.http.CloseIdleConnections() }
+func (c *Client) Close() { c.inner.Close() }
 
 // No operation retries automatically. Transport errors and ambiguous responses
 // preserve the exact incarnation/turn; they never authorize a replacement POST.
-func (c *Client) request(ctx context.Context, method, path string, body any, output any, respondAsync ...bool) (int, error) {
-	f, err := os.Open(c.tokenFile)
-	if err != nil {
-		return 0, errors.New("parent credential unavailable")
-	}
-	defer f.Close()
-	raw, err := io.ReadAll(io.LimitReader(f, 4097))
-	token := strings.TrimSpace(string(raw))
-	if err != nil || len(raw) > 4096 || len(token) < 24 {
-		return 0, errors.New("invalid parent credential")
-	}
-	for _, b := range []byte(token) {
-		if b < 33 || b > 126 {
-			return 0, errors.New("invalid parent credential")
-		}
-	}
-	var payload []byte
-	if body != nil {
-		payload, err = json.Marshal(body)
-		if err != nil {
-			return 0, err
-		}
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.origin+path, bytes.NewReader(payload))
-	if err != nil {
-		return 0, errors.New("invalid parent request")
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	if len(respondAsync) == 1 && respondAsync[0] {
-		req.Header.Set("Prefer", "respond-async")
-	}
-	res, err := c.http.Do(req)
-	if err != nil {
-		return 0, ErrReconcile
-	}
-	defer res.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(res.Body, 32769))
-	if err != nil || len(data) > 32768 {
-		return res.StatusCode, ErrReconcile
-	}
-	if res.StatusCode == 404 {
-		return res.StatusCode, ErrNotFound
-	}
-	if res.StatusCode != 200 && res.StatusCode != 202 {
-		return res.StatusCode, ErrReconcile
-	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if decoder.Decode(output) != nil || decoder.Decode(new(any)) != io.EOF {
-		return res.StatusCode, ErrReconcile
-	}
-	return res.StatusCode, nil
-}
-
-func parentPath(id string) (string, error) {
-	if !hashPattern.MatchString(id) {
-		return "", errors.New("invalid parent incarnation")
-	}
-	return "/v1/parents/" + id, nil
-}
 
 func (c *Client) Create(ctx context.Context, profile, incarnation string) error {
-	if !hashPattern.MatchString(profile) || !hashPattern.MatchString(incarnation) {
-		return errors.New("invalid frozen parent selection")
-	}
-	var result struct {
-		Incarnation string `json:"incarnation"`
-		Pending     bool   `json:"initializationPending"`
-		Retry       *bool  `json:"retryAuthorized"`
-	}
-	status, err := c.request(ctx, "POST", "/v1/parents", map[string]string{"apiVersion": "celln.parent-create/v1", "launchProfile": profile}, &result)
-	if err != nil {
-		return err
-	}
-	if status != 202 || result.Incarnation != incarnation || !result.Pending || result.Retry == nil || *result.Retry {
-		return ErrReconcile
-	}
-	return nil
-}
-
-type Status struct {
-	Incarnation string `json:"incarnation"`
-	Status      string `json:"status"`
-	Live        bool   `json:"statusIsLiveOwnerObservation"`
-	Retry       *bool  `json:"retryAuthorized"`
+	return c.inner.CreateParent(ctx, profile, incarnation)
 }
 
 func (c *Client) Status(ctx context.Context, id string) (Status, error) {
-	var result Status
-	path, err := parentPath(id)
-	if err != nil {
-		return result, err
-	}
-	code, err := c.request(ctx, "GET", path, nil, &result)
-	if err != nil {
-		return result, err
-	}
-	valid := false
-	for _, status := range []string{"Initializing", "Ready", "TurnActive", "Stopping", "Stopped", "ContextLost", "TeardownUncertain"} {
-		valid = valid || result.Status == status
-	}
-	if code != 200 || !valid || result.Incarnation != id || result.Retry == nil || *result.Retry || (!result.Live && result.Status != "ContextLost") {
-		return Status{}, ErrReconcile
-	}
-	return result, nil
-}
-
-type TurnResult struct {
-	Kind      string `json:"kind,omitempty"`
-	Version   string `json:"apiVersion,omitempty"`
-	TurnID    string `json:"turnId,omitempty"`
-	Succeeded *bool  `json:"succeeded,omitempty"`
-	Answer    string `json:"answer,omitempty"`
-	Pending   bool   `json:"pending,omitempty"`
-	Retry     *bool  `json:"retryAuthorized,omitempty"`
+	return c.inner.ParentStatus(ctx, id)
 }
 
 func (c *Client) Submit(ctx context.Context, id, turn, message string) (TurnResult, error) {
-	return c.submit(ctx, id, turn, message, false)
+	return c.inner.SubmitParentTurn(ctx, id, turn, message)
 }
 
 // SubmitAsync releases the controller to reconcile cancellation while the
 // original owner executes. Pending is not permission to submit again.
 func (c *Client) SubmitAsync(ctx context.Context, id, turn, message string) (TurnResult, error) {
-	return c.submit(ctx, id, turn, message, true)
-}
-
-func (c *Client) submit(ctx context.Context, id, turn, message string, respondAsync bool) (TurnResult, error) {
-	var result TurnResult
-	path, err := parentPath(id)
-	if err != nil {
-		return result, err
-	}
-	if !turnPattern.MatchString(turn) || strings.TrimSpace(message) == "" || len(message) > 2048 || strings.ContainsRune(message, 0) {
-		return result, errors.New("invalid bounded parent turn")
-	}
-	body := map[string]string{"kind": "turn", "apiVersion": "celln.parent-context/v1", "turnId": turn, "message": message}
-	code, err := c.request(ctx, "POST", path+"/turns", body, &result, respondAsync)
-	if err != nil {
-		return result, err
-	}
-	if code == 202 && result.Pending && result.Retry != nil && !*result.Retry && result.Kind == "" && result.TurnID == "" && result.Succeeded == nil && result.Answer == "" {
-		return result, nil
-	}
-	if code != 200 || result.Pending || result.Kind != "completed" || result.Version != "celln.parent-context/v1" || result.TurnID != turn || result.Succeeded == nil || len(result.Answer) > 2048 || strings.TrimSpace(result.Answer) == "" || strings.ContainsRune(result.Answer, 0) {
-		return TurnResult{}, ErrReconcile
-	}
-	return result, nil
+	return c.inner.SubmitParentTurnAsync(ctx, id, turn, message)
 }
 
 func (c *Client) Stop(ctx context.Context, id string) error {
-	path, err := parentPath(id)
-	if err != nil {
-		return err
-	}
-	var result struct {
-		Confirmed bool `json:"teardownConfirmed"`
-	}
-	code, err := c.request(ctx, "POST", path+"/stop", nil, &result)
-	if err != nil {
-		return err
-	}
-	if code != 200 || !result.Confirmed {
-		return ErrReconcile
-	}
-	return nil
+	return c.inner.StopParent(ctx, id)
 }
 
 func (c *Client) Cancel(ctx context.Context, id string) error {
-	path, err := parentPath(id)
-	if err != nil {
-		return err
-	}
-	var result struct {
-		Requested bool  `json:"cancellationRequested"`
-		Confirmed *bool `json:"teardownConfirmed"`
-	}
-	code, err := c.request(ctx, "POST", path+"/cancel", nil, &result)
-	if err != nil {
-		return err
-	}
-	if code != 202 || !result.Requested || result.Confirmed == nil || *result.Confirmed {
-		return ErrReconcile
-	}
-	return nil
+	return c.inner.CancelParent(ctx, id)
 }
 
 // CancelTurn signals only this immutable turn's child. Success is not proof of
 // teardown or parent readiness; callers must reconcile the durable turn result.
 // It never falls back to Cancel, which stops the entire parent.
 func (c *Client) CancelTurn(ctx context.Context, id, turn string) error {
-	path, err := parentPath(id)
-	if err != nil {
-		return err
-	}
-	if !turnPattern.MatchString(turn) {
-		return fmt.Errorf("invalid turn ID")
-	}
-	var result struct {
-		Requested bool  `json:"cancellationRequested"`
-		Confirmed *bool `json:"teardownConfirmed"`
-		Retry     *bool `json:"retryAuthorized"`
-	}
-	code, err := c.request(ctx, "POST", path+"/turns/"+turn+"/cancel", nil, &result)
-	if err != nil {
-		return err
-	}
-	if code != 202 || !result.Requested || result.Confirmed == nil || *result.Confirmed || result.Retry == nil || *result.Retry {
-		return ErrReconcile
-	}
-	return nil
-}
-
-type TurnEvidence struct {
-	Turn struct {
-		Stage  string          `json:"stage"`
-		Record json.RawMessage `json:"record"`
-	} `json:"turn"`
-	Retry       *bool  `json:"retryAuthorized"`
-	OwnerStatus string `json:"ownerStatus"`
+	return c.inner.CancelParentTurn(ctx, id, turn)
 }
 
 // Turn preserves both historical stage and live-owner observation. A committed
 // answer never implies a resumable parent. The controller must additionally
 // match child identity and request/budgets against its frozen admission.
 func (c *Client) Turn(ctx context.Context, id, turn string) (TurnEvidence, error) {
-	var result TurnEvidence
-	path, err := parentPath(id)
-	if err != nil {
-		return result, err
-	}
-	if !turnPattern.MatchString(turn) {
-		return result, fmt.Errorf("invalid turn ID")
-	}
-	code, err := c.request(ctx, "GET", path+"/turns/"+turn, nil, &result)
-	if err != nil {
-		return result, err
-	}
-	if code != 200 || result.Retry == nil || *result.Retry {
-		return TurnEvidence{}, ErrReconcile
-	}
-	switch result.OwnerStatus {
-	case "Initializing", "Ready", "TurnActive", "Stopping", "Stopped", "ContextLost", "TeardownUncertain":
-	default:
-		return TurnEvidence{}, ErrReconcile
-	}
-	var record struct {
-		Version int    `json:"version"`
-		Parent  string `json:"parent"`
-		Child   string `json:"child"`
-		TurnID  string `json:"turnId"`
-		Request struct {
-			TurnID string `json:"turnId"`
-		} `json:"request"`
-	}
-	if json.Unmarshal(result.Turn.Record, &record) != nil || record.Version != 1 || record.Parent != id || !hashPattern.MatchString(record.Child) {
-		return TurnEvidence{}, ErrReconcile
-	}
-	switch result.Turn.Stage {
-	case "reserved":
-		if record.Request.TurnID != turn {
-			return TurnEvidence{}, ErrReconcile
-		}
-	case "child-destroyed", "parent-committed":
-		if record.TurnID != turn {
-			return TurnEvidence{}, ErrReconcile
-		}
-	default:
-		return TurnEvidence{}, ErrReconcile
-	}
-	return result, nil
+	return c.inner.ParentTurn(ctx, id, turn)
 }

--- a/internal/cellnparent/config.go
+++ b/internal/cellnparent/config.go
@@ -116,7 +116,7 @@ func loadBinding(path string, run *api.AgentRun, recovery bool) (api.CellnParent
 			return zero, nil, fmt.Errorf("invalid parent trust bundle")
 		}
 	}
-	transport, err := New(Options{URL: selected.Binding.Target, TokenFile: selected.TokenFile, Roots: roots})
+	transport, err := New(Options{URL: selected.Binding.Target, TokenFile: selected.TokenFile, Roots: roots, AllowInsecure: os.Getenv("CELLN_ALLOW_INSECURE_HTTP") == "true"})
 	if err != nil {
 		return zero, nil, err
 	}

--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -54,9 +54,17 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // resolved digest on success, or a human-readable reason on failure.
 func (r *AgentRuntimeReconciler) validate(runtime *sympoziumv1alpha1.AgentRuntime) (string, string) {
 	image := runtime.Spec.Image
-	digest, ok := sympoziumv1alpha1.ParseImageDigest(image)
-	if !ok {
-		return "", fmt.Sprintf("spec.image must be a digest-pinned OCI reference (e.g. \"ghcr.io/acme/harness@sha256:<64-hex>\"); got %q", image)
+	digest := ""
+	if image == "" && runtime.Spec.Celln != nil {
+		// A Celln-native runtime has no OCI adapter: its admission is governed
+		// by the Celln profile (validated by the CRD), not by an image digest.
+		// Return no digest and no reason so OCI readiness stays unasserted.
+	} else {
+		var ok bool
+		digest, ok = sympoziumv1alpha1.ParseImageDigest(image)
+		if !ok {
+			return "", fmt.Sprintf("spec.image must be a digest-pinned OCI reference (e.g. \"ghcr.io/acme/harness@sha256:<64-hex>\"); got %q; set spec.celln for a Celln-native runtime", image)
+		}
 	}
 
 	for _, capability := range runtime.Spec.Capabilities {
@@ -110,12 +118,24 @@ func (r *AgentRuntimeReconciler) updateStatus(ctx context.Context, runtime *symp
 			ObservedGeneration: runtime.Generation,
 		})
 		runtime.Status.ResolvedImageDigest = digest
-	} else {
+	} else if reason != "" {
 		meta.SetStatusCondition(&runtime.Status.Conditions, metav1.Condition{
 			Type:               sympoziumv1alpha1.AgentRuntimeReadyCondition,
 			Status:             metav1.ConditionFalse,
 			Reason:             "Invalid",
 			Message:            reason,
+			ObservedGeneration: runtime.Generation,
+		})
+		runtime.Status.ResolvedImageDigest = ""
+	} else {
+		// The spec is a valid Celln-native runtime with no OCI adapter. Never
+		// assert OCI Ready for it; Celln admission remains governed by the
+		// CellnReady condition set above.
+		meta.SetStatusCondition(&runtime.Status.Conditions, metav1.Condition{
+			Type:               sympoziumv1alpha1.AgentRuntimeReadyCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NotApplicable",
+			Message:            "Celln-native runtime has no OCI adapter; OCI readiness does not apply",
 			ObservedGeneration: runtime.Generation,
 		})
 		runtime.Status.ResolvedImageDigest = ""

--- a/internal/controller/agentruntime_controller_test.go
+++ b/internal/controller/agentruntime_controller_test.go
@@ -18,16 +18,17 @@ import (
 
 func TestAgentRuntime_CellnReadinessIsIndependent(t *testing.T) {
 	for _, tc := range []struct {
-		name       string
-		image      string
-		profile    bool
-		wantOCI    bool
-		wantReason string
+		name          string
+		image         string
+		profile       bool
+		wantOCI       bool
+		wantOCIReason string
+		wantReason    string
 	}{
-		{"oci only", runtimeTestImage, false, true, "NotConfigured"},
-		{"dual profile", runtimeTestImage, true, true, "VerificationUnavailable"},
-		{"celln cannot rescue invalid OCI", "mutable:latest", true, false, "VerificationUnavailable"},
-		{"celln only remains unsupported", "", true, false, "VerificationUnavailable"},
+		{"oci only", runtimeTestImage, false, true, "Validated", "NotConfigured"},
+		{"dual profile", runtimeTestImage, true, true, "Validated", "VerificationUnavailable"},
+		{"celln cannot rescue invalid OCI", "mutable:latest", true, false, "Invalid", "VerificationUnavailable"},
+		{"celln only is accepted without an OCI adapter", "", true, false, "NotApplicable", "VerificationUnavailable"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
@@ -54,6 +55,9 @@ func TestAgentRuntime_CellnReadinessIsIndependent(t *testing.T) {
 			}
 			if meta.IsStatusConditionTrue(got.Status.Conditions, "Ready") != tc.wantOCI {
 				t.Fatalf("OCI readiness changed: %+v", got.Status)
+			}
+			if oci := meta.FindStatusCondition(got.Status.Conditions, "Ready"); oci == nil || oci.Reason != tc.wantOCIReason {
+				t.Fatalf("OCI condition reason = %+v, want %q", oci, tc.wantOCIReason)
 			}
 			cond := meta.FindStatusCondition(got.Status.Conditions, "CellnReady")
 			if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != tc.wantReason || cond.ObservedGeneration != 7 {
@@ -91,6 +95,21 @@ func TestAgentRuntime_Validate_RejectsUnpinnedImage(t *testing.T) {
 		if _, reason := r.validate(runtimeSpec(image)); reason == "" {
 			t.Fatalf("validate(%q) accepted an unpinned image", image)
 		}
+	}
+}
+
+func TestAgentRuntime_Validate_AcceptsCellnNativeWithoutImage(t *testing.T) {
+	runtime := runtimeSpec("")
+	runtime.Spec.Celln = &sympoziumv1alpha1.AgentRuntimeCellnProfile{Revision: "v1"}
+	digest, reason := (&AgentRuntimeReconciler{}).validate(runtime)
+	if reason != "" || digest != "" {
+		t.Fatalf("validate(celln-native) = (%q, %q), want (\"\", \"\")", digest, reason)
+	}
+}
+
+func TestAgentRuntime_Validate_RejectsEmptyImageWithoutCelln(t *testing.T) {
+	if _, reason := (&AgentRuntimeReconciler{}).validate(runtimeSpec("")); reason == "" {
+		t.Fatal("validate(empty image without spec.celln) accepted; want rejection")
 	}
 }
 

--- a/internal/controller/celln_transport.go
+++ b/internal/controller/celln_transport.go
@@ -2,58 +2,36 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
-	"strings"
 	"time"
+
+	"github.com/sympozium-ai/sympozium/internal/celln"
 )
 
-// Credentials belong to controller deployment configuration, never AgentRun
-// task text. Read the mounted file for every call so rotation takes effect.
-func cellnRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
-	base, err := url.Parse(cellnRouterURL())
-	if err != nil || base.Host == "" || base.User != nil || base.RawQuery != "" || base.Fragment != "" {
-		return nil, fmt.Errorf("Celln: invalid router URL")
-	}
-	loopback := base.Hostname() == "localhost"
-	if ip := net.ParseIP(base.Hostname()); ip != nil {
-		loopback = ip.IsLoopback()
-	}
-	if base.Scheme != "https" && !(base.Scheme == "http" && (loopback || os.Getenv("CELLN_ALLOW_INSECURE_HTTP") == "true")) {
-		return nil, fmt.Errorf("Celln: router requires HTTPS; plaintext non-loopback requires CELLN_ALLOW_INSECURE_HTTP=true")
-	}
-	filename := os.Getenv("CELLN_TOKEN_FILE")
-	if filename == "" {
-		return nil, fmt.Errorf("Celln: CELLN_TOKEN_FILE must name an operator-provisioned credential")
-	}
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, fmt.Errorf("Celln: cannot read dispatcher credential")
-	}
-	defer f.Close()
-	data, err := io.ReadAll(io.LimitReader(f, 4097))
-	token := strings.TrimSpace(string(data))
-	if err != nil || len(data) > 4096 || len(token) < 24 || strings.ContainsAny(token, "\r\n\t ") {
-		return nil, fmt.Errorf("Celln: invalid dispatcher credential")
-	}
-	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(base.String(), "/")+path, body)
-	if err != nil {
-		return nil, fmt.Errorf("Celln: cannot build dispatcher request")
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	return req, nil
+// cellnClientFromEnv builds the single Celln client from controller
+// configuration. Credentials belong to the deployment, never AgentRun task
+// text. The credential file is re-read on every request so a mounted Secret
+// rotation takes effect.
+func cellnClientFromEnv() (*celln.Client, error) {
+	return celln.New(celln.Config{
+		BaseURL:       cellnRouterURL(),
+		TokenFile:     os.Getenv("CELLN_TOKEN_FILE"),
+		AllowInsecure: os.Getenv("CELLN_ALLOW_INSECURE_HTTP") == "true",
+		Timeout:       30 * time.Second,
+	})
 }
 
-// Never follow redirects with a credential or reinterpret a redirected POST as
-// GET. A moved service needs an explicit operator configuration update.
-var cellnHTTPClient = &http.Client{
-	Timeout: 30 * time.Second,
-	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
-	},
+// cellnRequest builds a credentialed request against the configured origin.
+func cellnRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	c, err := cellnClientFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return c.Request(ctx, method, path, body)
 }
+
+// cellnHTTPClient sends already-built requests. The transport policy (no
+// redirects, bounded timeout) is owned by the shared celln client.
+var cellnHTTPClient = celln.DefaultHTTPClient


### PR DESCRIPTION
Tracks #490. Implements the design in `docs/design/celln-single-execution-plane.md` and wires the managed native plane on top.

## What this does

Collapses the two Celln stacks into **one Kubernetes-managed plane**:
- **One client** — `internal/celln` speaks `/v1/executions*` and `/v1/parents*` with a single origin/credential/transport policy; `internal/cellnparent` is a thin wrapper.
- **One transport posture** — cluster-local plaintext under the plane's insecure ack; HTTPS for external owners. No TLS edge / `celln-parent-proxy`.
- **One dispatcher** serves both surfaces; **one controller** takes `CELLN_PARENT_CONFIG`/`CELLN_PARENT_REGISTRATIONS` (the separate parent-controller Deployment goes away); `images/controller/Dockerfile` embeds the celln CLI.
- **One runtime contract** — `AgentRuntimeCellnProfile.lifecycle` accepts `disposable-one-shot` and `enduring`.

Managed-plane wiring (latest commit):
- **`cellninstall.ConfigurePlane`** — validates the owner credential against the prepared `trusted-parent-clients.json`, requires the shared state dirs + model profile, creates the `celln-parent-config` / `celln-router-parent` Secrets, returns the enabling Helm values.
- **CLI** — `--celln-native` requires `--celln-native-node` + `--celln-native-owner-token-file` (and router/installer images with parent routing + drain support); runs `Install → ConfigurePlane → runInstall`.
- **Chart** — node-pins controller **and** dispatcher to the shared-state node, mounts `<statePath>` hostPath into both, `--max-cells`/`--memory-bytes`, dispatcher `preStop` drain + readiness, router `--parent-token-file`, `CELLN_ENDURING_ENABLED`, dispatcher ingress NetworkPolicy, `cellntools` RBAC.
- **apiserver** reports enduring readiness from `CELLN_ENDURING_ENABLED` + the gateway's `parentRouting` (fail-closed).

## Verified live on `framework`
- One dispatcher serves both surfaces (`/v1/executions` 200, `/v1/parents` 403 authenticated/unregistered, cross-credential 401).
- Built/admitted/configured a native starter package; `install-native` created `AgentRuntime/celln-native`, 3 `CellnTool`s, 3 grant ConfigMaps, and the parent authority.
- The managed plane is deployed (custom images), controller node-pinned and sharing the state path; the gateway advertises `parentRouting: true`.

Build, `go vet`, `gofmt`, and the `celln`/`cellnparent`/`cellninstall`/`cellnauthority`/`apiserver`/`charts` tests pass.

## ⚠️ Gap for review
The parent **CREATE** call still does not confirm end-to-end. Enduring runs reach provisioning (launch profiles, approvals, permits, issuances are all written to the shared state) but stop at `CellnParentReady=False` / `reason=ReconciliationRequired` ("Parent outcome unavailable"). No parent cell runs (`celln ps -a` empty). The ambiguous response is at router→dispatcher `/v1/parents` (forwarding/`--parent-token-file` or the dispatcher's create response shape).

Also: `AgentRuntime celln-native` fails validation — `spec.image must be a digest-pinned OCI reference; got ""`.

And this depends on **custom celln images** (router with parent routing + drain, dispatcher with bounds); the CLI now requires them, since Celln v0.5.8 doesn't ship those flags.