### PR TITLE
feat(web): unify the Run/Harness × Kubernetes/Celln creation matrix

### DIFF
--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -43,6 +43,8 @@ import {
   Info,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { providersForPlane } from "@/lib/creation";
+import { PlanePicker } from "@/components/plane-picker";
 import { useCapabilities, useModels, useCellnTools } from "@/hooks/use-api";
 import { persistentHarnesses, persistentHarnessName } from "@/lib/persistent-harness";
 import { modelConnectionName, modelConnectionEndpoint } from "@/lib/agent-execution";
@@ -686,32 +688,18 @@ export function OnboardingWizard({
   const compatibleRuntime = celln
     ? selectedRuntime?.spec.celln?.contractVersion === "celln.json-tools/v1"
     : !form.runtimeRef || !!selectedRuntime?.spec.image;
-  // Provider choices mirror the run flow, narrowed to what the selected
-  // execution plane can actually reach.
-  const providerChoices = useMemo(() => {
-    if (celln) {
-      // The native Celln host transport only reaches public HTTPS endpoints by
-      // default. The explicit insecure opt-in also allows HTTP/self-signed
-      // local providers; Bedrock has no compatible protocol either way.
-      if (form.allowInsecure) {
-        return PROVIDERS.filter((p) => p.value !== "bedrock");
-      }
-      return PROVIDERS.filter(
-        (p) =>
-          p.value === "openai" ||
-          p.value === "anthropic" ||
-          p.value === "azure-openai" ||
-          p.value === "custom",
-      );
-    }
-    if (mode === "agent" && creationKind === "agent" && form.runtimeRef) {
-      // Persistent Kubernetes harnesses speak OpenAI-compatible chat.
-      return PROVIDERS.filter(
-        (p) => p.value !== "anthropic" && p.value !== "bedrock",
-      );
-    }
-    return PROVIDERS;
-  }, [celln, mode, creationKind, form.runtimeRef, form.allowInsecure]);
+  // Provider choices come from the shared creation model so the Run dialog and
+  // this wizard can never drift into showing a provider the plane cannot reach.
+  const providerChoices = useMemo(
+    () =>
+      providersForPlane(PROVIDERS, {
+        plane: celln ? "celln" : "job",
+        persistentHarness:
+          mode === "agent" && creationKind === "agent" && !!form.runtimeRef,
+        allowInsecure: !!form.allowInsecure,
+      }),
+    [celln, mode, creationKind, form.runtimeRef, form.allowInsecure],
+  );
   const staleTools = (form.borrowedTools || []).some((ref) => !(catalogue.data || []).some((tool) => tool.metadata.name === ref.name && tool.spec.revision === ref.revision && tool.spec.invocationABI === "celln.json-stdio/v1" && tool.spec.lane === "tool"));
   const [inferenceMode, setInferenceMode] = useState<"workload" | "node">(
     "workload",
@@ -965,6 +953,10 @@ export function OnboardingWizard({
       githubToken: d.githubToken || "",
       githubTeamInstructions: d.githubTeamInstructions || "",
       nodeSelector: d.nodeSelector,
+      agentSandboxEnabled: d.agentSandboxEnabled ?? false,
+      agentSandboxRuntimeClass: d.agentSandboxRuntimeClass || "gvisor",
+      runTimeout: d.runTimeout || "",
+      requireApproval: d.requireApproval ?? false,
       awsRegion: d.awsRegion || "",
       awsAccessKeyId: d.awsAccessKeyId || "",
       awsSecretAccessKey: d.awsSecretAccessKey || "",
@@ -1113,7 +1105,7 @@ export function OnboardingWizard({
               </div>
             ) : (
               <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
-                {celln ? "Select a native Celln runtime registered in this namespace. Native Celln runtimes are namespace-scoped: the Agent must live where the runtime was registered (for example celln-agents). The Celln host itself is cluster-wide." : "Choose Pi or Hermes to continue. Install the default persistent runtimes if none are listed."}
+                {celln ? "Pick a native Celln runtime for the enduring parent. Native runtimes are namespace-scoped: this Agent must live where the runtime is registered. For a single sealed computation, use New Run → Celln cell instead." : "Choose Pi or Hermes to continue. Install the default persistent runtimes if none are listed."}
               </div>
             )}
             {form.runtimeRef && !availablePolicies.some((policy) => policy.metadata.name === form.policyRef) && (
@@ -1126,52 +1118,46 @@ export function OnboardingWizard({
         {step === "plane" && <div className="space-y-3">
             <div className="space-y-2" data-testid="create-agent-execution-environment">
               <Label>Execution plane</Label>
-              <p className="text-xs text-muted-foreground">Celln uses a hardware-isolated native parent. Kubernetes runs a persistent Pi or Hermes session.</p>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {([["job", "Kubernetes", "Persistent Pi or Hermes"], ["celln", "Celln", "Persistent native parent"]] as const).map(([value, title, description]) => (
-                  <button
-                    key={value}
-                    type="button"
-                    className={`rounded-md border p-3 text-left ${form.executionBackend === value ? "border-primary bg-primary/5" : "border-border"}`}
-                    onClick={() => {
-                      toolsInitialized.current = false;
-                      const planeRuntimes = value === "celln" ? nativeRuntimes : persistentRuntimes;
-                      const keepRuntime = planeRuntimes.some((runtime) => runtime.metadata.name === form.runtimeRef);
-                      setForm({
-                        ...form,
-                        runtimeRef: keepRuntime ? form.runtimeRef : "",
-                        skills: value === "celln" ? [] : form.skills,
-                        borrowedTools: [],
-                        executionBackend: value,
-                        executionLifecycle: value === "celln" ? "enduring" : "one-shot",
-                        modelConnectionRef: value === form.executionBackend ? form.modelConnectionRef : undefined,
-                        credentialProfile: "",
-                        provider:
-                          value === "celln" &&
-                          !["openai", "anthropic", "azure-openai", "custom"].includes(form.provider)
-                            ? "openai"
-                            : form.provider || "openai",
-                        model: form.model || "gpt-4o",
-                        apiKey: value === "celln" ? "" : form.apiKey,
-                        secretName: value === "celln" ? "" : form.secretName,
-                        baseURL: value === "celln" ? "" : form.baseURL,
-                        modelRef: value === "celln" ? undefined : form.modelRef,
-                        agentSandboxEnabled: value === "celln" ? false : form.agentSandboxEnabled,
-                        channels: value === "celln" ? [] : form.channels,
-                        heartbeatInterval: value === "celln" ? "" : form.heartbeatInterval,
-                      });
-                    }}
-                  >
-                    <p className="text-sm font-medium">{title}</p>
-                    <p className="text-xs text-muted-foreground">{description}</p>
-                  </button>
-                ))}
-              </div>
+              <p className="text-xs text-muted-foreground">Celln runs a persistent hardware-isolated native parent. Kubernetes runs a persistent Pi or Hermes session.</p>
+              <PlanePicker
+                kind="harness"
+                value={form.executionBackend || "job"}
+                disabledPlanes={nativeRuntimes.length === 0 ? ["celln"] : []}
+                disabledHint={{ celln: "Needs the native Celln install — not the one-shot router" }}
+                onChange={(plane) => {
+                  toolsInitialized.current = false;
+                  const planeRuntimes = plane === "celln" ? nativeRuntimes : persistentRuntimes;
+                  const keepRuntime = planeRuntimes.some((runtime) => runtime.metadata.name === form.runtimeRef);
+                  setForm({
+                    ...form,
+                    runtimeRef: keepRuntime ? form.runtimeRef : "",
+                    skills: plane === "celln" ? [] : form.skills,
+                    borrowedTools: [],
+                    executionBackend: plane,
+                    executionLifecycle: plane === "celln" ? "enduring" : "one-shot",
+                    modelConnectionRef: plane === form.executionBackend ? form.modelConnectionRef : undefined,
+                    credentialProfile: "",
+                    provider:
+                      plane === "celln" &&
+                      !["openai", "anthropic", "azure-openai", "custom"].includes(form.provider)
+                        ? "openai"
+                        : form.provider || "openai",
+                    model: form.model || "gpt-4o",
+                    apiKey: plane === "celln" ? "" : form.apiKey,
+                    secretName: plane === "celln" ? "" : form.secretName,
+                    baseURL: plane === "celln" ? "" : form.baseURL,
+                    modelRef: plane === "celln" ? undefined : form.modelRef,
+                    agentSandboxEnabled: plane === "celln" ? false : form.agentSandboxEnabled,
+                    channels: plane === "celln" ? [] : form.channels,
+                    heartbeatInterval: plane === "celln" ? "" : form.heartbeatInterval,
+                  });
+                }}
+              />
               {form.executionBackend === "job" && persistentRuntimes.length === 0 && (
-                <p role="status" className="text-xs text-amber-500">No persistent Pi or Hermes harness is installed in this namespace. Install the default harnesses, or choose Celln.</p>
+                <p role="status" className="text-xs text-amber-500">No persistent Pi or Hermes harness is installed in this namespace. Install the default harnesses{nativeRuntimes.length > 0 ? ", or choose Celln parent" : ""}.</p>
               )}
-              {form.executionBackend === "celln" && nativeRuntimes.length === 0 && (
-                <p role="status" className="text-xs text-amber-500">No native Celln runtime is registered in this namespace. Native Celln runtimes are namespace-scoped — create this Agent in the namespace that holds the runtime registration (for example celln-agents), or choose Kubernetes. The Celln host itself is cluster-wide.</p>
+              {nativeRuntimes.length === 0 && (
+                <p role="status" className="text-xs text-amber-500">The <strong>Celln parent</strong> plane runs an enduring AgentHarness and needs a <strong>native Celln runtime</strong> registered in <em>this</em> namespace. That is a <em>separate operator install</em> from the one-shot Celln router + dispatcher that powers Runs — a running router does not provide it. Install it with <code className="break-all">sympozium install --celln-native …</code>, or use <strong>New Run → Celln cell</strong> for a single sealed computation.</p>
               )}
               {form.executionBackend === "celln" && (
                 <div className="space-y-2 rounded-md border p-3">

--- a/web/src/components/plane-picker.tsx
+++ b/web/src/components/plane-picker.tsx
@@ -1,0 +1,58 @@
+import { PLANES, planeDescription, planeTitle, type CreationKind, type ExecutionPlane } from "@/lib/creation";
+import { cn } from "@/lib/utils";
+
+interface PlanePickerProps {
+  value: ExecutionPlane;
+  onChange: (plane: ExecutionPlane) => void;
+  /** Differentiates the "Celln cell" (Run) vs "Celln parent" (Harness) copy. */
+  kind: CreationKind;
+  /** Planes that cannot be used yet (e.g. Celln without a native runtime). */
+  disabledPlanes?: ExecutionPlane[];
+  /** Reason shown on a disabled plane tile. */
+  disabledHint?: Partial<Record<ExecutionPlane, string>>;
+  className?: string;
+}
+
+/**
+ * The single Kubernetes/Celln selector used by both the Run dialog and the
+ * Agent/Harness wizard, so the choice looks and behaves identically everywhere.
+ * Unavailable planes are disabled up front instead of failing after selection.
+ */
+export function PlanePicker({
+  value,
+  onChange,
+  kind,
+  disabledPlanes = [],
+  disabledHint,
+  className,
+}: PlanePickerProps) {
+  return (
+    <div className={cn("grid gap-2 sm:grid-cols-2", className)}>
+      {PLANES.map((plane) => {
+        const active = value === plane.value;
+        const disabled = disabledPlanes.includes(plane.value);
+        const hint = disabled ? disabledHint?.[plane.value] : undefined;
+        return (
+          <button
+            key={plane.value}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(plane.value)}
+            aria-disabled={disabled}
+            className={cn(
+              "rounded-md border p-3 text-left transition-colors",
+              disabled
+                ? "cursor-not-allowed border-border/60 opacity-60"
+                : active
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:bg-muted/40",
+            )}
+          >
+            <p className="text-sm font-medium">{planeTitle(plane.value, kind)}</p>
+            <p className="text-xs text-muted-foreground">{hint || planeDescription(plane.value, kind)}</p>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/yaml-panel.tsx
+++ b/web/src/components/yaml-panel.tsx
@@ -11,24 +11,19 @@ import { cn } from "@/lib/utils";
 import { toYaml, type YamlValue } from "@/lib/yaml";
 import type { WizardResult } from "@/components/onboarding-wizard";
 import { executionFromWizard, modelConnectionName, modelConnectionEndpoint } from "@/lib/agent-execution";
+import { skillParamsFromWizard } from "@/lib/create-fields";
 import type { Agent, Ensemble } from "@/lib/api";
 
 // ── YAML builders ─────────────────────────────────────────────────────────────
 
 /** Build a Agent YAML manifest from wizard form state. */
 export function instanceYamlFromWizard(result: WizardResult): string {
+  const wizardSkillParams = skillParamsFromWizard(result);
   const skills = result.skills
     .filter((s) => s !== "memory")
     .map((s) => {
       const ref: Record<string, YamlValue> = { skillPackRef: s };
-      if (s === "web-endpoint") {
-        const params: Record<string, string> = {};
-        if (result.webEndpointRPM && result.webEndpointRPM !== "60")
-          params.rate_limit_rpm = result.webEndpointRPM;
-        if (result.webEndpointHostname)
-          params.hostname = result.webEndpointHostname;
-        if (Object.keys(params).length > 0) ref.params = params;
-      }
+      if (wizardSkillParams[s]) ref.params = wizardSkillParams[s];
       return ref;
     });
 
@@ -43,11 +38,13 @@ export function instanceYamlFromWizard(result: WizardResult): string {
   });
 
   const agentConfig: Record<string, YamlValue> = { model: result.model };
-  // Native Celln routes the model through a namespaced ModelConnection; the
-  // Agent references it by name instead of carrying an inline endpoint.
-  const usesConnection = result.executionBackend === "celln";
+  // Native Celln routes the model through a namespaced ModelConnection; a
+  // persistent Kubernetes harness does too. Both reference it by name instead
+  // of carrying an inline endpoint.
+  const usesConnection = result.executionBackend === "celln" || !!result.runtimeRef;
   const connectionName = modelConnectionName(result.name || "agent");
   if (!usesConnection && result.baseURL) agentConfig.baseURL = result.baseURL;
+  if (result.runTimeout) agentConfig.runTimeout = result.runTimeout;
   if (result.nodeSelector && Object.keys(result.nodeSelector).length > 0)
     agentConfig.nodeSelector = result.nodeSelector;
   if (result.agentSandboxEnabled)
@@ -127,10 +124,7 @@ export function ensembleYamlFromWizard(
     if (secret) channelConfigs[ch] = secret;
   }
 
-  const skillParams: Record<string, Record<string, string>> = {};
-  if (result.skills.includes("github-gitops") && result.githubRepo) {
-    skillParams["github-gitops"] = { repo: result.githubRepo };
-  }
+  const skillParams = skillParamsFromWizard(result);
 
   const spec: Record<string, YamlValue> = {
     enabled: true,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -119,6 +119,8 @@ export interface AgentSpec {
   channels?: ChannelSpec[];
   agents: AgentsSpec;
   skills?: SkillRef[];
+  /** Remote MCP servers. Native Celln refuses an Agent that has any. */
+  mcpServers?: Array<{ name: string }>;
   policyRef?: string;
   authRefs?: SecretRef[];
   memory?: MemorySpec;

--- a/web/src/lib/create-fields.ts
+++ b/web/src/lib/create-fields.ts
@@ -1,0 +1,42 @@
+import type { SkillRef } from "./api";
+
+/**
+ * The wizard collects inline per-skill configuration (web endpoint limits,
+ * GitHub repo) that differs from the SkillPack selection itself. Every creation
+ * path (Agent and Ensemble, in all three ensemble call sites) must turn those
+ * into SkillPack params the same way — previously each call site mapped a
+ * different subset and silently dropped the rest.
+ */
+export interface WizardSkillConfig {
+  skills: string[];
+  webEndpointRPM?: string;
+  webEndpointHostname?: string;
+  githubRepo?: string;
+}
+
+/** SkillPack params, keyed by SkillPack name, from the wizard's inline config. */
+export function skillParamsFromWizard(
+  r: WizardSkillConfig,
+): Record<string, Record<string, string>> {
+  const out: Record<string, Record<string, string>> = {};
+  if (r.skills.includes("web-endpoint")) {
+    const params: Record<string, string> = {};
+    if (r.webEndpointRPM && r.webEndpointRPM !== "60") {
+      params.rate_limit_rpm = r.webEndpointRPM;
+    }
+    if (r.webEndpointHostname) params.hostname = r.webEndpointHostname;
+    if (Object.keys(params).length > 0) out["web-endpoint"] = params;
+  }
+  if (r.skills.includes("github-gitops") && r.githubRepo) {
+    out["github-gitops"] = { repo: r.githubRepo };
+  }
+  return out;
+}
+
+/** Agent create API shape: one SkillRef per selected pack, with params attached. */
+export function skillRefsFromWizard(r: WizardSkillConfig): SkillRef[] {
+  const params = skillParamsFromWizard(r);
+  return r.skills.map((skillPackRef) =>
+    params[skillPackRef] ? { skillPackRef, params: params[skillPackRef] } : { skillPackRef },
+  );
+}

--- a/web/src/lib/creation.ts
+++ b/web/src/lib/creation.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared creation model for the Run/Harness × Kubernetes/Celln matrix.
+ *
+ * The Run dialog and the Agent/Harness wizard used to carry their own copies of
+ * the execution-plane rules and the provider allow-list, which drifted. This
+ * module is the single source of truth for both.
+ */
+
+/** Execution planes are identified by the AgentRun `spec.backend` value. */
+export type ExecutionPlane = "job" | "celln";
+
+/** What the user is creating. */
+export type CreationKind = "run" | "harness";
+
+export const PLANE_VALUES: readonly ExecutionPlane[] = ["job", "celln"] as const;
+
+export interface PlaneMeta {
+  value: ExecutionPlane;
+  /** Short label for the plane, independent of the artifact. */
+  label: string;
+  /** One-line description when creating a one-off Run. */
+  run: string;
+  /** One-line description when creating a persistent Harness/Agent. */
+  harness: string;
+}
+
+export const PLANES: readonly PlaneMeta[] = [
+  {
+    value: "job",
+    label: "Kubernetes",
+    run: "Default · containerized run",
+    harness: "Persistent Pi or Hermes",
+  },
+  {
+    value: "celln",
+    label: "Celln",
+    run: "One-shot · hardware-isolated KVM cell",
+    harness: "Enduring · persistent native parent",
+  },
+] as const;
+
+/** Plane option title, differentiated by what is being created. */
+export function planeTitle(
+  plane: ExecutionPlane,
+  kind: CreationKind,
+): string {
+  if (plane === "celln") return kind === "run" ? "Celln cell" : "Celln parent";
+  return "Kubernetes";
+}
+
+export function planeDescription(
+  plane: ExecutionPlane,
+  kind: CreationKind,
+): string {
+  const meta = PLANES.find((p) => p.value === plane);
+  if (!meta) return "";
+  return kind === "run" ? meta.run : meta.harness;
+}
+
+export interface ProviderReachContext {
+  plane: ExecutionPlane;
+  /** Persistent Kubernetes (a Pi/Hermes session) speaks OpenAI-compatible chat. */
+  persistentHarness?: boolean;
+  /** Explicit HTTP/self-signed private-endpoint opt-in (Celln only). */
+  allowInsecure?: boolean;
+}
+
+/**
+ * Single source of truth for which model providers a plane can reach.
+ *
+ * Mirrors the backend, which narrows provider support per execution plane:
+ * a provider shown here but unsupported on the selected plane is a setup bug.
+ */
+export function providerReachableOnPlane(
+  provider: string,
+  ctx: ProviderReachContext,
+): boolean {
+  if (ctx.plane === "celln") {
+    // The native Celln host transport reaches public HTTPS endpoints by
+    // default. The insecure opt-in also allows HTTP/self-signed locals;
+    // Bedrock has no compatible protocol either way.
+    if (provider === "bedrock") return false;
+    if (ctx.allowInsecure) return true;
+    return (
+      provider === "openai" ||
+      provider === "anthropic" ||
+      provider === "azure-openai" ||
+      provider === "custom"
+    );
+  }
+  if (ctx.persistentHarness) {
+    // Persistent Kubernetes harnesses speak OpenAI-compatible chat only.
+    return provider !== "anthropic" && provider !== "bedrock";
+  }
+  return true;
+}
+
+/** Filter a provider list down to what the selected plane can reach. */
+export function providersForPlane<T extends { value: string }>(
+  providers: readonly T[],
+  ctx: ProviderReachContext,
+): T[] {
+  return providers.filter((p) => providerReachableOnPlane(p.value, ctx));
+}

--- a/web/src/pages/agents.tsx
+++ b/web/src/pages/agents.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { executionFromWizard } from "@/lib/agent-execution";
+import { skillRefsFromWizard } from "@/lib/create-fields";
 import {
   useAgents,
   useDeleteAgent,
@@ -75,22 +76,7 @@ export function AgentsPage() {
         runtimeRef: result.runtimeRef || undefined,
         policyRef: result.policyRef || undefined,
         execution: executionFromWizard(result),
-        skills: result.skills.map((skillPackRef) => {
-          if (skillPackRef === "web-endpoint") {
-            const params: Record<string, string> = {};
-            if (result.webEndpointRPM && result.webEndpointRPM !== "60") {
-              params.rate_limit_rpm = result.webEndpointRPM;
-            }
-            if (result.webEndpointHostname) {
-              params.hostname = result.webEndpointHostname;
-            }
-            return {
-              skillPackRef,
-              params: Object.keys(params).length > 0 ? params : undefined,
-            };
-          }
-          return { skillPackRef };
-        }),
+        skills: skillRefsFromWizard(result),
         channels: result.channels.map((type) => ({
           type,
           configRef: result.channelConfigs[type]
@@ -98,6 +84,10 @@ export function AgentsPage() {
             : undefined,
         })),
         heartbeatInterval: result.heartbeatInterval || undefined,
+        nodeSelector:
+          result.nodeSelector && Object.keys(result.nodeSelector).length > 0
+            ? result.nodeSelector
+            : undefined,
         agentSandbox: result.agentSandboxEnabled
           ? {
               enabled: true,

--- a/web/src/pages/ensemble-detail.tsx
+++ b/web/src/pages/ensemble-detail.tsx
@@ -45,6 +45,7 @@ import {
 } from "lucide-react";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { formatAge } from "@/lib/utils";
+import { skillParamsFromWizard } from "@/lib/create-fields";
 import type { InstalledAgentConfig, SharedMemoryEntry } from "@/lib/api";
 import { EnsembleCanvas } from "@/components/ensemble-canvas";
 import {
@@ -152,10 +153,9 @@ export function EnsembleDetailPage() {
 
   function handleProviderChange(result: WizardResult) {
     if (!name) return;
-    let skillParams: Record<string, Record<string, string>> | undefined;
-    if (result.skills.includes("github-gitops") && result.githubRepo) {
-      skillParams = { "github-gitops": { repo: result.githubRepo } };
-    }
+    const skillParamsMap = skillParamsFromWizard(result);
+    const skillParams =
+      Object.keys(skillParamsMap).length > 0 ? skillParamsMap : undefined;
     patchMutation.mutate(
       {
         name,

--- a/web/src/pages/ensembles.tsx
+++ b/web/src/pages/ensembles.tsx
@@ -48,6 +48,7 @@ import {
   GraduationCap,
 } from "lucide-react";
 import { formatAge } from "@/lib/utils";
+import { skillParamsFromWizard } from "@/lib/create-fields";
 import type { Ensemble } from "@/lib/api";
 import { GlobalEnsembleCanvas } from "@/components/ensemble-canvas";
 
@@ -145,13 +146,9 @@ export function EnsemblesPage() {
     if (!wizardPack) return;
 
     // Build skillParams from inline skill configs
-    let skillParams: Record<string, Record<string, string>> | undefined;
-    if (result.skills.includes("github-gitops") && result.githubRepo) {
-      skillParams = {
-        ...skillParams,
-        "github-gitops": { repo: result.githubRepo },
-      };
-    }
+    const skillParamsMap = skillParamsFromWizard(result);
+    const skillParams =
+      Object.keys(skillParamsMap).length > 0 ? skillParamsMap : undefined;
 
     activatePack.mutate(
       {

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -12,6 +12,8 @@ import {
   useCellnTools,
 } from "@/hooks/use-api";
 import { StatusBadge } from "@/components/status-badge";
+import { PlanePicker } from "@/components/plane-picker";
+import type { ExecutionPlane } from "@/lib/creation";
 import {
   Table,
   TableHeader,
@@ -126,8 +128,12 @@ export function RunsPage() {
     }));
   const compatibleHarness = selectedRuntime?.spec.celln?.contractVersion === "celln.json-tools/v1";
   const staleTools = lentTools.some((ref) => !(catalogue.data || []).some((tool) => tool.metadata.name === ref.name && tool.spec.revision === ref.revision));
-  const incompatibleSkills = cellnHarness && !!selectedAgent?.spec.skills?.length;
-  const blockedSelection = cellnHarness && (incompatibleSkills || !compatibleHarness || !form.model.trim() || catalogue.isLoading || catalogue.isError || staleTools);
+  const incompatibleSkills = !!selectedAgent?.spec.skills?.length;
+  const incompatibleMcp = !!selectedAgent?.spec.mcpServers?.length;
+  // The backend refuses native Celln for any Agent that carries SkillPacks or
+  // MCP connections, one-shot or enduring. Match it here so the form fails fast.
+  const incompatibleAgent = form.backend === "celln" && (incompatibleSkills || incompatibleMcp);
+  const blockedSelection = incompatibleAgent || (cellnHarness && (!compatibleHarness || !form.model.trim() || catalogue.isLoading || catalogue.isError || staleTools));
   const jobIncompatible = form.backend === "job" && !!selectedRuntime?.spec.celln && !selectedRuntime.spec.image;
 
   useEffect(() => {
@@ -222,18 +228,14 @@ export function RunsPage() {
             <div className="space-y-4 pt-2">
               <fieldset className="space-y-2 rounded-md border p-3" data-testid="execution-environment">
                 <legend className="px-1 text-sm font-medium">Execution environment</legend>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  {[["job", "Kubernetes", "Default · containers and OCI harnesses"], ["celln", "Celln", "Opt-in · hardware-isolated cells"]].map(([value, title, description]) => (
-                    <label key={value} className={`cursor-pointer rounded-md border p-3 ${form.backend === value ? "border-primary bg-primary/5" : "border-border"}`}>
-                      <span className="flex items-center gap-2 font-medium">
-                        <input type="radio" name="execution-environment" value={value} checked={form.backend === value}
-                          onChange={() => { setForm({ ...form, backend: value, model: value === "celln" && !form.model ? "deepseek-chat" : form.model }); setLentTools([]); }} />
-                        {title}
-                      </span>
-                      <span className="mt-1 block text-xs text-muted-foreground">{description}</span>
-                    </label>
-                  ))}
-                </div>
+                <PlanePicker
+                  kind="run"
+                  value={form.backend as ExecutionPlane}
+                  onChange={(plane) => {
+                    setForm({ ...form, backend: plane, model: plane === "celln" && !form.model ? "deepseek-chat" : form.model });
+                    setLentTools([]);
+                  }}
+                />
                 <p className="text-xs text-muted-foreground">Harness selection does not change the execution environment.</p>
                 {form.backend === "celln" && <p className="text-xs text-muted-foreground" role="status">
                   {capabilities.isLoading ? "Checking Celln availability…" : capabilities.isError ? "Cannot check Celln availability. Operator setup and admission are required." : capabilities.data?.celln.available ? "Celln host eligibility detected. Your harness, tools and permissions still need approval." : `Celln needs operator setup: ${capabilities.data?.celln.reason || "no eligible host reported"}`}
@@ -314,7 +316,15 @@ export function RunsPage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  {cellnHarness && nativeConnection ? (
+                  {form.backend === "celln" && !cellnHarness ? (
+                    <>
+                      <Label>Model</Label>
+                      <p className="text-xs text-muted-foreground pt-2">
+                        The cell uses the model configured on the KVM host; this
+                        run&apos;s Model field does not apply.
+                      </p>
+                    </>
+                  ) : cellnHarness && nativeConnection ? (
                     <>
                       <Label>Model (from connection)</Label>
                       <Input
@@ -367,7 +377,7 @@ export function RunsPage() {
                     </p>}
                     {cellnHarness && <div className="space-y-3 rounded-md border p-3" data-testid="celln-harness-selection">
                       <p className="text-sm font-medium">Harness in Celln — {runtimeName}</p>
-                      {incompatibleSkills && <p role="alert" className="text-xs text-red-400">This Agent has SkillPacks ({selectedAgent?.spec.skills?.map((skill) => skill.skillPackRef || skill.configMapRef).join(", ")}) that native Celln cannot use. Choose a dedicated native Agent with borrowed tools, or a compatible backend. Skills will not be silently removed.</p>}
+                      {incompatibleAgent && <p role="alert" className="text-xs text-red-400">This Agent carries {incompatibleSkills ? `SkillPacks (${selectedAgent?.spec.skills?.map((skill) => skill.skillPackRef || skill.configMapRef).join(", ")})` : ""}{incompatibleSkills && incompatibleMcp ? " and " : ""}{incompatibleMcp ? "MCP connections" : ""} that native Celln cannot use. Choose a dedicated native Agent with borrowed tools, or a compatible backend. Nothing is silently removed.</p>}
                       <p className="text-xs text-muted-foreground">Skills are instructions; borrowed tools perform operations. Existing SkillPack sidecars and MCP connections are not automatically available in Celln.</p>
                       {!compatibleHarness && <p role="alert" className="text-xs text-red-400">This Harness does not declare the supported native JSON Celln contract. No backend fallback will be used.</p>}
                       <p className="text-xs text-muted-foreground">The model loop runs inside the cell. DeepSeek model access is independently approved by the host; Kubernetes model credentials are not used.</p>


### PR DESCRIPTION
Frontend half of the Celln single-plane work (#490). Independent of the backend PR #491.

## Problem
The Run dialog and the Agent/Harness wizard each carried their own copy of the execution-plane logic and each dropped different fields — e.g. the provider allow-list drifted, `nodeSelector` was collected but never sent, `resetWith` discarded `agentSandbox`/`runTimeout`/`requireApproval`, and the Celln option meant different things on each surface.

## What this does
- **`web/src/lib/creation.ts`** — one plane model (`Celln cell` for Run, `Celln parent` for Harness) and `providerReachableOnPlane`, a single provider allow-list rule shared by both flows.
- **`web/src/components/plane-picker.tsx`** — one Kubernetes/Celln selector used by the Run dialog and the wizard, with unavailable planes disabled up front (`disabledPlanes`/`disabledHint`).
- **`web/src/lib/create-fields.ts`** — one inline skill-param mapper, now used by `agents`, `ensembles`, `ensemble-detail` and the YAML preview, so no call site drops inline skill config.
- **Round-trip fixes** — `agents.tsx` sends `nodeSelector`; `resetWith` keeps `agentSandbox*`/`runTimeout`/`requireApproval`; the Run dialog blocks native Celln for Agents carrying SkillPacks **or** MCP connections (matching `internal/agentexecution`).
- **Clear differentiation** — one-shot "Celln cell" vs enduring "Celln parent", including an actionable message when no native runtime is registered in the namespace.

## Note
This is the UI layer only; it does not depend on #491 landing first. It updates the YAML preview to match the create payload (connection for persistent-harness job Agents, `runTimeout`, shared skill params).