### PR TITLE
fix(controller): gate the amd64-only Celln CLI in the multi-arch image

### DIFF
--- a/images/controller/Dockerfile
+++ b/images/controller/Dockerfile
@@ -7,7 +7,18 @@
 #
 # CELLN_IMAGE is the pinned Celln image from config/celln/release.json.
 ARG CELLN_IMAGE=ghcr.io/sympozium-ai/celln@sha256:a52d80fe8f492b456f6f47c49190935bff3939465c7189778eb3f3d18e767ef4
-FROM ${CELLN_IMAGE} AS celln
+
+# The Celln CLI is amd64-only: its KVM backend has no ARM64 ABI, so Celln
+# publishes no arm64 bundle. Native parent provisioning runs only on the amd64
+# KVM host, so stage the CLI behind an arch gate and carry it in the multi-arch
+# controller image only where it can run. Pin the source stage to amd64 so the
+# digest resolves on any build host.
+FROM --platform=linux/amd64 ${CELLN_IMAGE} AS celln
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS celln-cli
+ARG TARGETARCH
+COPY --from=celln /usr/local/bin/celln /celln
+RUN mkdir -p /rootfs/usr/local/bin && \
+    if [ "${TARGETARCH}" = "amd64" ]; then cp /celln /rootfs/usr/local/bin/celln; fi
 
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 ARG TARGETOS=linux
@@ -22,6 +33,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=mod -ldfla
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /controller /controller
-COPY --from=celln /usr/local/bin/celln /usr/local/bin/celln
+COPY --from=celln-cli /rootfs/ /
 USER 65532:65532
 ENTRYPOINT ["/controller"]


### PR DESCRIPTION
## Problem

`images/controller/Dockerfile` (added in #491) embeds the Celln CLI with `FROM ${CELLN_IMAGE}`, but the Celln image is **amd64-only** (its KVM backend has no ARM64 ABI). The `build-and-push` matrix builds `linux/amd64,linux/arm64`, so the arm64 build fails:

```
[linux/arm64] ghcr.io/sympozium-ai/celln@sha256:...: no match for platform in manifest: not found
```

This surfaced on the first main build after #491 merged (`build-and-push (controller): failure`).

## Fix

Gate the CLI behind an arch check: force the Celln source stage to amd64, stage the binary through a helper, and only place it in the final image when `TARGETARCH=amd64`. The native parent provisioner only runs on the amd64 KVM host, so the CLI is correctly absent from the arm64 image rather than shipping a wrong-arch binary.

## Verification

Built both platforms locally with podman:
- `linux/amd64`: image runs `celln 0.5.10`; 67.8 MB.
- `linux/arm64`: builds clean; 58.7 MB (no Celln CLI).
